### PR TITLE
DVB Widget: Tuner-Nummern benutzerfreundlich anzeigen 

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,7 @@
 VDR Plugin 'skinflatplus' Revision History
 ---------------------------------------
 2021-XX-XX: Version X.X.X
+- [add] option for widget dvbdevices to display device numbers userfriendly
 
 2021-02-24: Version 0.6.1
 - [fix] '%' sign not shown in menu weather widget at certian font

--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,6 @@
 VDR Plugin 'skinflatplus' Revision History
 ---------------------------------------
+2021-XX-XX: Version X.X.X
 
 2021-02-24: Version 0.6.1
 - [fix] '%' sign not shown in menu weather widget at certian font

--- a/README
+++ b/README
@@ -81,7 +81,7 @@ Die Widgets werden auf der rechten Seite des Hauptmenüs angezeigt. In der Höhe
 
 ** DVB Geräte
 
-Zeigt die DVB Geräte an, wer dieses benutzt und auf welchem Kanel das Gerät gerade ist. Über die Plugineinstellungen kann konfiguriert werden ob "unbekannte" und/oder "nicht benutzte" Geräte ausgeblendet werden sollen.
+Zeigt die DVB Geräte an, wer dieses benutzt und auf welchem Kanel das Gerät gerade ist. Über die Plugineinstellungen kann konfiguriert werden ob "unbekannte" und/oder "nicht benutzte" Geräte ausgeblendet werden sollen. Die Nummerierung der Geräte kann entweder wie VDR-Intern mit 0 beginnen oder wahlweise mit 1.
 Leider ist es derzeit nicht möglich 100% herauszufinden wer das Gerät derzeit nutzt. Z.B. gibt es Fälle wie den EPG-Scan welcher nicht erkannt wird.
 
 ** Aktive Timer

--- a/config.c
+++ b/config.c
@@ -89,6 +89,7 @@ cFlatConfig::cFlatConfig(void) {
     MainMenuWidgetDVBDevicesPosition = 2;
     MainMenuWidgetDVBDevicesDiscardUnknown = true;
     MainMenuWidgetDVBDevicesDiscardNotUsed = false;
+    MainMenuWidgetDVBDevicesNativeNumbering = false;  // Display device numbers from 1..x
 
     MainMenuWidgetActiveTimerShow = true;
     MainMenuWidgetActiveTimerPosition = 3;
@@ -366,6 +367,7 @@ bool cFlatConfig::SetupParse(const char *Name, const char *Value) {
     else if (strcmp(Name, "TVScraperReplayInfoPosterSize") == 0)        TVScraperReplayInfoPosterSize = atod(Value);
     else if (strcmp(Name, "MainMenuWidgetDVBDevicesDiscardUnknown") == 0)  MainMenuWidgetDVBDevicesDiscardUnknown = atoi(Value);
     else if (strcmp(Name, "MainMenuWidgetDVBDevicesDiscardNotUsed") == 0)  MainMenuWidgetDVBDevicesDiscardNotUsed = atoi(Value);
+    else if (strcmp(Name, "MainMenuWidgetDVBDevicesNativeNumbering") == 0)  MainMenuWidgetDVBDevicesNativeNumbering = atoi(Value);
     else if (strcmp(Name, "RecordingDimmOnPause") == 0)                 RecordingDimmOnPause = atoi(Value);
     else if (strcmp(Name, "RecordingDimmOnPauseDelay") == 0)            RecordingDimmOnPauseDelay = atoi(Value);
     else if (strcmp(Name, "RecordingDimmOnPauseOpaque") == 0)           RecordingDimmOnPauseOpaque = atoi(Value);

--- a/config.h
+++ b/config.h
@@ -277,6 +277,7 @@ class cFlatConfig
         int MainMenuWidgetDVBDevicesPosition;
         int MainMenuWidgetDVBDevicesDiscardUnknown;
         int MainMenuWidgetDVBDevicesDiscardNotUsed;
+        int MainMenuWidgetDVBDevicesNativeNumbering;
 
         int MainMenuWidgetActiveTimerShow;
         int MainMenuWidgetActiveTimerPosition;

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -4695,7 +4695,11 @@ int cFlatDisplayMenu::DrawMainMenuWidgetDVBDevices(int wLeft, int wWidth, int Co
       }
     }
     channelName = strDevice.str().c_str();
-    cString str = cString::sprintf("%d", i + 1);  // Display Tuners 1..4 instead of 0..3
+    if (Config.MainMenuWidgetDVBDevicesNativeNumbering) {
+      cString str = cString::sprintf("%d", i);  // Display Tuners 0..3
+    } else {
+      cString str = cString::sprintf("%d", i + 1);  // Display Tuners 1..4 
+    }
     int left = marginItem;
     if (numDevices <= 9) {
       contentWidget.AddText(*str, false, cRect(left, ContentTop, wWidth - marginItem * 2, fontSmlHeight),

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -4695,10 +4695,10 @@ int cFlatDisplayMenu::DrawMainMenuWidgetDVBDevices(int wLeft, int wWidth, int Co
       }
     }
     channelName = strDevice.str().c_str();
+    
+    cString str = cString::sprintf("%d", i + 1);  // Display Tuners 1..4
     if (Config.MainMenuWidgetDVBDevicesNativeNumbering) {
-      cString str = cString::sprintf("%d", i);  // Display Tuners 0..3
-    } else {
-      cString str = cString::sprintf("%d", i + 1);  // Display Tuners 1..4 
+       str = cString::sprintf("%d", i);  // Display Tuners 0..3
     }
     int left = marginItem;
     if (numDevices <= 9) {

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: vdr-skinflat 0.5.1\n"
+"Project-Id-Version: vdr-skinflat 0.6.1\n"
 "Report-Msgid-Bugs-To: <see README>\n"
 "POT-Creation-Date: 2017-05-06 16:13+0200\n"
 "PO-Revision-Date: 2015-02-09 20:09+0100\n"
@@ -818,6 +818,9 @@ msgstr "DVB Geräte-Widget: Unbekannte ausblenden"
 
 msgid "Widget DVB devices: don't show not used"
 msgstr "DVB Geräte-Widget: Nicht verw. ausblenden"
+
+msgid "Widget DVB devices: native numbering (0..)"
+msgstr "DVB Geräte-Widget: Interne Nummerierung (0..)"
 
 msgid "Widget timer"
 msgstr "Timer-Widget"

--- a/setup.c
+++ b/setup.c
@@ -313,6 +313,7 @@ void cFlatSetup::Store(void) {
     SetupStore("TVScraperReplayInfoPosterSize", dtoa(Config.TVScraperReplayInfoPosterSize));
     SetupStore("MainMenuWidgetDVBDevicesDiscardUnknown", Config.MainMenuWidgetDVBDevicesDiscardUnknown);
     SetupStore("MainMenuWidgetDVBDevicesDiscardNotUsed", Config.MainMenuWidgetDVBDevicesDiscardNotUsed);
+    SetupStore("MainMenuWidgetDVBDevicesNativeNumbering", Config.MainMenuWidgetDVBDevicesNativeNumbering);
     SetupStore("RecordingDimmOnPause", Config.RecordingDimmOnPause);
     SetupStore("RecordingDimmOnPauseDelay", Config.RecordingDimmOnPauseDelay);
     SetupStore("RecordingDimmOnPauseOpaque", Config.RecordingDimmOnPauseOpaque);
@@ -504,6 +505,7 @@ bool cFlatSetupGeneral::SetupParse(const char *Name, const char *Value) {
     else if (strcmp(Name, "TVScraperReplayInfoPosterSize") == 0)        SetupConfig->TVScraperReplayInfoPosterSize = atod(Value);
     else if (strcmp(Name, "MainMenuWidgetDVBDevicesDiscardUnknown") == 0) SetupConfig->MainMenuWidgetDVBDevicesDiscardUnknown = atoi(Value);
     else if (strcmp(Name, "MainMenuWidgetDVBDevicesDiscardNotUsed") == 0) SetupConfig->MainMenuWidgetDVBDevicesDiscardNotUsed = atoi(Value);
+    else if (strcmp(Name, "MainMenuWidgetDVBDevicesNativeNumbering") == 0) SetupConfig->MainMenuWidgetDVBDevicesNativeNumbering = atoi(Value);
     else if (strcmp(Name, "RecordingDimmOnPause") == 0)                 SetupConfig->RecordingDimmOnPause = atoi(Value);
     else if (strcmp(Name, "RecordingDimmOnPauseDelay") == 0)            SetupConfig->RecordingDimmOnPauseDelay = atoi(Value);
     else if (strcmp(Name, "RecordingDimmOnPauseOpaque") == 0)           SetupConfig->RecordingDimmOnPauseOpaque = atoi(Value);
@@ -677,6 +679,7 @@ void cFlatSetupGeneral::SaveCurrentSettings(void) {
     Config.Store("TVScraperReplayInfoPosterSize", dtoa(Config.TVScraperReplayInfoPosterSize), *Filename);
     Config.Store("MainMenuWidgetDVBDevicesDiscardUnknown", SetupConfig->MainMenuWidgetDVBDevicesDiscardUnknown, *Filename);
     Config.Store("MainMenuWidgetDVBDevicesDiscardNotUsed", SetupConfig->MainMenuWidgetDVBDevicesDiscardNotUsed, *Filename);
+    Config.Store("MainMenuWidgetDVBDevicesNativeNumbering", SetupConfig->MainMenuWidgetDVBDevicesNativeNumbering, *Filename);
     Config.Store("RecordingDimmOnPause", SetupConfig->RecordingDimmOnPause, *Filename);
     Config.Store("RecordingDimmOnPauseDelay", SetupConfig->RecordingDimmOnPauseDelay, *Filename);
     Config.Store("RecordingDimmOnPauseOpaque", SetupConfig->RecordingDimmOnPauseOpaque, *Filename);
@@ -1315,6 +1318,7 @@ void cFlatSetupMMWidget::Setup(void) {
             Add(new cMenuEditIntItem(tr("Widget DVB devices: position"), &SetupConfig->MainMenuWidgetDVBDevicesPosition));
             Add(new cMenuEditBoolItem(tr("Widget DVB devices: don't show unknown"), &SetupConfig->MainMenuWidgetDVBDevicesDiscardUnknown));
             Add(new cMenuEditBoolItem(tr("Widget DVB devices: don't show not used"), &SetupConfig->MainMenuWidgetDVBDevicesDiscardNotUsed));
+            Add(new cMenuEditBoolItem(tr("Widget DVB devices: native numbering (0..)"), &SetupConfig->MainMenuWidgetDVBDevicesNativeNumbering));
         }
 
         Add(new cOsdItem(tr("Widget timer"), osUnknown, false));


### PR DESCRIPTION
Die Nummerierung der Geräte im DVBDevices-Widget kann entweder wie VDR-Intern mit 0 beginnen oder wahlweise mit 1.