### PR TITLE
Version 1.1.9

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -5,7 +5,7 @@
             "includePath": [
                 "${workspaceFolder}/**",
                 "/home/darkwing/Dropbox/Public/VDR/**",
-                "/mnt/Daten/Dropbox/Public/VDR/**",
+                "/mnt/Daten/Dropbox/Public/VDR/includes/**",
                 "/usr/include/**",
                 "/usr/local/include/**"
             ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -89,5 +89,8 @@
     "C_Cpp.inlayHints.autoDeclarationTypes.showOnLeft": true,
     "C_Cpp.inlayHints.parameterNames.enabled": true,
     "C_Cpp.vcFormat.space.beforeInitializerListOpenBrace": true,
-    "javascript.inlayHints.enumMemberValues.enabled": true
+    "javascript.inlayHints.enumMemberValues.enabled": true,
+    "C_Cpp.default.defines": [
+        "PLUGIN_NAME_I18N=skinflatplus"
+    ]
 }

--- a/HISTORY
+++ b/HISTORY
@@ -1,8 +1,9 @@
 VDR Plugin 'skin flatPlus' Revision History
 -------------------------------------------
-2025-xx-xx: Version 1.1.9
+2025-03-03: Version 1.1.9
 - [fix] Fix order of timer count variables
 - [fix] Fix display of channel separators in plugin epg2vdr
+- [fix] Fix translation in system information widget
 - [add] Show ' - ' for missing short text in recording content
 - [update] Add '~' as delimiter char in cTextFloatingWrapper
 - [update] Search default icon only if theme icon not in cache

--- a/HISTORY
+++ b/HISTORY
@@ -4,6 +4,7 @@ VDR Plugin 'skin flatPlus' Revision History
 - [fix] Fix order of timer count variables
 - [fix] Fix display of channel separators in plugin epg2vdr
 - [add] Show ' - ' for missing short text in recording content
+- [update] Add '~' as delimiter char in cTextFloatingWrapper
 - [update] Search default icon only if theme icon not in cache
 - [update] Show timer icon in schedule menu only if timer is active
 - [update] Some internal optimizations

--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,10 @@
 VDR Plugin 'skin flatPlus' Revision History
 -------------------------------------------
+2025-xx-xx: Version 1.1.9
+- [fix] Fix display of channel separators in plugin epg2vdr
+- [update] Show timer icon in schedule menu only if timer is active
+- [update] Some internal optimizations
+
 2025-02-17: Version 1.1.8
 - [fix] Fix 'jumping' end times - Update only once per second
 - [add] Add audio icon (dolby/stereo) to replay and channel status

--- a/HISTORY
+++ b/HISTORY
@@ -1,7 +1,10 @@
 VDR Plugin 'skin flatPlus' Revision History
 -------------------------------------------
 2025-xx-xx: Version 1.1.9
+- [fix] Fix order of timer count variables
 - [fix] Fix display of channel separators in plugin epg2vdr
+- [add] Show ' - ' for missing short text in recording content
+- [update] Search default icon only if theme icon not in cache
 - [update] Show timer icon in schedule menu only if timer is active
 - [update] Some internal optimizations
 

--- a/baserender.c
+++ b/baserender.c
@@ -330,7 +330,7 @@ void cFlatBaseRender::TopBarUpdate() {
 
         cImage *img {nullptr};
         if (m_TopBarMenuIconSet && Config.TopBarMenuIconShow) {
-            img = ImgLoader.LoadIcon(*m_TopBarMenuIcon, 999, m_TopBarHeight - m_MarginItem2);
+            img = ImgLoader.LoadIcon(*m_TopBarMenuIcon, ICON_WIDTH_UNLIMITED, m_TopBarHeight - m_MarginItem2);
             if (img) {
                 const int IconLeft {m_MarginItem};
                 const int IconTop {(m_TopBarHeight / 2 - img->Height() / 2)};
@@ -446,7 +446,7 @@ void cFlatBaseRender::TopBarUpdate() {
 
         cImage *ImgExtra {nullptr};
         if (m_TopBarExtraIconSet) {  // Show extra icon (Disk usage)
-            ImgExtra = ImgLoader.LoadIcon(*m_TopBarExtraIcon, 999, m_TopBarHeight);
+            ImgExtra = ImgLoader.LoadIcon(*m_TopBarExtraIcon, ICON_WIDTH_UNLIMITED, m_TopBarHeight);
             if (ImgExtra) {
                 Right -= ImgExtra->Width() + m_MarginItem;
                 MiddleWidth += ImgExtra->Width() + m_MarginItem;
@@ -457,7 +457,7 @@ void cFlatBaseRender::TopBarUpdate() {
         int TitleWidth {m_TopBarFont->Width(*m_TopBarTitle)};
         cImage *ImgIconRight {nullptr};
         if (m_TopBarMenuIconRightSet) {
-            ImgIconRight = ImgLoader.LoadIcon(*m_TopBarMenuIconRight, 999, m_TopBarHeight);
+            ImgIconRight = ImgLoader.LoadIcon(*m_TopBarMenuIconRight, ICON_WIDTH_UNLIMITED, m_TopBarHeight);
             if (ImgIconRight) {
                 TopBarMenuIconRightWidth = ImgIconRight->Width() + m_MarginItem3;
                 TitleWidth += TopBarMenuIconRightWidth;

--- a/baserender.c
+++ b/baserender.c
@@ -31,6 +31,8 @@ cFlatBaseRender::cFlatBaseRender() {
     m_FontSmlHeight = m_FontSml->Height();
     m_FontFixedHeight = m_FontFixed->Height();
 
+    m_FontAscender = GetFontAscender(Setup.FontOsd, Setup.FontOsdSize);  // Top of capital letters
+
     m_ScrollBarWidth = Config.decorScrollBarSize;
 
     Borders.reserve(64);

--- a/baserender.c
+++ b/baserender.c
@@ -831,15 +831,13 @@ void cFlatBaseRender::ProgressBarDrawRaw(cPixmap *Pixmap, cPixmap *PixmapBg, cRe
         Pixmap->DrawRectangle(cRect(rect.Left(), rect.Top() + Middle - (sml / 2), rect.Width(), sml), ColorFg);
 
         if (Current > 0)
-            Pixmap->DrawRectangle(
-                cRect(rect.Left(), rect.Top() + Middle - (big / 2), Percent, big), ColorBarFg);
+            Pixmap->DrawRectangle(cRect(rect.Left(), rect.Top() + Middle - (big / 2), Percent, big), ColorBarFg);
         break;
     }
     case 1:  // big line
     {
         if (Current > 0)
-            Pixmap->DrawRectangle(
-                cRect(rect.Left(), rect.Top() + Middle - (big / 2), Percent, big), ColorBarFg);
+            Pixmap->DrawRectangle(cRect(rect.Left(), rect.Top() + Middle - (big / 2), Percent, big), ColorBarFg);
         break;
     }
     case 2:  // big line + outline
@@ -893,8 +891,7 @@ void cFlatBaseRender::ProgressBarDrawRaw(cPixmap *Pixmap, cPixmap *PixmapBg, cRe
         Pixmap->DrawRectangle(cRect(rect.Left(), rect.Top() + Middle - (sml / 2), rect.Width(), sml), ColorFg);
 
         if (Current > 0) {
-            Pixmap->DrawRectangle(
-                cRect(rect.Left(), rect.Top() + Middle - (big / 2), Percent, big), ColorBarFg);
+            Pixmap->DrawRectangle(cRect(rect.Left(), rect.Top() + Middle - (big / 2), Percent, big), ColorBarFg);
             // Dot
             Pixmap->DrawEllipse(cRect(rect.Left() + Percent - (big / 2), rect.Top() + Middle - (big / 2), big, big),
                                 ColorBarFg, 0);
@@ -904,8 +901,7 @@ void cFlatBaseRender::ProgressBarDrawRaw(cPixmap *Pixmap, cPixmap *PixmapBg, cRe
     case 4:  // big line + dot
     {
         if (Current > 0) {
-            Pixmap->DrawRectangle(
-                cRect(rect.Left(), rect.Top() + Middle - (big / 2), Percent, big), ColorBarFg);
+            Pixmap->DrawRectangle(cRect(rect.Left(), rect.Top() + Middle - (big / 2), Percent, big), ColorBarFg);
             // Dot
             Pixmap->DrawEllipse(cRect(rect.Left() + Percent - (big / 2), rect.Top() + Middle - (big / 2), big, big),
                                 ColorBarFg, 0);
@@ -922,8 +918,7 @@ void cFlatBaseRender::ProgressBarDrawRaw(cPixmap *Pixmap, cPixmap *PixmapBg, cRe
         Pixmap->DrawRectangle(cRect(rect.Left() + rect.Width() - out, rect.Top(), out, big), ColorFg);
 
         if (Current > 0) {
-            Pixmap->DrawRectangle(
-                cRect(rect.Left(), rect.Top() + Middle - (big / 2), Percent, big), ColorBarFg);
+            Pixmap->DrawRectangle(cRect(rect.Left(), rect.Top() + Middle - (big / 2), Percent, big), ColorBarFg);
             // Dot
             Pixmap->DrawEllipse(cRect(rect.Left() + Percent - (big / 2), rect.Top() + Middle - (big / 2), big, big),
                                 ColorBarFg, 0);
@@ -968,18 +963,15 @@ void cFlatBaseRender::ProgressBarDrawRaw(cPixmap *Pixmap, cPixmap *PixmapBg, cRe
 
         if (Current > 0) {
             DecorDrawGlowRectHor(Pixmap, rect.Left(), rect.Top(), Percent, big, ColorBarFg);
-            DecorDrawGlowRectHor(Pixmap, rect.Left(), rect.Top() + Middle + (sml / 2), Percent,
-                                 big * -1, ColorBarFg);
+            DecorDrawGlowRectHor(Pixmap, rect.Left(), rect.Top() + Middle + (sml / 2), Percent, big * -1, ColorBarFg);
         }
         break;
     }
     case 9:  // big line + alpha blend
     {
         if (Current > 0) {
-            DecorDrawGlowRectHor(Pixmap, rect.Left(), rect.Top() + Middle - (big / 2), Percent,
-                                 big / 2, ColorBarFg);
-            DecorDrawGlowRectHor(Pixmap, rect.Left(), rect.Top() + Middle, Percent, (big / -2),
-                                 ColorBarFg);
+            DecorDrawGlowRectHor(Pixmap, rect.Left(), rect.Top() + Middle - (big / 2), Percent, big / 2, ColorBarFg);
+            DecorDrawGlowRectHor(Pixmap, rect.Left(), rect.Top() + Middle, Percent, (big / -2), ColorBarFg);
         }
         break;
     }

--- a/baserender.h
+++ b/baserender.h
@@ -109,6 +109,7 @@ class cFlatBaseRender {
         int m_FontHeight2 {0};
         int m_FontSmlHeight {0};
         int m_FontFixedHeight {0};
+        int m_FontAscender {0};  // Ascender for font
 
         // Font for main menu weather widget
         cFont *m_FontTempSml {nullptr};

--- a/baserender.h
+++ b/baserender.h
@@ -98,8 +98,8 @@ class cFlatBaseRender {
         int m_OsdLeft {0}, m_OsdTop {0}, m_OsdWidth {0}, m_OsdHeight {0};
         const int m_MarginItem {5}, m_MarginItem2 {10}, m_MarginItem3 {15};
 
-        const int ICON_WIDTH_UNLIMITED {999};
-        const int ICON_HEIGHT_UNLIMITED {999};
+        const int ICON_WIDTH_UNLIMITED {999};   // Max icon width (999)
+        const int ICON_HEIGHT_UNLIMITED {999};  // Max icon height (999)
 
         // Standard fonts
         cFont *m_Font {nullptr};

--- a/baserender.h
+++ b/baserender.h
@@ -98,6 +98,9 @@ class cFlatBaseRender {
         int m_OsdLeft {0}, m_OsdTop {0}, m_OsdWidth {0}, m_OsdHeight {0};
         const int m_MarginItem {5}, m_MarginItem2 {10}, m_MarginItem3 {15};
 
+        const int ICON_WIDTH_UNLIMITED {999};
+        const int ICON_HEIGHT_UNLIMITED {999};
+
         // Standard fonts
         cFont *m_Font {nullptr};
         cFont *m_FontSml {nullptr};

--- a/baserender.h
+++ b/baserender.h
@@ -105,17 +105,13 @@ class cFlatBaseRender {
         cFont *m_Font {nullptr};
         cFont *m_FontSml {nullptr};
         cFont *m_FontFixed {nullptr};
-        int m_FontHeight {0};
-        int m_FontHeight2 {0};
+        int m_FontHeight {0}, m_FontHeight2 {0};
         int m_FontSmlHeight {0};
         int m_FontFixedHeight {0};
         int m_FontAscender {0};  // Ascender for font
 
-        // Font for main menu weather widget
-        cFont *m_FontTempSml {nullptr};
-
-        // Very small font for actor name and role
-        cFont *m_FontTiny {nullptr};
+        cFont *m_FontTempSml {nullptr};  // Font for main menu weather widget
+        cFont *m_FontTiny {nullptr};     // Very small font for actor name and role
 
         // TopBar
         cPixmap *TopBarPixmap {nullptr};
@@ -189,14 +185,14 @@ class cFlatBaseRender {
         void DecorDrawGlowRectBL(cPixmap *pixmap, int Left, int Top, int Width, int Height, tColor ColorBg);
         void DecorDrawGlowRectBR(cPixmap *pixmap, int Left, int Top, int Width, int Height, tColor ColorBg);
 
-        void DecorDrawGlowEllipseTL(cPixmap *pixmap, int Left, int Top, int Width, int Height,
-                                    tColor ColorBg, int type);
-        void DecorDrawGlowEllipseTR(cPixmap *pixmap, int Left, int Top, int Width, int Height,
-                                    tColor ColorBg, int type);
-        void DecorDrawGlowEllipseBL(cPixmap *pixmap, int Left, int Top, int Width, int Height,
-                                    tColor ColorBg, int type);
-        void DecorDrawGlowEllipseBR(cPixmap *pixmap, int Left, int Top, int Width, int Height,
-                                    tColor ColorBg, int type);
+        void DecorDrawGlowEllipseTL(cPixmap *pixmap, int Left, int Top, int Width, int Height, tColor ColorBg,
+                                    int type);
+        void DecorDrawGlowEllipseTR(cPixmap *pixmap, int Left, int Top, int Width, int Height, tColor ColorBg,
+                                    int type);
+        void DecorDrawGlowEllipseBL(cPixmap *pixmap, int Left, int Top, int Width, int Height, tColor ColorBg,
+                                    int type);
+        void DecorDrawGlowEllipseBR(cPixmap *pixmap, int Left, int Top, int Width, int Height, tColor ColorBg,
+                                    int type);
 
         void TopBarEnableDiskUsage();
         // tColor Multiply(tColor Color, uint8_t Alpha);

--- a/complexcontent.c
+++ b/complexcontent.c
@@ -147,7 +147,8 @@ void cComplexContent::AddImageWithFloatedText(cImage *image, int imageAlignment,
     for (int i {0}; i < Lines; ++i) {  // Add text line by line
         FloatedTextPos.SetTop(TextPos.Top() + (i * m_ScrollSize));
         Line = WrapperFloat.GetLine(i);
-        if (Config.MenuEventRecordingViewJustify == 1 && i < (Lines - 1))  // Last line is not justified
+        // Last line is not justified
+        if (Config.MenuEventRecordingViewJustify == 1 && i < (Lines - 1))
             JustifyLine(Line, Font, (i < FloatLines) ? TextWidthLeft : TextWidthFull);
 
         AddText(Line.c_str(), false, FloatedTextPos, ColorFg, ColorBg, Font, TextWidthFull, TextHeight, TextAlignment);

--- a/complexcontent.h
+++ b/complexcontent.h
@@ -38,7 +38,7 @@ class cSimpleContent {
     cImage *m_Image {nullptr};
     cFont *m_Font {nullptr};
 
-    cTextFloatingWrapper m_Wrapper;  // Reuse a single instance
+    // cTextFloatingWrapper m_Wrapper;  // Reuse a single instance
 
  public:
     cSimpleContent() {
@@ -55,7 +55,7 @@ class cSimpleContent {
         m_Text = rhs.m_Text;
         m_Image = rhs.m_Image;
         m_Font = rhs.m_Font;
-        m_Wrapper = rhs.m_Wrapper;
+        // m_Wrapper = rhs.m_Wrapper;
     }
 
     ~cSimpleContent() {
@@ -73,7 +73,7 @@ class cSimpleContent {
             this->m_Text = other.m_Text;
             this->m_Image = other.m_Image;
             this->m_Font = other.m_Font;
-            this->m_Wrapper = other.m_Wrapper;
+            // this->m_Wrapper = other.m_Wrapper;
         }
         return *this;
     }
@@ -108,9 +108,9 @@ class cSimpleContent {
             return m_Position.Top() + m_Font->Height();
 
         if (m_ContentType == CT_TextMultiline) {
-            // cTextFloatingWrapper Wrapper;  // Use modified wrapper
-            m_Wrapper.Set(*m_Text, m_Font, m_Position.Width());
-            return m_Position.Top() + (m_Wrapper.Lines() * m_Font->Height());
+            cTextFloatingWrapper Wrapper;  // Use modified wrapper
+            Wrapper.Set(*m_Text, m_Font, m_Position.Width());
+            return m_Position.Top() + (Wrapper.Lines() * m_Font->Height());
         }
 
         if (m_ContentType == CT_Image)
@@ -129,14 +129,14 @@ class cSimpleContent {
             Pixmap->DrawText(m_Position.Point(), *m_Text, m_ColorFg, m_ColorBg, m_Font, m_TextWidth,
                              m_TextHeight, m_TextAlignment);
         } else if (m_ContentType == CT_TextMultiline) {
-            // cTextFloatingWrapper Wrapper;  // Use modified wrapper
-            m_Wrapper.Set(*m_Text, m_Font, m_Position.Width());
+            cTextFloatingWrapper Wrapper;  // Use modified wrapper
+            Wrapper.Set(*m_Text, m_Font, m_Position.Width());
             std::string Line {""};
             Line.reserve(128);
-            const int Lines {m_Wrapper.Lines()};
+            const int Lines {Wrapper.Lines()};
             const int FontHeight {m_Font->Height()};
             for (int i {0}; i < Lines; ++i) {
-                Line = m_Wrapper.GetLine(i);
+                Line = Wrapper.GetLine(i);
                 // Last line is not justified
                 if (Config.MenuEventRecordingViewJustify == 1 && i < (Lines - 1))
                     JustifyLine(Line, m_Font, m_Position.Width());

--- a/complexcontent.h
+++ b/complexcontent.h
@@ -9,6 +9,8 @@
 
 #include <cstring>  // string.h
 #include <list>
+#include <string>
+#include <vector>
 
 #include "./imageloader.h"
 #include "./flat.h"
@@ -36,6 +38,8 @@ class cSimpleContent {
     cImage *m_Image {nullptr};
     cFont *m_Font {nullptr};
 
+    cTextFloatingWrapper m_Wrapper;  // Reuse a single instance
+
  public:
     cSimpleContent() {
     }
@@ -51,6 +55,7 @@ class cSimpleContent {
         m_Text = rhs.m_Text;
         m_Image = rhs.m_Image;
         m_Font = rhs.m_Font;
+        m_Wrapper = rhs.m_Wrapper;
     }
 
     ~cSimpleContent() {
@@ -68,6 +73,7 @@ class cSimpleContent {
             this->m_Text = other.m_Text;
             this->m_Image = other.m_Image;
             this->m_Font = other.m_Font;
+            this->m_Wrapper = other.m_Wrapper;
         }
         return *this;
     }
@@ -102,9 +108,9 @@ class cSimpleContent {
             return m_Position.Top() + m_Font->Height();
 
         if (m_ContentType == CT_TextMultiline) {
-            cTextFloatingWrapper Wrapper;  // Use modified wrapper
-            Wrapper.Set(*m_Text, m_Font, m_Position.Width());
-            return m_Position.Top() + (Wrapper.Lines() * m_Font->Height());
+            // cTextFloatingWrapper Wrapper;  // Use modified wrapper
+            m_Wrapper.Set(*m_Text, m_Font, m_Position.Width());
+            return m_Position.Top() + (m_Wrapper.Lines() * m_Font->Height());
         }
 
         if (m_ContentType == CT_Image)
@@ -123,16 +129,18 @@ class cSimpleContent {
             Pixmap->DrawText(m_Position.Point(), *m_Text, m_ColorFg, m_ColorBg, m_Font, m_TextWidth,
                              m_TextHeight, m_TextAlignment);
         } else if (m_ContentType == CT_TextMultiline) {
-            cTextFloatingWrapper Wrapper;  // Use modified wrapper
-            Wrapper.Set(*m_Text, m_Font, m_Position.Width());
+            // cTextFloatingWrapper Wrapper;  // Use modified wrapper
+            m_Wrapper.Set(*m_Text, m_Font, m_Position.Width());
             std::string Line {""};
             Line.reserve(128);
-            const int Lines {Wrapper.Lines()};
+            const int Lines {m_Wrapper.Lines()};
             const int FontHeight {m_Font->Height()};
-            for (int i {0}; i < Lines; ++i) {  // Justify line by line
-                Line = Wrapper.GetLine(i);
-                if (Config.MenuEventRecordingViewJustify == 1 && i < (Lines - 1))  // Last line is not justified
+            for (int i {0}; i < Lines; ++i) {
+                Line = m_Wrapper.GetLine(i);
+                // Last line is not justified
+                if (Config.MenuEventRecordingViewJustify == 1 && i < (Lines - 1))
                     JustifyLine(Line, m_Font, m_Position.Width());
+
                 Pixmap->DrawText(cPoint(m_Position.Left(), m_Position.Top() + (i * FontHeight)), Line.c_str(),
                                  m_ColorFg, m_ColorBg, m_Font, m_TextWidth, m_TextHeight, m_TextAlignment);
             }

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -203,7 +203,7 @@ void cFlatDisplayChannel::ChannelIconsDraw(const cChannel *Channel, bool Resolut
 
     cImage *img {nullptr};
     if (Channel) {
-        img = ImgLoader.LoadIcon((Channel->Ca()) ? "crypted" : "uncrypted", 999, ImageHeight);
+        img = ImgLoader.LoadIcon((Channel->Ca()) ? "crypted" : "uncrypted", ICON_WIDTH_UNLIMITED, ImageHeight);
         if (img) {
             left -= img->Width();
             ChanIconsPixmap->DrawImage(cPoint(left, top), *img);
@@ -215,7 +215,7 @@ void cFlatDisplayChannel::ChannelIconsDraw(const cChannel *Channel, bool Resolut
         cString IconName {""};
         if (Config.ChannelResolutionAspectShow) {  // Show Aspect (16:9)
             IconName = *GetAspectIcon(m_ScreenWidth, m_ScreenAspect);
-            img = ImgLoader.LoadIcon(*IconName, 999, ImageHeight);
+            img = ImgLoader.LoadIcon(*IconName, ICON_WIDTH_UNLIMITED, ImageHeight);
             if (img) {
                 left -= img->Width();
                 ChanIconsPixmap->DrawImage(cPoint(left, top), *img);
@@ -223,7 +223,7 @@ void cFlatDisplayChannel::ChannelIconsDraw(const cChannel *Channel, bool Resolut
             }
 
             IconName = *GetScreenResolutionIcon(m_ScreenWidth, m_ScreenHeight);  // Show Resolution (1920x1080)
-            img = ImgLoader.LoadIcon(*IconName, 999, ImageHeight);
+            img = ImgLoader.LoadIcon(*IconName, ICON_WIDTH_UNLIMITED, ImageHeight);
             if (img) {
                 left -= img->Width();
                 ChanIconsPixmap->DrawImage(cPoint(left, top), *img);
@@ -233,7 +233,7 @@ void cFlatDisplayChannel::ChannelIconsDraw(const cChannel *Channel, bool Resolut
 
         if (Config.ChannelFormatShow && !Config.ChannelSimpleAspectFormat) {
             IconName = *GetFormatIcon(m_ScreenWidth);  // Show Format (HD)
-            img = ImgLoader.LoadIcon(*IconName, 999, ImageHeight);
+            img = ImgLoader.LoadIcon(*IconName, ICON_WIDTH_UNLIMITED, ImageHeight);
             if (img) {
                 left -= img->Width();
                 ChanIconsPixmap->DrawImage(cPoint(left, top), *img);
@@ -243,7 +243,7 @@ void cFlatDisplayChannel::ChannelIconsDraw(const cChannel *Channel, bool Resolut
         // Show audio icon (Dolby, Stereo)
         if (Config.ChannelResolutionAspectShow) {  //? Add separate config option
             IconName = *GetCurrentAudioIcon();
-            img = ImgLoader.LoadIcon(*IconName, 999, ImageHeight);
+            img = ImgLoader.LoadIcon(*IconName, ICON_WIDTH_UNLIMITED, ImageHeight);
             if (img) {
                 left -= img->Width();
                 ChanIconsPixmap->DrawImage(cPoint(left, top), *img);
@@ -530,13 +530,13 @@ void cFlatDisplayChannel::DvbapiInfoDraw() {
     left += DvbapiInfoFont->Width(*DvbapiInfoText) + m_MarginItem;
 
     cString IconName = cString::sprintf("crypt_%s", *ecmInfo.cardsystem);
-    cImage *img {ImgLoader.LoadIcon(*IconName, 999, DvbapiInfoFont->Height())};
+    cImage *img {ImgLoader.LoadIcon(*IconName, ICON_WIDTH_UNLIMITED, DvbapiInfoFont->Height())};
     if (img) {
         ChanIconsPixmap->DrawImage(cPoint(left, top), *img);
         left += img->Width() + m_MarginItem;
     } else {
         IconName = "crypt_unknown";
-        img = ImgLoader.LoadIcon(*IconName, 999, DvbapiInfoFont->Height());
+        img = ImgLoader.LoadIcon(*IconName, ICON_WIDTH_UNLIMITED, DvbapiInfoFont->Height());
         if (img) {
             ChanIconsPixmap->DrawImage(cPoint(left, top), *img);
             left += img->Width() + m_MarginItem;
@@ -611,33 +611,33 @@ void cFlatDisplayChannel::PreLoadImages() {
     }  // for cChannel
 
     height = std::max(m_FontSmlHeight, Config.decorProgressSignalSize * 2 + m_MarginItem);
-    ImgLoader.LoadIcon("crypted", 999, height);
-    ImgLoader.LoadIcon("uncrypted", 999, height);
-    ImgLoader.LoadIcon("unknown_asp", 999, height);
-    ImgLoader.LoadIcon("43", 999, height);
-    ImgLoader.LoadIcon("169", 999, height);
-    ImgLoader.LoadIcon("169w", 999, height);
-    ImgLoader.LoadIcon("221", 999, height);
-    ImgLoader.LoadIcon("7680x4320", 999, height);
-    ImgLoader.LoadIcon("3840x2160", 999, height);
-    ImgLoader.LoadIcon("1920x1080", 999, height);
-    ImgLoader.LoadIcon("1440x1080", 999, height);
-    ImgLoader.LoadIcon("1280x720", 999, height);
-    ImgLoader.LoadIcon("960x720", 999, height);
-    ImgLoader.LoadIcon("704x576", 999, height);
-    ImgLoader.LoadIcon("720x576", 999, height);
-    ImgLoader.LoadIcon("544x576", 999, height);
-    ImgLoader.LoadIcon("528x576", 999, height);
-    ImgLoader.LoadIcon("480x576", 999, height);
-    ImgLoader.LoadIcon("352x576", 999, height);
-    ImgLoader.LoadIcon("unknown_res", 999, height);
-    ImgLoader.LoadIcon("uhd", 999, height);
-    ImgLoader.LoadIcon("hd", 999, height);
-    ImgLoader.LoadIcon("sd", 999, height);
-    ImgLoader.LoadIcon("audio_dolby", 999, height);
-    ImgLoader.LoadIcon("audio_stereo", 999, height);
+    ImgLoader.LoadIcon("crypted", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("uncrypted", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("unknown_asp", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("43", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("169", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("169w", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("221", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("7680x4320", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("3840x2160", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("1920x1080", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("1440x1080", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("1280x720", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("960x720", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("704x576", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("720x576", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("544x576", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("528x576", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("480x576", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("352x576", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("unknown_res", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("uhd", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("hd", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("sd", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("audio_dolby", ICON_WIDTH_UNLIMITED, height);
+    ImgLoader.LoadIcon("audio_stereo", ICON_WIDTH_UNLIMITED, height);
 
     // Audio tracks (displaytracks.c)
-    ImgLoader.LoadIcon("tracks_ac3", 999, m_FontHeight);
-    ImgLoader.LoadIcon("tracks_stereo", 999, m_FontHeight);
+    ImgLoader.LoadIcon("tracks_ac3", ICON_WIDTH_UNLIMITED, m_FontHeight);
+    ImgLoader.LoadIcon("tracks_stereo", ICON_WIDTH_UNLIMITED, m_FontHeight);
 }

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -634,6 +634,10 @@ void cFlatDisplayChannel::PreLoadImages() {
     ImgLoader.LoadIcon("uhd", 999, height);
     ImgLoader.LoadIcon("hd", 999, height);
     ImgLoader.LoadIcon("sd", 999, height);
-    ImgLoader.LoadIcon("audio_stereo", 999, height);
     ImgLoader.LoadIcon("audio_dolby", 999, height);
+    ImgLoader.LoadIcon("audio_stereo", 999, height);
+
+    // Audio tracks (displaytracks.c)
+    ImgLoader.LoadIcon("tracks_ac3", 999, m_FontHeight);
+    ImgLoader.LoadIcon("tracks_stereo", 999, m_FontHeight);
 }

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -516,10 +516,10 @@ void cFlatDisplayChannel::DvbapiInfoDraw() {
 
     const cFont *DvbapiInfoFont = cFont::CreateFont(Setup.FontOsd, ProgressBarHeight);
 
-    const int FontAscender {GetFontAscender(Setup.FontOsd, ProgressBarHeight)};
+    // const int FontAscender {GetFontAscender(Setup.FontOsd, ProgressBarHeight)};
     constexpr ulong CharCode {0x0044};  // U+0044 LATIN CAPITAL LETTER D
     const int GlyphSize = GetGlyphSize(Setup.FontOsd, CharCode, ProgressBarHeight);  // Narrowing conversion
-    const int TopOffset {(FontAscender - GlyphSize) / 2};  // Center vertically
+    const int TopOffset {(m_FontAscender - GlyphSize) / 2};  // Center vertically
     const int top {m_HeightBottom - ProgressBarHeight - m_MarginItem -
         TopOffset};  // One margin for progress bar to bottom
 

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -3413,12 +3413,11 @@ void cFlatDisplayMenu::SetText(const char *Text, bool FixedFont) {
 
     PixmapFill(ContentHeadPixmap, clrTransparent);
 
-    const int Left {Config.decorBorderMenuContentSize};
-    const int Top {m_TopBarHeight + m_MarginItem + Config.decorBorderTopBarSize * 2 +
-                   Config.decorBorderMenuContentSize};
-    int Width {m_MenuWidth - Config.decorBorderMenuContentSize * 2};
+    const int Left {Config.decorBorderMenuContentSize};  // Config.decorBorderMenuContentSize
+    const int Top {m_TopBarHeight + m_MarginItem + Config.decorBorderTopBarSize * 2 + Left};
+    int Width {m_MenuWidth - Left * 2};
     int Height {m_OsdHeight - (m_TopBarHeight + Config.decorBorderTopBarSize * 2 + m_ButtonsHeight +
-                Config.decorBorderButtonSize * 2 + Config.decorBorderMenuContentSize * 2 + m_MarginItem)};
+                Config.decorBorderButtonSize * 2 + Left * 2 + m_MarginItem)};
 
     if (!ButtonsDrawn())
         Height += m_ButtonsHeight + Config.decorBorderButtonSize * 2;
@@ -3482,7 +3481,7 @@ void cFlatDisplayMenu::SetText(const char *Text, bool FixedFont) {
                      .Width = Width,
                      .Height = (Config.MenuContentFullSize || Scrollable) ? ComplexContent.ContentHeight(true)
                                                                           : ComplexContent.ContentHeight(false),
-                     .Size = Config.decorBorderMenuContentSize,
+                     .Size = Left,
                      .Type = Config.decorBorderMenuContentType,
                      .ColorFg = Config.decorBorderMenuContentFg,
                      .ColorBg = Config.decorBorderMenuContentBg};

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -1866,7 +1866,7 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
                 IconName = *GetRecordingFormatIcon(Recording);  // Show (SD), HD or UHD Logo
                 if (!isempty(*IconName)) {
                     const int ImageHeight = m_FontHeight * (1.0 / 3.0);  // 1/3 image height. Narrowing conversion
-                    img = ImgLoader.LoadIcon(*IconName, 999, ImageHeight);
+                    img = ImgLoader.LoadIcon(*IconName, ICON_WIDTH_UNLIMITED, ImageHeight);
                         if (img) {
                             const int ImageTop {Top + m_FontHeight - m_FontAscender};
                             const int ImageLeft {Left + m_FontHeight - img->Width()};
@@ -2068,7 +2068,7 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
                 IconName = *GetRecordingFormatIcon(Recording);  // Show (SD), HD or UHD Logo
                 if (!isempty(*IconName)) {
                     const int ImageHeight = m_FontHeight * (1.0 / 3.0);  // 1/3 image height. Narrowing conversion
-                    img = ImgLoader.LoadIcon(*IconName, 999, ImageHeight);
+                    img = ImgLoader.LoadIcon(*IconName, ICON_WIDTH_UNLIMITED, ImageHeight);
                     if (img) {
                         const int ImageTop {Top + m_FontHeight - m_FontAscender};
                         const int ImageLeft {Left + m_FontHeight - img->Width()};
@@ -2864,7 +2864,7 @@ void cFlatDisplayMenu::AddActors(cComplexContent &ComplexContent, std::vector<cS
         for (uint col {0}; col < PicsPerLine; ++col) {
             if (Actor == NumActors)
                 break;
-            img = ImgLoader.LoadFile(*ActorsPath[Actor], ActorWidth, 999);
+            img = ImgLoader.LoadFile(*ActorsPath[Actor], ActorWidth, ICON_HEIGHT_UNLIMITED);
             if (img) {
                 ComplexContent.AddImage(img, cRect(x, y, 0, 0));
                 ImgHeight = img->Height();
@@ -3349,7 +3349,7 @@ void cFlatDisplayMenu::SetRecording(const cRecording *Recording) {
     if (Config.MenuItemRecordingShowRecordingErrors) {  // TODO: Separate config option?
         const cString RecErrIcon = cString::sprintf("%s_replay", *GetRecordingErrorIcon(RecInfo->Errors()));
 
-        img = ImgLoader.LoadIcon(*RecErrIcon, 999, m_FontSmlHeight);  // Small image
+        img = ImgLoader.LoadIcon(*RecErrIcon, ICON_WIDTH_UNLIMITED, m_FontSmlHeight);  // Small image
         if (img) {
             left += m_MarginItem;
             const int ImageTop {m_MarginItem + m_FontSmlHeight + m_FontHeight};
@@ -4123,7 +4123,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetActiveTimers(int wLeft, int wWidth, int 
                 if ((Config.MainMenuWidgetActiveTimerShowRemoteActive ||
                      Config.MainMenuWidgetActiveTimerShowRemoteRecording) &&
                     (TimerRemoteRec.Size() > 0 || TimerRemoteActive.Size() > 0)) {
-                    img = ImgLoader.LoadIcon("widgets/home", 999, m_FontSmlHeight);
+                    img = ImgLoader.LoadIcon("widgets/home", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
                     if (img) {
                         ContentWidget.AddImage(img, cRect(Left, ContentTop, Width, m_FontSmlHeight));
                         Left += m_FontSmlHeight + m_MarginItem;
@@ -4164,7 +4164,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetActiveTimers(int wLeft, int wWidth, int 
                 if ((Config.MainMenuWidgetActiveTimerShowRemoteActive ||
                      Config.MainMenuWidgetActiveTimerShowRemoteRecording) &&
                     (TimerRemoteRec.Size() > 0 || TimerRemoteActive.Size() > 0)) {
-                    img = ImgLoader.LoadIcon("widgets/home", 999, m_FontSmlHeight);
+                    img = ImgLoader.LoadIcon("widgets/home", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
                     if (img) {
                         ContentWidget.AddImage(img, cRect(Left, ContentTop, Width, m_FontSmlHeight));
                         Left += m_FontSmlHeight + m_MarginItem;
@@ -4200,7 +4200,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetActiveTimers(int wLeft, int wWidth, int 
                     break;
 
                 StrTimer = "";  // Reset string
-                img = ImgLoader.LoadIcon("widgets/remotetimer", 999, m_FontSmlHeight);
+                img = ImgLoader.LoadIcon("widgets/remotetimer", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
                 if (img) {
                     ContentWidget.AddImage(img, cRect(Left, ContentTop, Width, m_FontSmlHeight));
                     Left += m_FontSmlHeight + m_MarginItem;
@@ -4237,7 +4237,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetActiveTimers(int wLeft, int wWidth, int 
                     break;
 
                 StrTimer = "";  // Reset string
-                img = ImgLoader.LoadIcon("widgets/remotetimer", 999, m_FontSmlHeight);
+                img = ImgLoader.LoadIcon("widgets/remotetimer", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
                 if (img) {
                     ContentWidget.AddImage(img, cRect(Left, ContentTop, Width, m_FontSmlHeight));
                     Left += m_FontSmlHeight + m_MarginItem;
@@ -4788,7 +4788,7 @@ void cFlatDisplayMenu::PreLoadImages() {
     }
 
     if (Config.TopBarMenuIconShow)
-        ImgLoader.LoadIcon(cString::sprintf("menuIcons/%s", VDRLOGO), 999, m_TopBarHeight - m_MarginItem2);
+        ImgLoader.LoadIcon(cString::sprintf("menuIcons/%s", VDRLOGO), ICON_WIDTH_UNLIMITED, m_TopBarHeight - m_MarginItem2);
 
     ImgLoader.LoadIcon("menuIcons/blank", ImageHeight - m_MarginItem2, ImageHeight - m_MarginItem2);
 
@@ -4819,9 +4819,9 @@ void cFlatDisplayMenu::PreLoadImages() {
         }
     }  // for channel
 
-    ImgLoader.LoadIcon("radio", 999, m_TopBarHeight - m_MarginItem2);
-    ImgLoader.LoadIcon("changroup", 999, m_TopBarHeight - m_MarginItem2);
-    ImgLoader.LoadIcon("tv", 999, m_TopBarHeight - m_MarginItem2);
+    ImgLoader.LoadIcon("radio", ICON_WIDTH_UNLIMITED, m_TopBarHeight - m_MarginItem2);
+    ImgLoader.LoadIcon("changroup", ICON_WIDTH_UNLIMITED, m_TopBarHeight - m_MarginItem2);
+    ImgLoader.LoadIcon("tv", ICON_WIDTH_UNLIMITED, m_TopBarHeight - m_MarginItem2);
 
     ImgLoader.LoadIcon("timer_full", ImageHeight, ImageHeight);
     ImgLoader.LoadIcon("timer_full_cur", ImageHeight, ImageHeight);

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -319,8 +319,8 @@ void cFlatDisplayMenu::SetTitle(const char *Title) {
     case mcTimer:
         IconName = "menuIcons/Timers";
         if (Config.MenuTimerShowCount) {
-            GetTimerCounts(m_LastTimerCount, m_LastTimerActiveCount);  // Update timer counts
-            NewTitle = cString::sprintf("%s (%d/%d)", Title, m_LastTimerCount, m_LastTimerActiveCount);
+            GetTimerCounts(m_LastTimerActiveCount, m_LastTimerCount);  // Update timer counts
+            NewTitle = cString::sprintf("%s (%d/%d)", Title, m_LastTimerActiveCount, m_LastTimerCount);
         }
         break;
     case mcRecording:
@@ -3524,12 +3524,12 @@ void cFlatDisplayMenu::Flush() {
     }
 
     if (m_MenuCategory == mcTimer && Config.MenuTimerShowCount) {
-        uint TimerCount {0}, TimerActiveCount {0};
-        GetTimerCounts(TimerCount, TimerActiveCount);
+        uint TimerActiveCount {0}, TimerCount {0};
+        GetTimerCounts(TimerActiveCount, TimerCount);
 
-        if (m_LastTimerCount != TimerCount || m_LastTimerActiveCount != TimerActiveCount) {
-            m_LastTimerCount = TimerCount;
+        if (m_LastTimerActiveCount != TimerActiveCount || m_LastTimerCount != TimerCount) {
             m_LastTimerActiveCount = TimerActiveCount;
+            m_LastTimerCount = TimerCount;
             const cString NewTitle = cString::sprintf("%s (%d/%d)", *m_LastTitle, TimerActiveCount, TimerCount);
             TopBarSetTitle(*NewTitle, false);  // Do not clear
         }
@@ -3688,9 +3688,9 @@ cString cFlatDisplayMenu::GetRecCounts() {
     return RecCounts;
 }
 
-void cFlatDisplayMenu::GetTimerCounts(uint &TimerCount, uint &TimerActiveCount) {
-    TimerCount = 0;
+void cFlatDisplayMenu::GetTimerCounts(uint &TimerActiveCount, uint &TimerCount) {
     TimerActiveCount = 0;
+    TimerCount = 0;
     LOCK_TIMERS_READ;  // Creates local const cTimers *Timers
     for (const cTimer *Timer = Timers->First(); Timer; Timer = Timers->Next(Timer)) {
         ++TimerCount;

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -38,7 +38,7 @@ cFlatDisplayMenu::cFlatDisplayMenu() {
     ButtonsCreate();
     MessageCreate();
 
-    m_FontAscender = GetFontAscender(Setup.FontOsd, Setup.FontOsdSize);  // Top of capital letter
+    // m_FontAscender = GetFontAscender(Setup.FontOsd, Setup.FontOsdSize);  // Top of capital letter
 
     m_RecFolder.reserve(256);
     m_LastRecFolder.reserve(256);

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -4408,27 +4408,30 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation(int wLeft, int wWidth,
         int Column {1};
         int ContentLeft {m_MarginItem};
 
+        // Items are stored in an array, in which case they need to be marked differently
+        // Using the trNOOP() macro, the actual translation is then done when such a text is used
+        // https://github.com/vdr-projects/vdr/wiki/The-VDR-Plugin-System#internationalization
         const struct ItemData {
             const char *key;
-            const char *label;  // Store the translated string. Needed for 'xgettext'
+            const char *label;
         } items[] {
-            {"sys_version", tr("System Version")},
-            {"kernel_version", tr("Kernel Version")},
-            {"uptime", tr("Uptime")},
-            {"load", tr("Load")},
-            {"processes", tr("Processes")},
-            {"mem_usage", tr("Memory Usage")},
-            {"swap_usage", tr("Swap Usage")},
-            {"root_usage", tr("Root Usage")},
-            {"video_usage", tr("Video Usage")},
-            {"vdr_cpu_usage", tr("VDR CPU Usage")},
-            {"vdr_mem_usage", tr("VDR MEM Usage")},
-            {"cpu", tr("Temp CPU")},
-            {"gpu", tr("Temp GPU")},
-            {"pccase", tr("Temp PC-Case")},
-            {"motherboard", tr("Temp MB")},
-            {"updates", tr("Updates")},
-            {"security_updates", tr("Security Updates")}
+            {"sys_version", trNOOP("System Version")},
+            {"kernel_version", trNOOP("Kernel Version")},
+            {"uptime", trNOOP("Uptime")},
+            {"load", trNOOP("Load")},
+            {"processes", trNOOP("Processes")},
+            {"mem_usage", trNOOP("Memory Usage")},
+            {"swap_usage", trNOOP("Swap Usage")},
+            {"root_usage", trNOOP("Root Usage")},
+            {"video_usage", trNOOP("Video Usage")},
+            {"vdr_cpu_usage", trNOOP("VDR CPU Usage")},
+            {"vdr_mem_usage", trNOOP("VDR MEM Usage")},
+            {"cpu", trNOOP("Temp CPU")},
+            {"gpu", trNOOP("Temp GPU")},
+            {"pccase", trNOOP("Temp PC-Case")},
+            {"motherboard", trNOOP("Temp MB")},
+            {"updates", trNOOP("Updates")},
+            {"security_updates", trNOOP("Security Updates")}
         };
 
         for (const auto &FileName : files) {
@@ -4445,7 +4448,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation(int wLeft, int wWidth,
 
             for (const auto &data : items) {
                 if (item.compare(data.key) == 0) {
-                    str = cString::sprintf("%s: %s", data.label, ItemContent.c_str());
+                    str = cString::sprintf("%s: %s", tr(data.label), ItemContent.c_str());
                     ContentWidget.AddText(*str, false,
                                           cRect(ContentLeft, ContentTop, wWidth - m_MarginItem2, m_FontSmlHeight),
                                           Theme.Color(clrMenuEventFontInfo), Theme.Color(clrMenuEventBg), m_FontSml,

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -2876,12 +2876,12 @@ void cFlatDisplayMenu::AddActors(cComplexContent &ComplexContent, std::vector<cS
                     *Role, false, cRect(x, y + ImgHeight + m_MarginItem + FontTinyHeight, ActorWidth, 0),
                     Theme.Color(clrMenuRecFontInfo), Theme.Color(clrMenuRecBg), m_FontTiny, ActorWidth,
                     FontTinyHeight, taCenter);
-                if (ImgHeight > MaxImgHeight) {
-                    MaxImgHeight = ImgHeight;  // In case images have different size
 #ifdef DEBUGFUNCSCALL
-                    dsyslog("   Column %d: MaxImgHeight changed to %d", col, MaxImgHeight);
-#endif
+                if (ImgHeight > MaxImgHeight) {
+                    dsyslog("   Column %d: MaxImgHeight changed to %d", col, ImgHeight);
                 }
+#endif
+                MaxImgHeight = std::max(MaxImgHeight, ImgHeight);  // In case images have different size
             }
             x += ActorWidth + ActorMargin;
             ++Actor;

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -4410,25 +4410,25 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation(int wLeft, int wWidth,
 
         const struct ItemData {
             const char *key;
-            const char *label;
+            const char *label;  // Store the translated string. Needed for 'xgettext'
         } items[] {
-            {"sys_version", "System Version"},
-            {"kernel_version", "Kernel Version"},
-            {"uptime", "Uptime"},
-            {"load", "Load"},
-            {"processes", "Processes"},
-            {"mem_usage", "Memory Usage"},
-            {"swap_usage", "Swap Usage"},
-            {"root_usage", "Root Usage"},
-            {"video_usage", "Video Usage"},
-            {"vdr_cpu_usage", "VDR CPU Usage"},
-            {"vdr_mem_usage", "VDR MEM Usage"},
-            {"cpu", "Temp CPU"},
-            {"gpu", "Temp GPU"},
-            {"pccase", "Temp PC-Case"},
-            {"motherboard", "Temp MB"},
-            {"updates", "Updates"},
-            {"security_updates", "Security Updates"}
+            {"sys_version", tr("System Version")},
+            {"kernel_version", tr("Kernel Version")},
+            {"uptime", tr("Uptime")},
+            {"load", tr("Load")},
+            {"processes", tr("Processes")},
+            {"mem_usage", tr("Memory Usage")},
+            {"swap_usage", tr("Swap Usage")},
+            {"root_usage", tr("Root Usage")},
+            {"video_usage", tr("Video Usage")},
+            {"vdr_cpu_usage", tr("VDR CPU Usage")},
+            {"vdr_mem_usage", tr("VDR MEM Usage")},
+            {"cpu", tr("Temp CPU")},
+            {"gpu", tr("Temp GPU")},
+            {"pccase", tr("Temp PC-Case")},
+            {"motherboard", tr("Temp MB")},
+            {"updates", tr("Updates")},
+            {"security_updates", tr("Security Updates")}
         };
 
         for (const auto &FileName : files) {
@@ -4445,7 +4445,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation(int wLeft, int wWidth,
 
             for (const auto &data : items) {
                 if (item.compare(data.key) == 0) {
-                    str = cString::sprintf("%s: %s", tr(data.label), ItemContent.c_str());
+                    str = cString::sprintf("%s: %s", data.label, ItemContent.c_str());
                     ContentWidget.AddText(*str, false,
                                           cRect(ContentLeft, ContentTop, wWidth - m_MarginItem2, m_FontSmlHeight),
                                           Theme.Color(clrMenuEventFontInfo), Theme.Color(clrMenuEventBg), m_FontSml,

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -18,7 +18,7 @@
 #include "./services/scraper2vdr.h"
 
 #include "./flat.h"
-#include "./locale"
+// #include "./locale"
 
 #ifndef VDRLOGO
 #define VDRLOGO "vdrlogo_default"
@@ -4374,7 +4374,6 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation(int wLeft, int wWidth,
     [[maybe_unused]] int r {system(*ExecFile)};  // Prevent warning for unused variable
 
     const cString ConfigsPath = cString::sprintf("%s/system_information/", WIDGETOUTPUTPATH);
-
     std::vector<std::string> files;
     files.reserve(32);  // Set to at least 32 entry's
 
@@ -4396,8 +4395,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation(int wLeft, int wWidth,
     std::sort(files.begin(), files.end(), StringCompare);
 
     cString str {""};
-    const std::size_t FilesSize {files.size()};
-    if (FilesSize == 0) {
+    if (files.size() == 0) {
         str = cString::sprintf("%s - %s", tr("no information available please check the script"), *ExecFile);
         ContentWidget.AddText(*str, false, cRect(m_MarginItem, ContentTop, wWidth - m_MarginItem2, m_FontSmlHeight),
                               Theme.Color(clrMenuEventFontInfo), Theme.Color(clrMenuEventBg), m_FontSml,
@@ -4413,23 +4411,25 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation(int wLeft, int wWidth,
         const struct ItemData {
             const char *key;
             const char *label;
-        } items[] {{"sys_version", "System Version"},
-                   {"kernel_version", "Kernel Version"},
-                   {"uptime", "Uptime"},
-                   {"load", "Load"},
-                   {"processes", "Processes"},
-                   {"mem_usage", "Memory Usage"},
-                   {"swap_usage", "Swap Usage"},
-                   {"root_usage", "Root Usage"},
-                   {"video_usage", "Video Usage"},
-                   {"vdr_cpu_usage", "VDR CPU Usage"},
-                   {"vdr_mem_usage", "VDR MEM Usage"},
-                   {"cpu", "Temp CPU"},
-                   {"gpu", "Temp GPU"},
-                   {"pccase", "Temp PC-Case"},
-                   {"motherboard", "Temp MB"},
-                   {"updates", "Updates"},
-                   {"security_updates", "Security Updates"}};
+        } items[] {
+            {"sys_version", "System Version"},
+            {"kernel_version", "Kernel Version"},
+            {"uptime", "Uptime"},
+            {"load", "Load"},
+            {"processes", "Processes"},
+            {"mem_usage", "Memory Usage"},
+            {"swap_usage", "Swap Usage"},
+            {"root_usage", "Root Usage"},
+            {"video_usage", "Video Usage"},
+            {"vdr_cpu_usage", "VDR CPU Usage"},
+            {"vdr_mem_usage", "VDR MEM Usage"},
+            {"cpu", "Temp CPU"},
+            {"gpu", "Temp GPU"},
+            {"pccase", "Temp PC-Case"},
+            {"motherboard", "Temp MB"},
+            {"updates", "Updates"},
+            {"security_updates", "Security Updates"}
+        };
 
         for (const auto &FileName : files) {
             if (ContentTop + m_MarginItem > MenuPixmapViewPortHeight) break;

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -3511,7 +3511,6 @@ void cFlatDisplayMenu::Flush() {
 #endif
 
     if (!MenuPixmap) return;
-    TopBarUpdate();
 
     if (Config.MenuFullOsd && !m_MenuFullOsdIsDrawn) {
         MenuPixmap->DrawRectangle(cRect(0, m_MenuItemLastHeight - Config.decorBorderMenuItemSize,
@@ -3538,6 +3537,7 @@ void cFlatDisplayMenu::Flush() {
     if (cVideoDiskUsage::HasChanged(m_VideoDiskUsageState))
         TopBarEnableDiskUsage();  // Keep 'DiskUsage' up to date
 
+    TopBarUpdate();
     m_Osd->Flush();
 }
 

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -3918,7 +3918,8 @@ void cFlatDisplayMenu::DrawMainMenuWidgets() {
 }
 
 int cFlatDisplayMenu::DrawMainMenuWidgetDVBDevices(int wLeft, int wWidth, int ContentTop) {
-    if (ContentTop + m_FontHeight + 6 + m_FontSmlHeight > MenuPixmap->ViewPort().Height())
+    const int MenuPixmapViewPortHeight {MenuPixmap->ViewPort().Height()};
+    if (ContentTop + m_FontHeight + 6 + m_FontSmlHeight > MenuPixmapViewPortHeight)
         return -1;
 
     cImage *img {ImgLoader.LoadIcon("widgets/dvb_devices", m_FontHeight, m_FontHeight - m_MarginItem2)};
@@ -3958,7 +3959,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetDVBDevices(int wLeft, int wWidth, int Co
     int ActualNumDevices {0};
     cString ChannelName {""}, str {""}, StrDevice {""};
     for (int i {0}; i < NumDevices; ++i) {
-        if (ContentTop + m_MarginItem > MenuPixmap->ViewPort().Height())
+        if (ContentTop + m_MarginItem > MenuPixmapViewPortHeight)
             continue;
 
         const cDevice *device = cDevice::GetDevice(i);
@@ -4037,7 +4038,8 @@ int cFlatDisplayMenu::DrawMainMenuWidgetDVBDevices(int wLeft, int wWidth, int Co
 }
 
 int cFlatDisplayMenu::DrawMainMenuWidgetActiveTimers(int wLeft, int wWidth, int ContentTop) {
-    if (ContentTop + m_FontHeight + 6 + m_FontSmlHeight > MenuPixmap->ViewPort().Height())
+    const int MenuPixmapViewPortHeight {MenuPixmap->ViewPort().Height()};
+    if (ContentTop + m_FontHeight + 6 + m_FontSmlHeight > MenuPixmapViewPortHeight)
         return -1;
 
     cImage *img {ImgLoader.LoadIcon("widgets/active_timers", m_FontHeight, m_FontHeight - m_MarginItem2)};
@@ -4113,7 +4115,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetActiveTimers(int wLeft, int wWidth, int 
             const int TimerRecSize {TimerRec.Size()};
             for (int i {0}; i < TimerRecSize; ++i) {
                 ++count;
-                if (ContentTop + m_MarginItem > MenuPixmap->ViewPort().Height())
+                if (ContentTop + m_MarginItem > MenuPixmapViewPortHeight)
                     break;
 
                 if (count >= Config.MainMenuWidgetActiveTimerMaxCount)
@@ -4154,7 +4156,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetActiveTimers(int wLeft, int wWidth, int 
             const int TimerActiveSize {TimerActive.Size()};
             for (int i {0}; i < TimerActiveSize; ++i) {
                 ++count;
-                if (ContentTop + m_MarginItem > MenuPixmap->ViewPort().Height())
+                if (ContentTop + m_MarginItem > MenuPixmapViewPortHeight)
                     break;
 
                 if (count >= Config.MainMenuWidgetActiveTimerMaxCount)
@@ -4193,7 +4195,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetActiveTimers(int wLeft, int wWidth, int 
             const int TimerRemoteRecSize {TimerRemoteRec.Size()};
             for (int i {0}; i < TimerRemoteRecSize; ++i) {
                 ++RemoteCount;
-                if (ContentTop + m_MarginItem > MenuPixmap->ViewPort().Height())
+                if (ContentTop + m_MarginItem > MenuPixmapViewPortHeight)
                     break;
 
                 if (count + RemoteCount >= Config.MainMenuWidgetActiveTimerMaxCount)
@@ -4230,7 +4232,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetActiveTimers(int wLeft, int wWidth, int 
             const int TimerRemoteActiveSize {TimerRemoteActive.Size()};
             for (int i {0}; i < TimerRemoteActiveSize; ++i) {
                 ++RemoteCount;
-                if (ContentTop + m_MarginItem > MenuPixmap->ViewPort().Height())
+                if (ContentTop + m_MarginItem > MenuPixmapViewPortHeight)
                     break;
 
                 if (count + RemoteCount >= Config.MainMenuWidgetActiveTimerMaxCount)
@@ -4267,7 +4269,8 @@ int cFlatDisplayMenu::DrawMainMenuWidgetActiveTimers(int wLeft, int wWidth, int 
 }
 
 int cFlatDisplayMenu::DrawMainMenuWidgetLastRecordings(int wLeft, int wWidth, int ContentTop) {
-    if (ContentTop + m_FontHeight + 6 + m_FontSmlHeight > MenuPixmap->ViewPort().Height())
+    const int MenuPixmapViewPortHeight {MenuPixmap->ViewPort().Height()};
+    if (ContentTop + m_FontHeight + 6 + m_FontSmlHeight > MenuPixmapViewPortHeight)
         return -1;
 
     cImage *img {ImgLoader.LoadIcon("widgets/last_recordings", m_FontHeight, m_FontHeight - m_MarginItem2)};
@@ -4302,7 +4305,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetLastRecordings(int wLeft, int wWidth, in
     int index {0};
     cString Rec {""};
     while (!Recs.empty() && index < Config.MainMenuWidgetLastRecMaxCount) {
-        if (ContentTop + m_MarginItem > MenuPixmap->ViewPort().Height())
+        if (ContentTop + m_MarginItem > MenuPixmapViewPortHeight)
             continue;
 
         PairRec = Recs.back();
@@ -4352,7 +4355,8 @@ int cFlatDisplayMenu::DrawMainMenuWidgetTimerConflicts(int wLeft, int wWidth, in
 }
 
 int cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation(int wLeft, int wWidth, int ContentTop) {
-    if (ContentTop + m_FontHeight + 6 + m_FontSmlHeight > MenuPixmap->ViewPort().Height())
+    const int MenuPixmapViewPortHeight {MenuPixmap->ViewPort().Height()};
+    if (ContentTop + m_FontHeight + 6 + m_FontSmlHeight > MenuPixmapViewPortHeight)
         return -1;
 
     cImage *img {ImgLoader.LoadIcon("widgets/system_information", m_FontHeight, m_FontHeight - m_MarginItem2)};
@@ -4427,14 +4431,9 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation(int wLeft, int wWidth,
                    {"security_updates", "Security Updates"}};
 
         for (const auto &FileName : files) {
-            if (ContentTop + m_MarginItem > MenuPixmap->ViewPort().Height()) break;
+            if (ContentTop + m_MarginItem > MenuPixmapViewPortHeight) break;
 
             found = FileName.find('_');
-            // if (found == std::string::npos) continue;  // Only files with '_' added above
-
-            // auto num = FileName.substr(0, found);  // Already checked above
-            // if (atoi(num.c_str()) <= 0) continue;
-
             item = FileName.substr(found + 1);
             ItemFilename = cString::sprintf("%s/system_information/%s", WIDGETOUTPUTPATH, FileName.c_str());
 
@@ -4584,7 +4583,8 @@ int cFlatDisplayMenu::DrawMainMenuWidgetTemperatures(int wLeft, int wWidth, int 
 }
 
 int cFlatDisplayMenu::DrawMainMenuWidgetCommand(int wLeft, int wWidth, int ContentTop) {
-    if (ContentTop + m_FontHeight + 6 + m_FontSmlHeight > MenuPixmap->ViewPort().Height())
+    const int MenuPixmapViewPortHeight {MenuPixmap->ViewPort().Height()};
+    if (ContentTop + m_FontHeight + 6 + m_FontSmlHeight > MenuPixmapViewPortHeight)
         return -1;
 
     const cString ExecFile = cString::sprintf("\"%s/command_output/command\"", WIDGETFOLDER);
@@ -4609,7 +4609,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetCommand(int wLeft, int wWidth, int Conte
     std::ifstream file(*ItemFilename);
     if (file.is_open()) {
         for (; std::getline(file, Output);) {
-            if (ContentTop + m_MarginItem > MenuPixmap->ViewPort().Height())
+            if (ContentTop + m_MarginItem > MenuPixmapViewPortHeight)
                 break;
             ContentWidget.AddText(
                 Output.c_str(), false, cRect(m_MarginItem, ContentTop, wWidth - m_MarginItem2, m_FontSmlHeight),
@@ -4628,7 +4628,8 @@ int cFlatDisplayMenu::DrawMainMenuWidgetCommand(int wLeft, int wWidth, int Conte
 }
 
 int cFlatDisplayMenu::DrawMainMenuWidgetWeather(int wLeft, int wWidth, int ContentTop) {
-    if (ContentTop + m_FontHeight + 6 + m_FontSmlHeight > MenuPixmap->ViewPort().Height())
+    const int MenuPixmapViewPortHeight {MenuPixmap->ViewPort().Height()};
+    if (ContentTop + m_FontHeight + 6 + m_FontSmlHeight > MenuPixmapViewPortHeight)
         return -1;
 
     // Read location
@@ -4722,7 +4723,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetWeather(int wLeft, int wWidth, int Conte
                                   Theme.Color(clrMenuEventFontInfo), Theme.Color(clrMenuEventBg), m_FontTempSml);
             left += m_FontTempSml->Width(*PrecString) + m_MarginItem2;
         } else {  // Long
-            if (ContentTop + m_MarginItem > MenuPixmap->ViewPort().Height())
+            if (ContentTop + m_MarginItem > MenuPixmapViewPortHeight)
                 break;
 
             left = m_MarginItem;
@@ -4788,7 +4789,8 @@ void cFlatDisplayMenu::PreLoadImages() {
     }
 
     if (Config.TopBarMenuIconShow)
-        ImgLoader.LoadIcon(cString::sprintf("menuIcons/%s", VDRLOGO), ICON_WIDTH_UNLIMITED, m_TopBarHeight - m_MarginItem2);
+        ImgLoader.LoadIcon(cString::sprintf("menuIcons/%s", VDRLOGO), ICON_WIDTH_UNLIMITED,
+                           m_TopBarHeight - m_MarginItem2);
 
     ImgLoader.LoadIcon("menuIcons/blank", ImageHeight - m_MarginItem2, ImageHeight - m_MarginItem2);
 

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -174,7 +174,7 @@ void cFlatDisplayMenu::DrawScrollbar(int Total, int Offset, int Shown, int Top, 
     if (!MenuPixmap) return;
 
     if (Total > 0 && Total > Shown) {
-        if (m_IsScrolling == false && m_ShowEvent == false && m_ShowRecording == false && m_ShowText == false) {
+        if (!m_IsScrolling && !(m_ShowEvent || m_ShowRecording || m_ShowText)) {
             m_IsScrolling = true;
             DecorBorderClearByFrom(BorderMenuItem);
             ItemBorderDrawAllWithScrollbar();
@@ -191,7 +191,7 @@ void cFlatDisplayMenu::DrawScrollbar(int Total, int Offset, int Shown, int Top, 
                                                 m_WidthScrollBar + m_MarginItem, m_ScrollBarHeight),
                                           clrTransparent);
         }
-    } else if (m_ShowEvent == false && m_ShowRecording == false && m_ShowText == false) {
+    } else if (!(m_ShowEvent || m_ShowRecording || m_ShowText)) {
         m_IsScrolling = false;
     }
 
@@ -2567,8 +2567,8 @@ void cFlatDisplayMenu::SetEvent(const cEvent *Event) {
         cString::sprintf("%s  %s - %s", *Event->GetDateString(), *Event->GetTimeString(), *Event->GetEndTimeString());
 
     const cString Title = Event->Title();
-    const cString ShortText = Event->ShortText();
-    const int ShortTextWidth {m_FontSml->Width(*ShortText)};      // Width of short text
+    const cString ShortText = (Event->ShortText()) ? Event->ShortText() : " - ";  // No short text. Show ' - '
+    const int ShortTextWidth {m_FontSml->Width(*ShortText)};  // Width of short text
     const int MaxWidth {HeadIconLeft - m_MarginItem};
     int left {m_MarginItem};
 
@@ -2907,8 +2907,7 @@ void cFlatDisplayMenu::SetRecording(const cRecording *Recording) {
     cTimeMs Timer;  // Set Timer
 #endif
 
-    if (!ContentHeadPixmap || !ContentHeadIconsPixmap) return;
-    if (!Recording) return;
+    if (!ContentHeadPixmap || !ContentHeadIconsPixmap || !Recording) return;
 
     m_ShowEvent = false;
     m_ShowRecording = true;
@@ -3307,7 +3306,7 @@ void cFlatDisplayMenu::SetRecording(const cRecording *Recording) {
     if (isempty(*Title))
         Title = Recording->Name();
 
-    const cString ShortText = RecInfo->ShortText();
+    const cString ShortText = (RecInfo->ShortText() ? RecInfo->ShortText() : " - ");  // No short text. Show ' - '
     const int ShortTextWidth {m_FontSml->Width(*ShortText)};  // Width of short text
     int MaxWidth {HeadIconLeft - m_MarginItem};  // Reduce redundant calculations
     int left {m_MarginItem};

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -2194,8 +2194,7 @@ void cFlatDisplayMenu::SetEvent(const cEvent *Event) {
     dsyslog("flatPlus: cFlatDisplayMenu::SetEvent()");
 #endif
 
-    if (!ContentHeadIconsPixmap || !ContentHeadPixmap) return;
-    if (!Event) return;
+    if (!ContentHeadIconsPixmap || !ContentHeadPixmap || !Event ) return;
 
 #ifdef DEBUGEPGTIME
     cTimeMs Timer;  // Set Timer
@@ -2567,8 +2566,8 @@ void cFlatDisplayMenu::SetEvent(const cEvent *Event) {
         cString::sprintf("%s  %s - %s", *Event->GetDateString(), *Event->GetTimeString(), *Event->GetEndTimeString());
 
     const cString Title = Event->Title();
-    const cString ShortText = (Event->ShortText()) ? Event->ShortText() : " - ";  // No short text. Show ' - '
-    const int ShortTextWidth {m_FontSml->Width(*ShortText)};  // Width of short text
+    const cString ShortText = (Event->ShortText()) ? Event->ShortText() : "";  // No short text. Show empty string
+    const int ShortTextWidth {m_FontSml->Width(*ShortText)};
     const int MaxWidth {HeadIconLeft - m_MarginItem};
     int left {m_MarginItem};
 
@@ -3307,7 +3306,7 @@ void cFlatDisplayMenu::SetRecording(const cRecording *Recording) {
         Title = Recording->Name();
 
     const cString ShortText = (RecInfo->ShortText() ? RecInfo->ShortText() : " - ");  // No short text. Show ' - '
-    const int ShortTextWidth {m_FontSml->Width(*ShortText)};  // Width of short text
+    const int ShortTextWidth {m_FontSml->Width(*ShortText)};
     int MaxWidth {HeadIconLeft - m_MarginItem};  // Reduce redundant calculations
     int left {m_MarginItem};
 

--- a/displaymenu.h
+++ b/displaymenu.h
@@ -79,7 +79,7 @@ class cFlatDisplayMenu : public cFlatBaseRender, public cSkinDisplayMenu {
         // int m_FontAscender {0};  // Top of capital letter
         // int m_VideoDiskUsageState;  // Also in cFlatBaseRender
 
-        uint m_LastTimerCount {0}, m_LastTimerActiveCount {0};
+        uint m_LastTimerActiveCount {0}, m_LastTimerCount {0};
         cString m_LastTitle {""};
 
         int m_chLeft {0}, m_chTop {0}, m_chWidth {0}, m_chHeight {0};
@@ -131,7 +131,7 @@ class cFlatDisplayMenu : public cFlatBaseRender, public cSkinDisplayMenu {
         cString GetRecordingName(const cRecording *Recording, int Level, bool IsFolder);
         cString GetRecCounts();  // Get number of recordings and new recordings (35*/53)
 
-        void GetTimerCounts(uint &TimerCount, uint &TimerActiveCount);  // NOLINT
+        void GetTimerCounts(uint &TimerActiveCount, uint &TimerCount);  // NOLINT
 
         bool IsRecordingOld(const cRecording *Recording, int Level);
 

--- a/displaymenu.h
+++ b/displaymenu.h
@@ -76,7 +76,7 @@ class cFlatDisplayMenu : public cFlatBaseRender, public cSkinDisplayMenu {
 
         eMenuCategory m_MenuCategory {mcUndefined};
 
-        int m_FontAscender {0};  // Top of capital letter
+        // int m_FontAscender {0};  // Top of capital letter
         // int m_VideoDiskUsageState;  // Also in cFlatBaseRender
 
         uint m_LastTimerCount {0}, m_LastTimerActiveCount {0};

--- a/displayreplay.c
+++ b/displayreplay.c
@@ -78,7 +78,7 @@ cFlatDisplayReplay::~cFlatDisplayReplay() {
 
 void cFlatDisplayReplay::SetRecording(const cRecording *Recording) {
 #ifdef DEBUGFUNCSCALL
-    dsyslog("flatPlus: cFlatDisplayReplay::Setrecording()");
+    dsyslog("flatPlus: cFlatDisplayReplay::SetRecording()");
 #endif
 
     if (!IconsPixmap || !LabelPixmap || m_ModeOnly) return;
@@ -98,7 +98,6 @@ void cFlatDisplayReplay::SetRecording(const cRecording *Recording) {
     cImage *img {nullptr};
     if ((Recording->IsInUse() & ruTimer) != 0) {  // The recording is currently written to by a timer
         img = ImgLoader.LoadIcon("timerRecording", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);  // Small image
-
         if (img) {
             const int ImageTop {SmallTop};
             IconsPixmap->DrawImage(cPoint(left, ImageTop), *img);

--- a/displayreplay.c
+++ b/displayreplay.c
@@ -342,17 +342,17 @@ void cFlatDisplayReplay::UpdateInfo() {
 
     if (!LabelPixmap || !ChanEpgImagesPixmap || !IconsPixmap || m_ModeOnly) return;
 
-    const int FontAscender {GetFontAscender(Setup.FontOsd, Setup.FontOsdSize)};
+    // const int FontAscender {GetFontAscender(Setup.FontOsd, Setup.FontOsdSize)};
     const int FontSecsAscender {GetFontAscender(Setup.FontOsd, Setup.FontOsdSize * Config.TimeSecsScale * 100.0)};
-    const int TopSecs {FontAscender - FontSecsAscender};
+    const int TopSecs {m_FontAscender - FontSecsAscender};
 
     constexpr ulong CharCode {0x0030};  // U+0030 DIGIT ZERO
     const int GlyphSize = GetGlyphSize(Setup.FontOsd, CharCode, Setup.FontOsdSize);  // Narrowing conversion
-    const int TopOffset {FontAscender - GlyphSize};
+    const int TopOffset {m_FontAscender - GlyphSize};
 
 #ifdef DEBUGFUNCSCALL
     dsyslog("   GlyphSize %d, Setup.FontOsdSize %d, m_FontHeight %d, FontAscender %d",
-             GlyphSize, Setup.FontOsdSize, m_FontHeight, FontAscender);
+             GlyphSize, Setup.FontOsdSize, m_FontHeight, m_FontAscender);
 #endif
 
     //* Draw current position with symbol (1. line)

--- a/displayreplay.c
+++ b/displayreplay.c
@@ -97,7 +97,7 @@ void cFlatDisplayReplay::SetRecording(const cRecording *Recording) {
     int left {m_MarginItem};  // Position for recording symbol/short text/date
     cImage *img {nullptr};
     if ((Recording->IsInUse() & ruTimer) != 0) {  // The recording is currently written to by a timer
-        img = ImgLoader.LoadIcon("timerRecording", 999, m_FontSmlHeight);  // Small image
+        img = ImgLoader.LoadIcon("timerRecording", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);  // Small image
 
         if (img) {
             const int ImageTop {SmallTop};
@@ -130,7 +130,7 @@ void cFlatDisplayReplay::SetRecording(const cRecording *Recording) {
         MaxWidth -= m_FontSmlHeight;  // Substract width of imgRecErr
 #endif
 
-    img = ImgLoader.LoadIcon("1920x1080", 999, m_FontSmlHeight);
+    img = ImgLoader.LoadIcon("1920x1080", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
     if (img)
         MaxWidth -= img->Width() * 3;  //* Substract guessed max. used space of aspect and format icons
 
@@ -162,7 +162,7 @@ void cFlatDisplayReplay::SetRecording(const cRecording *Recording) {
     if (Config.PlaybackShowRecordingErrors) {  // Separate config option
         const cString RecErrIcon = cString::sprintf("%s_replay", *GetRecordingErrorIcon(RecInfo->Errors()));
 
-        img = ImgLoader.LoadIcon(*RecErrIcon, 999, m_FontSmlHeight);  // Small image
+        img = ImgLoader.LoadIcon(*RecErrIcon, ICON_WIDTH_UNLIMITED, m_FontSmlHeight);  // Small image
         if (img) {
             left += m_MarginItem;
             const int ImageTop {SmallTop};
@@ -357,7 +357,7 @@ void cFlatDisplayReplay::UpdateInfo() {
 
     //* Draw current position with symbol (1. line)
     int left {m_MarginItem};
-    cImage *img {ImgLoader.LoadIcon("recording_pos", 999, GlyphSize)};
+    cImage *img {ImgLoader.LoadIcon("recording_pos", ICON_WIDTH_UNLIMITED, GlyphSize)};
     if (img) {
         IconsPixmap->DrawImage(cPoint(left, TopOffset), *img);
         left += img->Width() + m_MarginItem;
@@ -423,11 +423,11 @@ void cFlatDisplayReplay::UpdateInfo() {
 
     //* Draw total and cutted length with cutted symbol (Right side, 1. line)
     const int Spacer {m_Font->Width("0")};  // One digit width space between total and cutted length
-    img = ImgLoader.LoadIcon("recording_total", 999, GlyphSize);
+    img = ImgLoader.LoadIcon("recording_total", ICON_WIDTH_UNLIMITED, GlyphSize);
     const int ImgWidth {(img) ? img->Width() : 0};
     if (FramesAfterEdit > 0) {
         const cString cutted = *IndexToHMSF(FramesAfterEdit, false, FramesPerSecond);
-        cImage *ImgCutted {ImgLoader.LoadIcon("recording_cutted_extra", 999, GlyphSize)};
+        cImage *ImgCutted {ImgLoader.LoadIcon("recording_cutted_extra", ICON_WIDTH_UNLIMITED, GlyphSize)};
         const int ImgCuttedWidth {(ImgCutted) ? ImgCutted->Width() : 0};
 
         int right {m_OsdWidth - Config.decorBorderReplaySize * 2 - ImgWidth - m_MarginItem -
@@ -577,7 +577,7 @@ void cFlatDisplayReplay::UpdateInfo() {
             const int RestCutted {FramesAfterEdit - CurrentFramesAfterEdit};
             EndTime = *TimeString(time(0) + (RestCutted / FramesPerSecond));  // HH:MM
             if (strcmp(TimeStr, EndTime) != 0) {  // Only if not equal
-                img = ImgLoader.LoadIcon("recording_cutted_extra", 999, GlyphSize);
+                img = ImgLoader.LoadIcon("recording_cutted_extra", ICON_WIDTH_UNLIMITED, GlyphSize);
                 if (img) {
                     IconsPixmap->DrawImage(cPoint(left, m_FontHeight + TopOffset), *img);
                     left += img->Width() + m_MarginItem;
@@ -719,7 +719,7 @@ void cFlatDisplayReplay::ResolutionAspectDraw() {
         cString IconName {""};
         if (Config.RecordingResolutionAspectShow) {  // Show Aspect (16:9)
             IconName = *GetAspectIcon(m_ScreenWidth, m_ScreenAspect);
-            img = ImgLoader.LoadIcon(*IconName, 999, m_FontSmlHeight);
+            img = ImgLoader.LoadIcon(*IconName, ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
             if (img) {
                 left -= img->Width();
                 IconsPixmap->DrawImage(cPoint(left, ImageTop), *img);
@@ -727,7 +727,7 @@ void cFlatDisplayReplay::ResolutionAspectDraw() {
             }
 
             IconName = *GetScreenResolutionIcon(m_ScreenWidth, m_ScreenHeight);  // Show Resolution (1920x1080)
-            img = ImgLoader.LoadIcon(*IconName, 999, m_FontSmlHeight);
+            img = ImgLoader.LoadIcon(*IconName, ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
             if (img) {
                 left -= img->Width();
                 IconsPixmap->DrawImage(cPoint(left, ImageTop), *img);
@@ -737,7 +737,7 @@ void cFlatDisplayReplay::ResolutionAspectDraw() {
 
         if (Config.RecordingFormatShow && !Config.RecordingSimpleAspectFormat) {
             IconName = *GetFormatIcon(m_ScreenWidth);  // Show Format (HD)
-            img = ImgLoader.LoadIcon(*IconName, 999, m_FontSmlHeight);
+            img = ImgLoader.LoadIcon(*IconName, ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
             if (img) {
                 left -= img->Width();
                 IconsPixmap->DrawImage(cPoint(left, ImageTop), *img);
@@ -747,7 +747,7 @@ void cFlatDisplayReplay::ResolutionAspectDraw() {
         // Show audio icon (Dolby, Stereo)
         if (Config.RecordingResolutionAspectShow) {  //? Add separate config option
             IconName = *GetCurrentAudioIcon();
-            img = ImgLoader.LoadIcon(*IconName, 999, m_FontSmlHeight);
+            img = ImgLoader.LoadIcon(*IconName, ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
             if (img) {
                 left -= img->Width();
                 IconsPixmap->DrawImage(cPoint(left, ImageTop), *img);
@@ -787,35 +787,35 @@ void cFlatDisplayReplay::PreLoadImages() {
 
     constexpr ulong CharCode {0x0030};  // U+0030 DIGIT ZERO
     const int GlyphSize = GetGlyphSize(Setup.FontOsd, CharCode, Setup.FontOsdSize);  // Narrowing conversion
-    ImgLoader.LoadIcon("recording_pos", 999, GlyphSize);
-    ImgLoader.LoadIcon("recording_total", 999, GlyphSize);
-    ImgLoader.LoadIcon("recording_cutted_extra", 999, GlyphSize);
+    ImgLoader.LoadIcon("recording_pos", ICON_WIDTH_UNLIMITED, GlyphSize);
+    ImgLoader.LoadIcon("recording_total", ICON_WIDTH_UNLIMITED, GlyphSize);
+    ImgLoader.LoadIcon("recording_cutted_extra", ICON_WIDTH_UNLIMITED, GlyphSize);
 
-    ImgLoader.LoadIcon("recording_untested_replay", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("recording_ok_replay", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("recording_warning_replay", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("recording_error_replay", 999, m_FontSmlHeight);
+    ImgLoader.LoadIcon("recording_untested_replay", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("recording_ok_replay", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("recording_warning_replay", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("recording_error_replay", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
 
-    ImgLoader.LoadIcon("43", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("169", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("169w", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("221", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("7680x4320", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("3840x2160", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("1920x1080", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("1440x1080", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("1280x720", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("960x720", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("704x576", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("720x576", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("544x576", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("528x576", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("480x576", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("352x576", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("unknown_res", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("uhd", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("hd", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("sd", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("audio_stereo", 999, m_FontSmlHeight);
-    ImgLoader.LoadIcon("audio_dolby", 999, m_FontSmlHeight);
+    ImgLoader.LoadIcon("43", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("169", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("169w", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("221", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("7680x4320", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("3840x2160", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("1920x1080", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("1440x1080", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("1280x720", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("960x720", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("704x576", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("720x576", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("544x576", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("528x576", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("480x576", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("352x576", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("unknown_res", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("uhd", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("hd", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("sd", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("audio_stereo", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
+    ImgLoader.LoadIcon("audio_dolby", ICON_WIDTH_UNLIMITED, m_FontSmlHeight);
 }

--- a/displayreplay.c
+++ b/displayreplay.c
@@ -229,7 +229,7 @@ void cFlatDisplayReplay::SetMode(bool Play, bool Forward, int Speed) {
                                          m_FontHeight * 4 + m_MarginItem * 6 + m_Font->Width("99") * 2, m_FontHeight),
                                    Theme.Color(clrReplayBg));
 
-        cString rewind("rewind"), pause("pause"), play("play"), forward("forward");
+        cString rewind {"rewind"}, pause {"pause"}, play {"play"}, forward {"forward"};
         if (Speed == -1) {  // Replay or pause
             (Play) ? play = "play_sel" : pause = "pause_sel";
         } else {

--- a/displaytracks.c
+++ b/displaytracks.c
@@ -12,8 +12,8 @@ cFlatDisplayTracks::cFlatDisplayTracks(const char *Title, int NumTracks, const c
     CreateFullOsd();
     TopBarCreate();
 
-    img_ac3 = ImgLoader.LoadIcon("tracks_ac3", 999, m_FontHeight);
-    img_stereo = ImgLoader.LoadIcon("tracks_stereo", 999, m_FontHeight);
+    img_ac3 = ImgLoader.LoadIcon("tracks_ac3", ICON_WIDTH_UNLIMITED, m_FontHeight);
+    img_stereo = ImgLoader.LoadIcon("tracks_stereo", ICON_WIDTH_UNLIMITED, m_FontHeight);
 
     if (img_ac3)
         m_Ac3Width = img_ac3->Width();

--- a/flat.c
+++ b/flat.c
@@ -706,7 +706,10 @@ std::string_view trim(std::string_view str) {
 cTextFloatingWrapper::cTextFloatingWrapper() {}
 
 cTextFloatingWrapper::~cTextFloatingWrapper() {
-    free(m_Text);
+    if (m_Text) {
+        free(m_Text);
+        m_Text = nullptr;
+    }
 }
 
 void cTextFloatingWrapper::Set(const char *Text, const cFont *Font, int WidthLower, int UpperLines, int WidthUpper) {

--- a/flat.c
+++ b/flat.c
@@ -770,7 +770,7 @@ void cTextFloatingWrapper::Set(const char *Text, const cFont *Font, int WidthLow
             }
         }
         w += cw;
-        if (strchr("-.,:;!?_", *p)) {  //! Breaks '...'
+        if (strchr("-.,:;!?_~", *p)) {  //! Breaks '...'
             if (*p != *(p + 1)) {      // Next char is different, so use it for 'Delim'
                 Delim = p;
                 Blank = nullptr;

--- a/imagecache.c
+++ b/imagecache.c
@@ -44,6 +44,7 @@ bool cImageCache::RemoveFromCache(const std::string &Name) {
 
         if (BaseFileName == Name) {
             dsyslog("flatPlus: RemoveFromCache - %s", CacheName[i].c_str());
+            delete CacheImage[i];
             CacheImage[i] = nullptr;
             CacheName[i] = "";
             CacheWidth[i] = -1;

--- a/imageloader.c
+++ b/imageloader.c
@@ -186,7 +186,7 @@ cImage* cImageLoader::LoadFile(const char *cFile, int width, int height) {
     img = CreateImage(width, height);
 
 #ifdef DEBUGIMAGELOADTIME
-    dsyslog("   scale logo: %ld ms", Timer.Elapsed());
+    dsyslog("   scale image: %ld ms", Timer.Elapsed());
 #endif
 
     if (img) {

--- a/imageloader.c
+++ b/imageloader.c
@@ -14,7 +14,8 @@
 
 #include "./flat.h"
 
-using namespace Magick;
+using Magick::Image;
+using Magick::Geometry;
 
 cImageLoader::cImageLoader() {}
 
@@ -48,13 +49,10 @@ cImage* cImageLoader::LoadLogo(const char *logo, int width, int height) {
 
 #ifdef DEBUGIMAGELOADTIME
         dsyslog("   search in cache #%d: %ld ms", i + 1, Timer.Elapsed());
+        Timer.Set();  // Reset timer
 #endif
 
         if (img) return img;  // Image found in imagecache
-
-#ifdef DEBUGIMAGELOADTIME
-        Timer.Set();  // Reset timer
-#endif
 
         success = LoadImage(*File);  // Try to load image from disk
         if (!success) {              // Image not found on disk
@@ -86,73 +84,72 @@ cImage* cImageLoader::LoadLogo(const char *logo, int width, int height) {
 cImage* cImageLoader::LoadIcon(const char *cIcon, int width, int height) {
     if (width == 0 || height == 0) return nullptr;
 
-    const cString File[] {cString::sprintf("%s/%s/%s.%s", *Config.IconPath, Setup.OSDTheme, cIcon, *m_LogoExtension),
-                          cString::sprintf("%s/%s/%s.%s", *Config.IconPath, "default", cIcon, *m_LogoExtension)};
-    cImage *img {nullptr};
+    cString File = cString::sprintf("%s/%s/%s.%s", *Config.IconPath, Setup.OSDTheme, cIcon, *m_LogoExtension);
 
 #ifdef DEBUGIMAGELOADTIME
-    dsyslog("flatPlus: cImageLoader::LoadIcon() '%s' %dx%d", *File[0], width, height);
+    dsyslog("flatPlus: cImageLoader::LoadIcon() '%s'", *File);
     cTimeMs Timer;  // Start timer
 #endif
 
-    img = ImgCache.GetImage(*File[0], width, height);
+    cImage *img {nullptr};
+    img = ImgCache.GetImage(*File, width, height);
 
 #ifdef DEBUGIMAGELOADTIME
-    dsyslog("   search in cache: %ld ms", Timer.Elapsed());
-#endif
-
-    if (img)
-        return img;  // Image found in imagecache
-    else
-        img = ImgCache.GetImage(*File[1], width, height);
-
-#ifdef DEBUGIMAGELOADTIME
-    dsyslog("   search in cache (default): %ld ms", Timer.Elapsed());
-#endif
-
-    if (img) return img;  // Image found in imagecache
-
-#ifdef DEBUGIMAGELOADTIME
+    dsyslog("   search in cache: %d ms", Timer.Elapsed());
     Timer.Set();  // Reset timer
 #endif
 
-    bool success = LoadImage(*File[0]);
+    if (img) return img;
+
+    bool success = LoadImage(*File);
 
 #ifdef DEBUGIMAGELOADTIME
-    dsyslog("   load file from disk: %ld ms", Timer.Elapsed());
-    Timer.Set();  // Reset timer
+    dsyslog("   load file from disk: %d ms", Timer.Elapsed());
 #endif
 
-    bool DefaultPath {false};
     if (!success) {  // Search for logo in default folder
-        success = LoadImage(*File[1]);
+        File = cString::sprintf("%s/%s/%s.%s", *Config.IconPath, "default", cIcon, *m_LogoExtension);
 
 #ifdef DEBUGIMAGELOADTIME
-        dsyslog("   load file from disk (default): %ld ms", Timer.Elapsed());
+        dsyslog("flatPlus: cImageLoader::LoadIcon() '%s'", *File);
+        Timer.Set();  // Reset timer
+#endif
+
+        img = ImgCache.GetImage(*File, width, height);
+
+#ifdef DEBUGIMAGELOADTIME
+        dsyslog("   search in cache: %d ms", Timer.Elapsed());
+        Timer.Set();  // Reset timer
+#endif
+
+        if (img) return img;
+
+        success = LoadImage(*File);
+
+#ifdef DEBUGIMAGELOADTIME
+        dsyslog("   load file from disk: %d ms", Timer.Elapsed());
         Timer.Set();  // Reset timer
 #endif
 
         if (!success) {
-            isyslog("flatPlus: cImageLoader::LoadIcon() '%s' and '%s' could not be loaded", *File[0], *File[1]);
+            isyslog("flatPlus: cImageLoader::LoadIcon() '%s' could not be loaded", *File);
             return nullptr;
         }
-
-        DefaultPath = true;
-    }  // if (!success)
+    }
 
     img = CreateImage(width, height);
 
 #ifdef DEBUGIMAGELOADTIME
-    dsyslog("   scale logo: %ld ms", Timer.Elapsed());
+    dsyslog("   scale logo: %d ms", Timer.Elapsed());
 #endif
 
-    if (img) {
-        ImgCache.InsertImage(img, *File[DefaultPath ? 1 : 0], width, height);
-        return img;
+    if (!img) {
+        dsyslog("flatPlus: cImageLoader::LoadIcon() '%s' 'CreateImage' failed", *File);
+        return nullptr;
     }
 
-    dsyslog("flatPlus: cImageLoader::LoadIcon() '%s' 'CreateImage' failed", *File[DefaultPath ? 1 : 0]);
-    return nullptr;
+    ImgCache.InsertImage(img, *File, width, height);
+    return img;
 }
 
 cImage* cImageLoader::LoadFile(const char *cFile, int width, int height) {
@@ -170,13 +167,10 @@ cImage* cImageLoader::LoadFile(const char *cFile, int width, int height) {
 
 #ifdef DEBUGIMAGELOADTIME
     dsyslog("   search in cache: %ld ms", Timer.Elapsed());
+    Timer.Set();  // Reset timer
 #endif
 
     if (img) return img;  // Image found in imagecache
-
-#ifdef DEBUGIMAGELOADTIME
-    Timer.Set();  // Reset timer
-#endif
 
     const bool success = LoadImage(*File);
     if (!success) {

--- a/imagemagickwrapper.c
+++ b/imagemagickwrapper.c
@@ -96,7 +96,7 @@ cImage cImageMagickWrapper::CreateImageCopy() {
     cImage image(cSize(w, h));
     tColor col {0};
 #ifndef IMAGEMAGICK7
-    const PixelPacket *pixels = buffer.getConstPixels(0, 0, w, h);
+    const Magick::PixelPacket *pixels = buffer.getConstPixels(0, 0, w, h);
 #else
     unsigned char r {}, g {}, b {}, o {};  // Initialise outside of for loop
 #endif

--- a/imagemagickwrapper.c
+++ b/imagemagickwrapper.c
@@ -41,7 +41,7 @@ cImage *cImageMagickWrapper::CreateImage(int width, int height, bool PreserveAsp
             height = h * width / w;
     }
 #ifndef IMAGEMAGICK7
-    const PixelPacket *pixels = buffer.getConstPixels(0, 0, w, h);
+    const Magick::PixelPacket *pixels = buffer.getConstPixels(0, 0, w, h);
 #endif
     cImage *image = new cImage(cSize(width, height));
     tColor *imgData = (tColor *)image->Data();
@@ -125,11 +125,11 @@ cImage cImageMagickWrapper::CreateImageCopy() {
 bool cImageMagickWrapper::LoadImage(const char *fullpath) {
     if ((fullpath == nullptr) || (strlen(fullpath) < 5))
         return false;
+
     try {
         buffer.read(fullpath);
-    } catch (...) {
-        return false;
-    }
+    } catch (...) { return false; }
+
     return true;
 }
 

--- a/imagescaler.c
+++ b/imagescaler.c
@@ -29,7 +29,10 @@ ImageScaler::ImageScaler() :
 }
 
 ImageScaler::~ImageScaler() {
-    if (m_memory) free(m_memory);
+    if (m_memory) {
+        free(m_memory);
+        m_memory = nullptr;
+    }
 }
 
 // sin(x)/(x)

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: vdr-skinflatplus 1.0.1\n"
+"Project-Id-Version: vdr-skinflatplus 1.1.8\n"
 "Report-Msgid-Bugs-To: <see README>\n"
 "POT-Creation-Date: 2017-05-06 16:13+0200\n"
-"PO-Revision-Date: 2024-01-27 10:09+0100\n"
+"PO-Revision-Date: 2025-02-27 10:09+0100\n"
 "Last-Translator: Martin Schirrmacher\n"
 "Language-Team: Martin Schirrmacher\n"
 "Language: de_DE\n"

--- a/skinflatplus.c
+++ b/skinflatplus.c
@@ -17,7 +17,7 @@
 #include "./setup.h"
 #include "./imageloader.h"
 
-static const char *VERSION        = "1.1.8";
+static const char *VERSION        = "1.1.9";
 static const char *DESCRIPTION    = "Skin flatPlus";
 
 class cPluginFlat : public cPlugin {

--- a/skinflatplus.c
+++ b/skinflatplus.c
@@ -32,7 +32,7 @@ class cPluginFlat : public cPlugin {
         virtual bool Start();
         virtual void Stop();
         virtual void Housekeeping();
-        virtual void MainThreadHook();
+        // virtual void MainThreadHook();  // Deprecated in VDR 2.7.4
         virtual cString Active();
         virtual time_t WakeupTime();
         virtual const char *MainMenuEntry() { return nullptr; }
@@ -113,8 +113,7 @@ void cPluginFlat::Stop() {
 void cPluginFlat::Housekeeping() {
 }
 
-void cPluginFlat::MainThreadHook() {
-}
+// void cPluginFlat::MainThreadHook() {}  // Deprecated in VDR 2.7.4
 
 cString cPluginFlat::Active() {
     return NULL;


### PR DESCRIPTION
2025-03-03: Version 1.1.9
- [fix] Fix order of timer count variables
- [fix] Fix display of channel separators in plugin epg2vdr
- [fix] Fix translation in system information widget
- [add] Show ' - ' for missing short text in recording content
- [update] Add '~' as delimiter char in cTextFloatingWrapper
- [update] Search default icon only if theme icon not in cache
- [update] Show timer icon in schedule menu only if timer is active
- [update] Some internal optimizations