### PR TITLE
Version 1.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -406,4 +406,6 @@ FodyWeavers.xsd
 
 .codegpt
 .codemate
+.sixth
+.stfolder
 AGENTS.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -91,6 +91,10 @@
     "C_Cpp.vcFormat.space.beforeInitializerListOpenBrace": true,
     "javascript.inlayHints.enumMemberValues.enabled": true,
     "C_Cpp.default.defines": [
-        "PLUGIN_NAME_I18N=skinflatplus"
+        "PLUGIN_NAME_I18N=skinflatplus",
+        "USE_ZAPCOCKPIT=1"
+    ],
+    "editor.dropIntoEditor.preferences": [
+
     ]
 }

--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,8 @@
 VDR Plugin 'skin flatPlus' Revision History
 -------------------------------------------
+2026-XX-XX: Version 1.2.11
+- [update] Add spacing before percent and degree symbols
+
 2026-03-31: Version 1.2.10
 - [fix] Refactor image processing and fix opacity handling. This is a try to fix mld issues
 
@@ -161,7 +164,7 @@ VDR Plugin 'skin flatPlus' Revision History
 2025-01-14: Version 1.1.6
 - [fix] Fix display of weather location in main menu
 - [fix] Fix display of plugin icons in main menu
-- [update] Show usage also if disk is 100%full
+- [update] Show usage also if disk is 100 % full
 - [update] Some internal optimizations
 
 2025-01-07: Version 1.1.5
@@ -256,7 +259,7 @@ VDR Plugin 'skin flatPlus' Revision History
         The script can be found in 'contrib/'
 - [add] Some new fonts added in 'contrib/Fonts'
 - [update] If available use 'HairSpace' for justifying text for best result
-- [update] Only justify lines with minimum of 80% width
+- [update] Only justify lines with minimum of 80 % width
 - [update] Some internal optimizations
 
 2024-02-27: Version 1.0.2
@@ -330,7 +333,7 @@ VDR Plugin 'skin flatPlus' Revision History
 2023-11-08: Version 0.8.0
 - [fix] Better display of channel icons (Resolution, ...)
 - [add] Option to show short text without date in playback
-- [update] Tweak toLowerCase(). Preloading time of images reduced by ~15%
+- [update] Tweak toLowerCase(). Preloading time of images reduced by ~15 %
             Before: Image cache pre load images time: 425 ms
             After: Image cache pre load images time: 361 ms
 - [update] Some internal optimizations

--- a/HISTORY
+++ b/HISTORY
@@ -2,6 +2,8 @@ VDR Plugin 'skin flatPlus' Revision History
 -------------------------------------------
 2026-XX-XX: Version 1.2.11
 - [update] Add spacing before percent and degree symbols
+- [update] Improve image cache by replacing linear search with hash-based lookup
+- [update] Clarify disk usage time units by adding 'h' to hour values in top bar
 
 2026-03-31: Version 1.2.10
 - [fix] Refactor image processing and fix opacity handling. This is a try to fix mld issues

--- a/HISTORY
+++ b/HISTORY
@@ -4,7 +4,10 @@ VDR Plugin 'skin flatPlus' Revision History
 - [update] Add spacing before percent and degree symbols
 - [update] Improve image cache by replacing linear search with hash-based lookup
 - [update] Clarify disk usage time units by adding 'h' to hour values in top bar
-- [update] Replace hyphens with en dashes in time range formatting
+- [update] Replace hyphens (U+002D) with en dashes (U+2013) in time range formatting
+- [update] Add prerequisite tool validation before execution in 'update_weather.sh'
+- [update] Optimice ReadAndExtractData() for faster access
+- [update] Some internal optimizations
 
 2026-03-31: Version 1.2.10
 - [fix] Refactor image processing and fix opacity handling. This is a try to fix mld issues

--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,6 @@
 VDR Plugin 'skin flatPlus' Revision History
 -------------------------------------------
-2026-XX-XX: Version 1.3.0
+2026-07-23: Version 1.3.0
 - [add] Zapcockpit support (extended channel display) like in skindesigner:
         channellist, grouplist with separate group channel list, channel hints
         while entering a channel number and detailed EPG info (2nd 'Ok').

--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,26 @@
 VDR Plugin 'skin flatPlus' Revision History
 -------------------------------------------
-2026-XX-XX: Version 1.2.11
+2026-XX-XX: Version 1.3.0
+- [add] Zapcockpit support (extended channel display) like in skindesigner:
+        channellist, grouplist with separate group channel list, channel hints
+        while entering a channel number and detailed EPG info (2nd 'Ok').
+        Requires a VDR patched with the zapcockpit patch (USE_ZAPCOCKPIT in
+        vdr/skins.h) and 'Zapcockpit: enabled' in the VDR miscellaneous setup.
+        The lists slide in from the side of the pressed key (key 'left'
+        opens its list at the right edge) and while a list is shown all
+        other OSD elements (top bar, channel info) are hidden.
+        The channellist items show the channel logo and three text lines:
+        Remaining time, title of the running event and the following event.
+        The lists use the full OSD height; too long texts are cut off and
+        end with '...' like in skindesigner. The channel logos in the lists
+        are drawn on the 'logo_background' image like in the channel info
+        display at the bottom (alpha blended in software, so semi transparent
+        images do not punch through to the live picture).
+        Builds unchanged against an unpatched VDR.
+        New setup options: 'Zapcockpit: Key right opens channellist',
+        relative list width, relative list font size, list fade-in time and
+        list shift-in time (ms, 0 = off) for animated showing of the lists.
+        Thanks to heifisch @ VDR-Portal
 - [update] Add spacing before percent and degree symbols
 - [update] Improve image cache by replacing linear search with hash-based lookup
 - [update] Clarify disk usage time units by adding 'h' to hour values in top bar

--- a/HISTORY
+++ b/HISTORY
@@ -4,6 +4,7 @@ VDR Plugin 'skin flatPlus' Revision History
 - [update] Add spacing before percent and degree symbols
 - [update] Improve image cache by replacing linear search with hash-based lookup
 - [update] Clarify disk usage time units by adding 'h' to hour values in top bar
+- [update] Replace hyphens with en dashes in time range formatting
 
 2026-03-31: Version 1.2.10
 - [fix] Refactor image processing and fix opacity handling. This is a try to fix mld issues

--- a/MV_Themes.HISTORY
+++ b/MV_Themes.HISTORY
@@ -6,7 +6,7 @@ HISTORY
  [...] Erste Version
  [18.11.2013] - Themen ueberarbeitet. Farben angepasst und .decor erstellt
  [24.11.2013] - Widergabestatus: Symbole passend zu den Themen eingefaerbt
-              - Formatsymbole: von 100% Weiss nach 95%
+              - Formatsymbole: von 100 % Weiss nach 95 %
  [25.11.2013] - Wiedergabe-Info: Eigenes Symbol (extraIcons/playing.png)
  [26.11.2013] - Wiedergabe-Info: Symbolname korrigiert (extraIcons/Playing.png)
               - Themen "Blood" und "Rauchglas" nur noch mit geaendertem Hintergrund
@@ -43,7 +43,7 @@ HISTORY
               - 'timer_full.png' verkleinert, 'timer_partial.png' geaendert
  [10.03.2014] - ExtraTextFont in Themenfarbe
               - ExtraTextCurrentFont in Hintergrundfarbe
- [11.03.2014] - 'logo_background.png' fuer Kanallogos mit 30% Deckkraft und in #FFFFFF
+ [11.03.2014] - 'logo_background.png' fuer Kanallogos mit 30 % Deckkraft und in #FFFFFF
  [12.03.2014] - 'logo_background.png' mit runden Ecken und leichtem Verlauf
               - 'vps.png' Schrift vergroessert
  [14.03.2014] - Verlinkung von Themenuebergreifenden Symbolen mit symbolischen Links
@@ -112,7 +112,7 @@ HISTORY
               - Hinweis auf Schriften geaendert
  [09.12.2014] - Diskanzeige - Symbole neu verlinkt (16 statt 8 Abschnitte)
  [08.02.2015] - Symbole fuer "Aufnahme gesehen" ab VDR 2.1.8 in Skinfarbe
- [10.02.2015] - Symbol fuer "Aufnahme komplett (100%) gesehen" hinzugefuegt
+ [10.02.2015] - Symbol fuer "Aufnahme komplett (100 %) gesehen" hinzugefuegt
  [25.04.2015] - Diskanzeige - Symbole neu verlinkt (32 statt 16 Abschnitte)
  [26.04.2015] - Symbol 'timerInactive_cur.png' in Skinfarbe (HG)
  [01.05.2015] - Symbole 'radio_cur.png', 'tv_cur.png' und 'recording_cur.png'

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Die Widgets werden auf der rechten Seite des Hauptmenüs angezeigt. In der Höhe
 ** DVB Geräte
 
 Zeigt die DVB Geräte an, wer dieses benutzt und auf welchem Kanel das Gerät gerade ist. Über die Plugineinstellungen kann konfiguriert werden ob "unbekannte" und/oder "nicht benutzte" Geräte ausgeblendet werden sollen. Die Nummerierung der Geräte kann entweder wie VDR-Intern mit 0 beginnen oder wahlweise mit 1.
-Leider ist es derzeit nicht möglich 100% herauszufinden wer das Gerät derzeit nutzt. Z.B. gibt es Fälle wie den EPG-Scan welcher nicht erkannt wird.
+Leider ist es derzeit nicht möglich 100 % herauszufinden wer das Gerät derzeit nutzt. Z.B. gibt es Fälle wie den EPG-Scan welcher nicht erkannt wird.
 
 ** Aktive Timer
 

--- a/baserender.c
+++ b/baserender.c
@@ -65,7 +65,7 @@ cFlatBaseRender::cFlatBaseRender() {
         m_FontTempSmlHeight = FontCache.GetFontHeight(Setup.FontOsd, Setup.FontOsdSize / 2);
     }
     if (Config.TVScraperEPGInfoShowActors || Config.TVScraperRecInfoShowActors) {
-        m_FontTiny = FontCache.GetFont(Setup.FontSml, Setup.FontSmlSize * 0.8);  // 80% of small font size
+        m_FontTiny = FontCache.GetFont(Setup.FontSml, Setup.FontSmlSize * 0.8);  // 80 % of small font size
         m_FontTinyHeight = FontCache.GetFontHeight(Setup.FontSml, Setup.FontSmlSize * 0.8);
     }
     m_FontBigHeight = FontCache.GetFontHeight(Setup.FontOsd, Setup.FontOsdSize * Config.ChannelNameFontSize * 100.0);
@@ -272,19 +272,19 @@ void cFlatBaseRender::TopBarEnableDiskUsage() {
         if (Config.DiskUsageFree == 1) {  // Show in free mode
             const div_t FreeHM {std::div(FreeMinutes, 60)};
             if (Config.DiskUsageShort == false) {  // Long format
-                Extra1 = cString::sprintf("%s: ~ 0%% %s", tr("Disk"), tr("free"));
+                Extra1 = cString::sprintf("%s: ~ 0 %% %s", tr("Disk"), tr("free"));
                 Extra2 = cString::sprintf("%.2f GB ≈ %02d:%02d", FreeGB, FreeHM.quot, FreeHM.rem);
             } else {  // Short format
-                Extra1 = cString::sprintf("~ 0%% %s", tr("free"));
+                Extra1 = cString::sprintf("~ 0 %% %s", tr("free"));
                 Extra2 = cString::sprintf("≈ %02d:%02d", FreeHM.quot, FreeHM.rem);
             }
             IconName = "chart31b";
         } else {                                   // Show in occupied mode
             if (Config.DiskUsageShort == false) {  // Long format
-                Extra1 = cString::sprintf("%s: ~ 100%% %s", tr("Disk"), tr("occupied"));
+                Extra1 = cString::sprintf("%s: ~ 100 %% %s", tr("Disk"), tr("occupied"));
                 Extra2 = "? GB ≈ ??:??";  //* Can not be calculated if disk is full (DIV/0)
             } else {                      // Short format
-                Extra1 = cString::sprintf("~ 100%% %s", tr("occupied"));
+                Extra1 = cString::sprintf("~ 100 %% %s", tr("occupied"));
                 Extra2 = "≈ ??:??";
             }
             IconName = "chart32";
@@ -308,14 +308,14 @@ void cFlatBaseRender::TopBarEnableDiskUsage() {
         dsyslog("   FreeMinutes/60 %d, FreeMinutes%%60 %d", FreeHM.quot, FreeHM.rem);
 #endif
         if (Config.DiskUsageShort == false) {  // Long format
-            Extra1 = cString::sprintf("%s: %d%% %s", tr("Disk"), DiskFreePercent, tr("free"));
+            Extra1 = cString::sprintf("%s: %d %% %s", tr("Disk"), DiskFreePercent, tr("free"));
             if (FreeGB < 1000.0) {  // Less than 1000 GB
                 Extra2 = cString::sprintf("%.1f GB ≈ %02d:%02d", FreeGB, FreeHM.quot, FreeHM.rem);
             } else {  // 1000 GB+
                 Extra2 = cString::sprintf("%.2f TB ≈ %02d:%02d", FreeGB * (1.0 / 1024.0), FreeHM.quot, FreeHM.rem);
             }
         } else {  // Short format
-            Extra1 = cString::sprintf("%d%% %s", DiskFreePercent, tr("free"));
+            Extra1 = cString::sprintf("%d %% %s", DiskFreePercent, tr("free"));
             Extra2 = cString::sprintf("≈ %02d:%02d", FreeHM.quot, FreeHM.rem);
         }
 
@@ -337,7 +337,7 @@ void cFlatBaseRender::TopBarEnableDiskUsage() {
         if (Config.DiskUsageFree == 2) {  //* Special mixed mode free time instead of used
             const div_t FreeHM {std::div(FreeMinutes, 60)};
             if (Config.DiskUsageShort == false) {  // Long format
-                Extra1 = cString::sprintf("%s: %d%% %s", tr("Disk"), DiskUsagePercent, tr("occupied"));
+                Extra1 = cString::sprintf("%s: %d %% %s", tr("Disk"), DiskUsagePercent, tr("occupied"));
                 if (OccupiedGB < 1000.0) {  // Less than 1000 GB
                     Extra2 = cString::sprintf("%.1f GB | %02d:%02d", OccupiedGB, FreeHM.quot, FreeHM.rem);
                 } else {  // 1000 GB+
@@ -345,13 +345,13 @@ void cFlatBaseRender::TopBarEnableDiskUsage() {
                         cString::sprintf("%.2f TB | %02d:%02d", OccupiedGB * (1.0 / 1024.0), FreeHM.quot, FreeHM.rem);
                 }
             } else {  // Short format
-                Extra1 = cString::sprintf("%d%% %s", DiskUsagePercent, tr("occupied"));
+                Extra1 = cString::sprintf("%d %% %s", DiskUsagePercent, tr("occupied"));
                 Extra2 = cString::sprintf("≈ %02d:%02d", FreeHM.quot, FreeHM.rem);
             }
         } else {  // Show in occupied mode
             const div_t OccupiedHM {std::div(OccupiedMinutes, 60)};
             if (Config.DiskUsageShort == false) {  // Long format
-                Extra1 = cString::sprintf("%s: %d%% %s", tr("Disk"), DiskUsagePercent, tr("occupied"));
+                Extra1 = cString::sprintf("%s: %d %% %s", tr("Disk"), DiskUsagePercent, tr("occupied"));
                 if (OccupiedGB < 1000.0) {  // Less than 1000 GB
                     Extra2 = cString::sprintf("%.1f GB ≈ %02d:%02d", OccupiedGB, OccupiedHM.quot, OccupiedHM.rem);
                 } else {  // 1000 GB+
@@ -359,7 +359,7 @@ void cFlatBaseRender::TopBarEnableDiskUsage() {
                                               OccupiedHM.rem);
                 }
             } else {  // Short format
-                Extra1 = cString::sprintf("%d%% %s", DiskUsagePercent, tr("occupied"));
+                Extra1 = cString::sprintf("%d %% %s", DiskUsagePercent, tr("occupied"));
                 Extra2 = cString::sprintf("≈ %02d:%02d", OccupiedHM.quot, OccupiedHM.rem);
             }
         }
@@ -1050,7 +1050,7 @@ void cFlatBaseRender::ProgressBarDrawMarks(int Current, int Total, const cMarks 
     // large collections of marks.
     const double PosScaleFactor {static_cast<double>(m_ProgressBarWidth) / Total};
     const int PosCurrent {static_cast<int>(Current * PosScaleFactor)};  // Not needed to calculate for every mark
-    const int sml {std::max(m_ProgressBarHeight / 10 * 2, 4)};  // 20% of progressbar height with an minimum of 4 pixel
+    const int sml {std::max(m_ProgressBarHeight / 10 * 2, 4)};  // 20 % of progressbar height with an minimum of 4 pixel
     if (!Marks || !Marks->First()) {
         // m_ProgressBarColorFg = m_ProgressBarColorBarFg; m_ProgressBarColorFg = m_ProgressBarColorBarCurFg;
         m_ProgressBarColorBarFg = m_ProgressBarColorBarCurFg;
@@ -1808,13 +1808,13 @@ bool cFlatBaseRender::BatchReadWeatherData(FontImageWeatherCache &out, time_t &o
             istr.clear();  // Clear the error state of the stream
             double p {0.0};
             if (istr >> p) {  // Check if parsing succeeded
-                out.Days[day].Precipitation = cString::sprintf("%d%%", RoundUp(p * 100.0, 10));
+                out.Days[day].Precipitation = cString::sprintf("%d %%", RoundUp(p * 100.0, 10));
             } else {
                 dsyslog("flatPlus: BatchReadWeatherData() Failed to parse precipitation value: %s", *precipitation);
-                out.Days[day].Precipitation = "-%";  // Default fallback
+                out.Days[day].Precipitation = "- %";  // Default fallback
             }
         } else {
-            out.Days[day].Precipitation = "-%";  // Default fallback
+            out.Days[day].Precipitation = "- %";  // Default fallback
         }
 
         out.Days[day].Summary = ReadAndExtractData(summaryFile);

--- a/baserender.c
+++ b/baserender.c
@@ -1560,13 +1560,19 @@ tColor cFlatBaseRender::Multiply(tColor Color, uint8_t Alpha) {
   return AG | RB;
 } */
 
+/**
+ * Set the alpha channel of a color.
+ *
+ * @param Color The color to be modified
+ * @param am The alpha multiplier (0.0-1.0)
+ * @return The modified color
+ */
 tColor cFlatBaseRender::SetAlpha(tColor Color, double am) {
-    uint8_t A = (Color & 0xFF000000) >> 24;
-    uint8_t R = (Color & 0x00FF0000) >> 16;
-    uint8_t G = (Color & 0x0000FF00) >> 8;
-    uint8_t B = (Color & 0x000000FF);
+    const uint8_t A = ((Color & 0xFF000000) >> 24) * am;  // Extract alpha and apply multiplier
+    const uint8_t R = (Color & 0x00FF0000) >> 16;
+    const uint8_t G = (Color & 0x0000FF00) >> 8;
+    const uint8_t B = (Color & 0x000000FF);
 
-    A = static_cast<uint8_t>(A * am);  // Explicitly cast the result to uint8_t
     return ArgbToColor(A, R, G, B);
 }
 

--- a/baserender.c
+++ b/baserender.c
@@ -48,8 +48,8 @@ cFlatBaseRender::cFlatBaseRender() {
     m_FontSml = FontCache.GetFont(Setup.FontSml, Setup.FontSmlSize);
     m_FontFixed = FontCache.GetFont(Setup.FontFix, Setup.FontFixSize);
 
-    m_FontName = Setup.FontOsd;     // VDR font size
-    m_FontSmlName = Setup.FontSml;  // VDR font small size
+    m_FontName = Setup.FontOsd;     // VDR font name
+    m_FontSmlName = Setup.FontSml;  // VDR font small name
 
     m_FontHeight = FontCache.GetFontHeight(Setup.FontOsd, Setup.FontOsdSize);
     m_FontHeight2 = m_FontHeight * 2;
@@ -118,10 +118,7 @@ void cFlatBaseRender::CreateOsd(int Left, int Top, int Width, int Height) {
     dsyslog("flatPlus: cFlatBaseRender::CreateOsd() left: %d, top: %d, size: %dx%d", Left, Top, Width, Height);
 #endif
 
-    // Set Margins only when the OSD size has changed
-    if (m_OsdWidth != Width || m_OsdHeight != Height) {
-        SetMargins(Width, Height);  // Set margins relative to the OSD size
-    }
+    SetMargins(Width, Height);  // Set margins relative to the OSD size
 
     m_OsdLeft = Left;
     m_OsdTop = Top;
@@ -393,20 +390,19 @@ void cFlatBaseRender::TopBarUpdate() {
         m_TopBarLastDate = now;
         if (!TopBarPixmap || !TopBarIconPixmap || !TopBarIconBgPixmap) return;
 
-        const int TopBarWidth {m_OsdWidth - Config.decorBorderTopBarSize * 2};
-        int MenuIconWidth {0};
+        PixmapFill(TopBarPixmap, Theme.Color(clrTopBarBg));
+        PixmapClear(TopBarIconPixmap);
+        PixmapClear(TopBarIconBgPixmap);
 
         const int FontTop {(m_TopBarHeight - m_TopBarFontHeight) / 2};
         const int FontSmlTop {(m_TopBarHeight - m_TopBarFontSmlHeight * 2) / 2};
         const int FontClockTop {(m_TopBarHeight - m_TopBarFontClockHeight) / 2};
 
-        PixmapFill(TopBarPixmap, Theme.Color(clrTopBarBg));
-        PixmapClear(TopBarIconPixmap);
-        PixmapClear(TopBarIconBgPixmap);
-
+        const int TopBarWidth {m_OsdWidth - Config.decorBorderTopBarSize * 2};
         const int TopBarLogoHeight {m_TopBarHeight - m_MarginItem2};      // Height of TopBar
         const int TopBarIconHeight {m_TopBarFontHeight - m_MarginItem2};  // Height of font in TopBar
 
+        int MenuIconWidth {0};
         cImage *img {nullptr};
         if (Config.TopBarMenuIconShow) {
             int IconLeft {m_MarginItem};

--- a/baserender.c
+++ b/baserender.c
@@ -1725,15 +1725,25 @@ void cFlatBaseRender::DecorDrawGlowEllipseBR(cPixmap *pixmap, int Left, int Top,
 cString cFlatBaseRender::ReadAndExtractData(const cString &FilePath) const {
     if (isempty(*FilePath)) return "";
 
-    FILE *f {fopen(*FilePath, "r")};
-    if (f == nullptr) return "";  // File doesn't exist
+    // Faster first-line read:
+    // - Avoids stdio FILE*/cReadLine overhead
+    // - Reads only a small chunk and stops at '\n'
+    const int fd {open(*FilePath, O_RDONLY)};
+    if (fd < 0) return "";
 
-    // Read the first line
-    cReadLine ReadLine;
-    const char *s {ReadLine.Read(f)};  // ReadLine will read from the file pointer
-    fclose(f);
+    char buf[256];
+    const ssize_t n {read(fd, buf, sizeof(buf) - 1)};
+    close(fd);
+    if (n <= 0) return "";
 
-    return cString(s);
+    buf[n] = '\0';  // Ensure null-termination
+
+    // Cut at line endings
+    char *end {buf};
+    while (*end && *end != '\n' && *end != '\r') ++end;
+    *end = '\0';
+
+    return cString(buf);
 }
 
 // --- Disk read batching and stat cache for weather widget and main menu widget

--- a/baserender.c
+++ b/baserender.c
@@ -135,16 +135,17 @@ void cFlatBaseRender::CreateOsd(int Left, int Top, int Width, int Height) {
 void cFlatBaseRender::SetMargins(int Width, int Height) {
     // Set margins relative to the OSD size with an minimum of 3 pixels
     static constexpr int kMinSize {3};  // Minimum margin size
-    int SizeIncrease {static_cast<int>((Width / 720) + 0.5)};  // (1920: 3 pixels, 3840: 5 pixels, 7680: 11 pixels)
-    // Example: 720 pixels OSD width -> 4 pixels margin, 1920 -> 6 pixels, 3840 -> 8 pixels, 7680 -> 14 pixels
+      // (1920: +3 pixels, 3840: +5 pixels, 7680: +11 pixels)
+    int SizeIncrease {static_cast<int>((Width * (1.0 / 720.0)) + 0.5)};
     m_MarginItem = kMinSize + SizeIncrease;
     m_MarginItem2 = m_MarginItem * 2;
     m_MarginItem3 = m_MarginItem * 3;
     m_MarginItem10 = m_MarginItem * 10;
     // Margin for EPG image in EPG info and recording info
-    m_MarginEPGImage += SizeIncrease;  // (1920: +3 pixels, 3840: +5 pixels, 7680: +11 pixels)
-    // Example: 576 pixels OSD hight -> 4 pixels line width, 1080 -> 5 pixels, 2160 -> 7 pixels, 4320 -> 11 pixels
-    SizeIncrease = static_cast<int>((Height / 576) + 0.5);  // (1080: 2 pixels, 2160: 4 pixels, 4320: 8 pixels)
+    m_MarginEPGImage += SizeIncrease;
+
+    // (1080: +2 pixels, 2160: +4 pixels, 4320: +8 pixels)
+    SizeIncrease = static_cast<int>((Height * (1.0 / 576.0)) + 0.5);
     m_LineWidth = kMinSize + SizeIncrease;  // Increase line width for larger OSD heights
     m_LineMargin = m_LineWidth * 2;
     // Margin for color buttons and messages
@@ -637,9 +638,6 @@ void cFlatBaseRender::ButtonsSet(const char *Red, const char *Green, const char 
 
     if (!ButtonsPixmap) return;
 
-    const int WidthMargin {m_ButtonsWidth - m_MarginItem3};
-    int ButtonWidth {WidthMargin / 4 - Config.decorBorderButtonSize * 2};
-
     PixmapClear(ButtonsPixmap);
     DecorBorderClearByFrom(BorderButton);
 
@@ -649,8 +647,8 @@ void cFlatBaseRender::ButtonsSet(const char *Red, const char *Green, const char 
     const tColor ButtonColor[] {clrButtonRed, clrButtonGreen, clrButtonYellow, clrButtonBlue};  // ButtonColor
     const int ColorKey[] {Setup.ColorKey0, Setup.ColorKey1, Setup.ColorKey2, Setup.ColorKey3};  // ColorKey
 
+    int ButtonWidth {(m_ButtonsWidth - m_MarginItem3) / 4 - Config.decorBorderButtonSize * 2};
     int x {0};
-
     for (int i {0}; i < 4; i++) {  // Four buttons
         // If there is enough space for the last button, add its width to the
         // right edge of the buttons area. This is done to align the last button
@@ -885,7 +883,6 @@ void cFlatBaseRender::ProgressBarDrawRaw(cPixmap *Pixmap, cPixmap *PixmapBg, con
     case 0:  // Small line + big line
         {
             const int sml {std::max(big / 10 * 2, 2)};
-
             Pixmap->DrawRectangle(cRect(rect.Left(), rect.Top() + Middle - (sml / 2), rect.Width(), sml), ColorFg);
 
             if (Current > 0) Pixmap->DrawRectangle(cRect(rect.Left(), rect.Top(), PercentPos, big), ColorBarFg);
@@ -1073,10 +1070,10 @@ void cFlatBaseRender::ProgressBarDrawMarks(int Current, int Total, const cMarks 
         }
 
         // Draw last mark vertical line
-        if (PosCurrent == PosMark)
-            ProgressBarMarkerPixmap->DrawRectangle(cRect(PosMark - sml, 0, sml * 2, m_ProgressBarHeight), ColorCurrent);
-        else
-            ProgressBarMarkerPixmap->DrawRectangle(cRect(PosMark - SmlHalf, 0, sml, m_ProgressBarHeight), Color);
+        (PosCurrent == PosMark)
+            ? ProgressBarMarkerPixmap->DrawRectangle(cRect(PosMark - sml, 0, sml * 2, m_ProgressBarHeight),
+                                                     ColorCurrent)
+            : ProgressBarMarkerPixmap->DrawRectangle(cRect(PosMark - SmlHalf, 0, sml, m_ProgressBarHeight), Color);
 
         const int big {m_ProgressBarHeight - (sml * 2) - 2};  // Position marker size
         const int BigHalf {big / 2};
@@ -1122,12 +1119,11 @@ void cFlatBaseRender::ProgressBarDrawMark(int PosMark, int PosMarkLast, int PosC
 
     const int sml {std::max(m_ProgressBarHeight / 10 * 2, 4)};
     // Mark vertical line
-    if (PosCurrent == PosMark)
-        ProgressBarMarkerPixmap->DrawRectangle(cRect(PosMark - sml, 0, sml * 2, m_ProgressBarHeight),
-                                               m_ProgressBarColorMarkCurrent);
-    else
-        ProgressBarMarkerPixmap->DrawRectangle(cRect(PosMark - (sml / 2), 0, sml, m_ProgressBarHeight),
-                                               m_ProgressBarColorMark);
+    (PosCurrent == PosMark)
+        ? ProgressBarMarkerPixmap->DrawRectangle(cRect(PosMark - sml, 0, sml * 2, m_ProgressBarHeight),
+                                                 m_ProgressBarColorMarkCurrent)
+        : ProgressBarMarkerPixmap->DrawRectangle(cRect(PosMark - (sml / 2), 0, sml, m_ProgressBarHeight),
+                                                 m_ProgressBarColorMark);
 
     const int top {m_ProgressBarHeight / 2};
     const int big {m_ProgressBarHeight - (sml * 2) - 2};
@@ -1145,11 +1141,8 @@ void cFlatBaseRender::ProgressBarDrawMark(int PosMark, int PosMarkLast, int PosC
                                                  m_ProgressBarColorBarCurFg);
         }
         // Mark top
-        if (IsCurrent)
-            ProgressBarMarkerPixmap->DrawRectangle(cRect(PosMark - (mbig / 2), 0, mbig, sml),
-                                                   m_ProgressBarColorMarkCurrent);
-        else
-            ProgressBarMarkerPixmap->DrawRectangle(cRect(PosMark - (mbig / 2), 0, mbig, sml), m_ProgressBarColorMark);
+        ProgressBarMarkerPixmap->DrawRectangle(cRect(PosMark - (mbig / 2), 0, mbig, sml),
+                                               (IsCurrent) ? m_ProgressBarColorMarkCurrent : m_ProgressBarColorMark);
     } else {
         // Big line
         if (PosCurrent > PosMark) {
@@ -1170,12 +1163,8 @@ void cFlatBaseRender::ProgressBarDrawMark(int PosMark, int PosMarkLast, int PosC
             }
         }
         // Mark bottom
-        if (IsCurrent)
-            ProgressBarMarkerPixmap->DrawRectangle(cRect(PosMark - (mbig / 2), m_ProgressBarHeight - sml, mbig, sml),
-                                                   m_ProgressBarColorMarkCurrent);
-        else
-            ProgressBarMarkerPixmap->DrawRectangle(cRect(PosMark - (mbig / 2), m_ProgressBarHeight - sml, mbig, sml),
-                                                   m_ProgressBarColorMark);
+        ProgressBarMarkerPixmap->DrawRectangle(cRect(PosMark - (mbig / 2), m_ProgressBarHeight - sml, mbig, sml),
+                                               (IsCurrent) ? m_ProgressBarColorMarkCurrent : m_ProgressBarColorMark);
     }
 
     if (PosCurrent == PosMarkLast && PosMarkLast != 0)

--- a/baserender.c
+++ b/baserender.c
@@ -328,7 +328,7 @@ void cFlatBaseRender::TopBarEnableDiskUsage() {
     } else {  // Show in occupied mode
         const double OccupiedGB {AllGB - FreeGB};
         const double AllMinutes {static_cast<double>(FreeMinutes) * GBScale};  // All disk space in minutes
-        const int OccupiedMinutes = AllMinutes - FreeMinutes;  // Narrowing conversion
+        const int OccupiedMinutes {static_cast<int>(AllMinutes) - FreeMinutes};  // Occupied disk space in minutes
 #ifdef DEBUGFUNCSCALL
         dsyslog("   DiskUsagePercent %d, OccupiedMinutes %d", DiskUsagePercent, OccupiedMinutes);
         dsyslog("   OccupiedGB %.2f, AllGB %.2f, OccupiedMinutes %d", OccupiedGB, AllGB, OccupiedMinutes);
@@ -408,7 +408,8 @@ void cFlatBaseRender::TopBarUpdate() {
             int IconTop {0};
             if (m_TopBarMenuLogoSet) {  // Show menu channel logo
                 int ImageBGHeight {TopBarLogoHeight};
-                int ImageBGWidth = ImageBGHeight * 1.34f;  // Narrowing conversion
+                // 4:3 logo format (1.33) + some margin (0.01) for better look
+                int ImageBGWidth {static_cast<int>(ImageBGHeight * 1.34f)};
 
                 img = ImgLoader.GetLogoBg(ImageBGWidth, ImageBGHeight);  // Load 'logo_background'
                 if (img) {

--- a/baserender.c
+++ b/baserender.c
@@ -151,9 +151,10 @@ void cFlatBaseRender::SetMargins(int Width, int Height) {
     m_MarginButtonColor += SizeIncrease;  // Increase margin for larger OSD heights
     m_ButtonColorHeight += SizeIncrease;  // Increase color height for larger OSD heights
     // Size for error marks
-    m_MarkerWidth = (Width > 720) ? 2 : 1;  // One pixel for sd and two for hd
-    m_MarkerHorWidth = (Width > 720) ? 6 : 3;
-    m_MarkerHorOffset = (Width > 720) ? 2 : 1;
+    const bool IsHD {Width > 720};      // Determine if the OSD is HD based on its width
+    m_MarkerWidth = (IsHD) ? 2 : 1;     // One pixel for sd and two for hd
+    m_MarkerHorWidth = (IsHD) ? 6 : 3;
+    m_MarkerHorOffset = m_MarkerWidth;  // Horizontal marker offset
 #ifdef DEBUGFUNCSCALL
     dsyslog("flatPlus: cFlatBaseRender::SetMargins() Osd: %dx%d, m_MarginItem: %d, m_LineWidth: %d (Margin "
             "%d), m_ButtonColorHeight: %d (Margin %d), m_MarginEPGImage: %d",

--- a/baserender.c
+++ b/baserender.c
@@ -34,7 +34,7 @@
 #include "./fontcache.h"
 
 // Global flag to indicate if logo was found in channel logo path
-bool g_LogoBgOverwrite = false;
+bool g_LogoBgOverwrite {false};
 
 cRecCountThread RecCountThread;
 
@@ -72,7 +72,7 @@ cFlatBaseRender::cFlatBaseRender() {
     m_FontMediumHeight = FontCache.GetFontHeight(Setup.FontOsd, (Setup.FontOsdSize + Setup.FontSmlSize) / 2);
 
     // Top bar fonts
-    const int fs = cOsd::OsdHeight() * Config.TopBarFontSize + 0.5;
+    const int fs {static_cast<int>(cOsd::OsdHeight() * Config.TopBarFontSize + 0.5)};
     m_TopBarFont = FontCache.GetFont(Setup.FontOsd, fs);
     m_TopBarFontClock = FontCache.GetFont(Setup.FontOsd, fs * Config.TopBarFontClockScale * 100.0);
     m_TopBarFontSml = FontCache.GetFont(Setup.FontOsd, fs / 2);
@@ -713,7 +713,7 @@ void cFlatBaseRender::MessageSet(eMessageType Type, const char *Text) {
     static const struct {
         tColor color;
         const char *icon;
-    } MessageSettings[] = {
+    } MessageSettings[] {
         {Theme.Color(clrMessageStatus), "message_status"},    // mtStatus = 0
         {Theme.Color(clrMessageInfo), "message_info"},        // mtInfo
         {Theme.Color(clrMessageWarning), "message_warning"},  // mtWarning
@@ -722,7 +722,7 @@ void cFlatBaseRender::MessageSet(eMessageType Type, const char *Text) {
 
     const int TypeIndex {static_cast<int>(Type)};
     const tColor Col {MessageSettings[TypeIndex].color};
-    const cString Icon = MessageSettings[TypeIndex].icon;
+    const cString Icon {MessageSettings[TypeIndex].icon};
 
     PixmapFill(MessagePixmap, Theme.Color(clrMessageBg));
     MessageScroller.Clear();
@@ -1198,8 +1198,8 @@ void cFlatBaseRender::ProgressBarDrawError(int Pos, int SmallLine, tColor Color,
         // Small types (1, 3, 5) are smaller and centered on the middle line,
         // while big types (2, 4, 6) are bigger and start at the top of the progress bar
         const bool SmallType {Type == 1 || Type == 3 || Type == 5};
-        const int Top = Middle - (SmallLine * (SmallType ? 0.5 : 0.75));
-        const int Height = SmallLine * (SmallType ? 1 : 1.5);
+        const int Top {Middle - static_cast<int>(SmallLine * (SmallType ? 0.5 : 0.75))};
+        const int Height {static_cast<int>(SmallLine * (SmallType ? 1 : 1.5))};
         // Draw the '|'
         ProgressBarPixmap->DrawRectangle(cRect(Pos, Top, m_MarkerWidth, Height), Color);
         if (Type == 3 || Type == 4) {  // Draw the two '-' for the 'I'
@@ -1725,12 +1725,12 @@ void cFlatBaseRender::DecorDrawGlowEllipseBR(cPixmap *pixmap, int Left, int Top,
 cString cFlatBaseRender::ReadAndExtractData(const cString &FilePath) const {
     if (isempty(*FilePath)) return "";
 
-    FILE *f = fopen(*FilePath, "r");
+    FILE *f {fopen(*FilePath, "r")};
     if (f == nullptr) return "";  // File doesn't exist
 
     // Read the first line
     cReadLine ReadLine;
-    const char *s = ReadLine.Read(f);  // ReadLine will read from the file pointer
+    const char *s {ReadLine.Read(f)};  // ReadLine will read from the file pointer
     fclose(f);
 
     return cString(s);
@@ -1745,7 +1745,7 @@ bool cFlatBaseRender::BatchReadWeatherData(FontImageWeatherCache &out, time_t &o
     static constexpr const char *prefix {WIDGETOUTPUTPATH "/weather/weather."};
 
     // First check if temp file exists and get its last modified time
-    static const cString tempFile = cString::sprintf("%s%s", prefix, "0.temp");
+    static const cString tempFile {cString::sprintf("%s%s", prefix, "0.temp")};
     const time_t latest {LastModifiedTime(tempFile)};  // Get the latest modification time of the temp file
     if (latest == 0) {
         dsyslog("flatPlus: BatchReadWeatherData() Failed to get latest modification time for %s", *tempFile);
@@ -1792,7 +1792,7 @@ bool cFlatBaseRender::BatchReadWeatherData(FontImageWeatherCache &out, time_t &o
                 out.TempTodaySign = "";
             }
 
-            static const cString locationFile = cString::sprintf("%s%s", prefix, "location");
+            static const cString locationFile {cString::sprintf("%s%s", prefix, "location")};
             out.Location = ReadAndExtractData(locationFile);
             if (isempty(*out.Location)) out.Location = tr("Unknown");
         }  // End of day 0 specific data reading
@@ -1887,7 +1887,7 @@ void cFlatBaseRender::DrawWidgetWeather() {  // Weather widget (repay/channel)
         WeatherCache.valid = true;
     }
 
-    const auto &wd = WeatherCache;  // Weather data reference
+    const auto &wd {WeatherCache};  // Weather data reference
 
     // Check if data is valid
     if (isempty(*wd.Temp) || isempty(*wd.Days[1].TempMax)) {
@@ -1949,7 +1949,7 @@ void cFlatBaseRender::DrawWidgetWeather() {  // Weather widget (repay/channel)
     left += wd.TempTodaySignWidth + m_MarginItem2;
 
     // Add weather icon
-    cString WeatherIcon = cString::sprintf("widgets/%s", *wd.Days[0].Icon);
+    cString WeatherIcon {cString::sprintf("widgets/%s", *wd.Days[0].Icon)};
     cImage *img {ImgLoader.GetIcon(*WeatherIcon, wd.FontHeight, WeatherFontHeightMinusMargin)};
     if (img) {
         WeatherWidget.AddImage(img, cRect(left, 0 + m_MarginItem, wd.FontHeight, wd.FontHeight));

--- a/baserender.c
+++ b/baserender.c
@@ -273,19 +273,19 @@ void cFlatBaseRender::TopBarEnableDiskUsage() {
             const div_t FreeHM {std::div(FreeMinutes, 60)};
             if (Config.DiskUsageShort == false) {  // Long format
                 Extra1 = cString::sprintf("%s: ~ 0 %% %s", tr("Disk"), tr("free"));
-                Extra2 = cString::sprintf("%.2f GB ≈ %02d:%02d", FreeGB, FreeHM.quot, FreeHM.rem);
+                Extra2 = cString::sprintf("%.2f GB ≈ %02d:%02d h", FreeGB, FreeHM.quot, FreeHM.rem);
             } else {  // Short format
                 Extra1 = cString::sprintf("~ 0 %% %s", tr("free"));
-                Extra2 = cString::sprintf("≈ %02d:%02d", FreeHM.quot, FreeHM.rem);
+                Extra2 = cString::sprintf("≈ %02d:%02d h", FreeHM.quot, FreeHM.rem);
             }
             IconName = "chart31b";
         } else {                                   // Show in occupied mode
             if (Config.DiskUsageShort == false) {  // Long format
                 Extra1 = cString::sprintf("%s: ~ 100 %% %s", tr("Disk"), tr("occupied"));
-                Extra2 = "? GB ≈ ??:??";  //* Can not be calculated if disk is full (DIV/0)
+                Extra2 = "? GB ≈ ??:?? h";  //* Can not be calculated if disk is full (DIV/0)
             } else {                      // Short format
                 Extra1 = cString::sprintf("~ 100 %% %s", tr("occupied"));
-                Extra2 = "≈ ??:??";
+                Extra2 = "≈ ??:?? h";
             }
             IconName = "chart32";
         }
@@ -310,13 +310,13 @@ void cFlatBaseRender::TopBarEnableDiskUsage() {
         if (Config.DiskUsageShort == false) {  // Long format
             Extra1 = cString::sprintf("%s: %d %% %s", tr("Disk"), DiskFreePercent, tr("free"));
             if (FreeGB < 1000.0) {  // Less than 1000 GB
-                Extra2 = cString::sprintf("%.1f GB ≈ %02d:%02d", FreeGB, FreeHM.quot, FreeHM.rem);
+                Extra2 = cString::sprintf("%.1f GB ≈ %02d:%02d h", FreeGB, FreeHM.quot, FreeHM.rem);
             } else {  // 1000 GB+
-                Extra2 = cString::sprintf("%.2f TB ≈ %02d:%02d", FreeGB * (1.0 / 1024.0), FreeHM.quot, FreeHM.rem);
+                Extra2 = cString::sprintf("%.2f TB ≈ %02d:%02d h", FreeGB * (1.0 / 1024.0), FreeHM.quot, FreeHM.rem);
             }
         } else {  // Short format
             Extra1 = cString::sprintf("%d %% %s", DiskFreePercent, tr("free"));
-            Extra2 = cString::sprintf("≈ %02d:%02d", FreeHM.quot, FreeHM.rem);
+            Extra2 = cString::sprintf("≈ %02d:%02d h", FreeHM.quot, FreeHM.rem);
         }
 
         const int IconIndex {static_cast<int>(DiskFreePercent * kChartSegmentPercent)};  // 0..31
@@ -339,28 +339,28 @@ void cFlatBaseRender::TopBarEnableDiskUsage() {
             if (Config.DiskUsageShort == false) {  // Long format
                 Extra1 = cString::sprintf("%s: %d %% %s", tr("Disk"), DiskUsagePercent, tr("occupied"));
                 if (OccupiedGB < 1000.0) {  // Less than 1000 GB
-                    Extra2 = cString::sprintf("%.1f GB | %02d:%02d", OccupiedGB, FreeHM.quot, FreeHM.rem);
+                    Extra2 = cString::sprintf("%.1f GB | %02d:%02d h", OccupiedGB, FreeHM.quot, FreeHM.rem);
                 } else {  // 1000 GB+
                     Extra2 =
-                        cString::sprintf("%.2f TB | %02d:%02d", OccupiedGB * (1.0 / 1024.0), FreeHM.quot, FreeHM.rem);
+                        cString::sprintf("%.2f TB | %02d:%02d h", OccupiedGB * (1.0 / 1024.0), FreeHM.quot, FreeHM.rem);
                 }
             } else {  // Short format
                 Extra1 = cString::sprintf("%d %% %s", DiskUsagePercent, tr("occupied"));
-                Extra2 = cString::sprintf("≈ %02d:%02d", FreeHM.quot, FreeHM.rem);
+                Extra2 = cString::sprintf("≈ %02d:%02d h", FreeHM.quot, FreeHM.rem);
             }
         } else {  // Show in occupied mode
             const div_t OccupiedHM {std::div(OccupiedMinutes, 60)};
             if (Config.DiskUsageShort == false) {  // Long format
                 Extra1 = cString::sprintf("%s: %d %% %s", tr("Disk"), DiskUsagePercent, tr("occupied"));
                 if (OccupiedGB < 1000.0) {  // Less than 1000 GB
-                    Extra2 = cString::sprintf("%.1f GB ≈ %02d:%02d", OccupiedGB, OccupiedHM.quot, OccupiedHM.rem);
+                    Extra2 = cString::sprintf("%.1f GB ≈ %02d:%02d h", OccupiedGB, OccupiedHM.quot, OccupiedHM.rem);
                 } else {  // 1000 GB+
-                    Extra2 = cString::sprintf("%.2f TB ≈ %02d:%02d", OccupiedGB * (1.0 / 1024.0), OccupiedHM.quot,
+                    Extra2 = cString::sprintf("%.2f TB ≈ %02d:%02d h", OccupiedGB * (1.0 / 1024.0), OccupiedHM.quot,
                                               OccupiedHM.rem);
                 }
             } else {  // Short format
                 Extra1 = cString::sprintf("%d %% %s", DiskUsagePercent, tr("occupied"));
-                Extra2 = cString::sprintf("≈ %02d:%02d", OccupiedHM.quot, OccupiedHM.rem);
+                Extra2 = cString::sprintf("≈ %02d:%02d h", OccupiedHM.quot, OccupiedHM.rem);
             }
         }
 

--- a/baserender.c
+++ b/baserender.c
@@ -1195,15 +1195,18 @@ void cFlatBaseRender::ProgressBarDrawError(int Pos, int SmallLine, tColor Color,
         ProgressBarMarkerPixmap->DrawRectangle(cRect(Pos - (Big / 2), Middle - (Big / 2), Big, Big), Color);
     } else {
         const int Type {Config.PlaybackShowErrorMarks};  // 1 & 2 = '|', 3 & 4 = 'I', 5 & 6 = '+'
-        const int Top = Middle - (SmallLine * ((Type == 1 || Type == 3 || Type == 5) ? 0.5 : 0.75));
-        const int Height = SmallLine * ((Type == 1 || Type == 3 || Type == 5) ? 1 : 1.5);
+        // Small types (1, 3, 5) are smaller and centered on the middle line,
+        // while big types (2, 4, 6) are bigger and start at the top of the progress bar
+        const bool SmallType {Type == 1 || Type == 3 || Type == 5};
+        const int Top = Middle - (SmallLine * (SmallType ? 0.5 : 0.75));
+        const int Height = SmallLine * (SmallType ? 1 : 1.5);
         // Draw the '|'
         ProgressBarPixmap->DrawRectangle(cRect(Pos, Top, m_MarkerWidth, Height), Color);
         if (Type == 3 || Type == 4) {  // Draw the two '-' for the 'I'
             ProgressBarPixmap->DrawRectangle(cRect(Pos - m_MarkerHorOffset, Top, m_MarkerHorWidth, m_MarkerWidth),
                                              Color);
             ProgressBarPixmap->DrawRectangle(cRect(Pos - m_MarkerHorOffset,
-                                                   Middle + (SmallLine * (Type == 3 ? 0.5 : 0.75)) - m_MarkerWidth,
+                                                   Middle + (SmallLine * (SmallType ? 0.5 : 0.75)) - m_MarkerWidth,
                                                    m_MarkerHorWidth, m_MarkerWidth),
                                              Color);
         } else if (Type == 5 || Type == 6) {  // Draw the '-' for the '+'
@@ -1228,7 +1231,7 @@ void cFlatBaseRender::ScrollbarDraw(cPixmap *Pixmap, int Left, int Top, int Heig
         const int ScrollTop {std::min(static_cast<int>(static_cast<double>(Top) + Height * Offset / Total + 0.5),
                                       Top + Height - ScrollHeight)};
 
-        static int LastTotal = -1, LastShown = -1, LastOffset = -1;
+        static int LastTotal {-1}, LastShown {-1}, LastOffset {-1};
         if (Total != LastTotal || Shown != LastShown || Offset != LastOffset) {
 #ifdef DEBUGFUNCSCALL
             dsyslog("   Clear scrollbar pixmap");
@@ -1864,7 +1867,7 @@ void cFlatBaseRender::DrawWidgetWeather() {  // Weather widget (repay/channel)
 #endif
 
     static int LastOsdHeight {0};
-    const int fs = cOsd::OsdHeight() * Config.WeatherFontSize + 0.5;
+    const int fs {static_cast<int>(cOsd::OsdHeight() * Config.WeatherFontSize + 0.5)};
 
     // Only reload/calc data/fonts if input files or screen size changed, else use prepared/cached
     time_t NewestFiletime {0};
@@ -1908,13 +1911,13 @@ void cFlatBaseRender::DrawWidgetWeather() {  // Weather widget (repay/channel)
     const int WeatherFontHeightMinusMargin {wd.FontHeight - m_MarginItem2};
     const int WeatherFontHeightDiff {(wd.FontHeight - wd.FontSmlHeight) / 2};
 
-    const int TempTodayWidth = wd.WeatherFont->Width(wd.Temp);
-    const int PrecTodayWidth = wd.WeatherFontSml->Width(wd.Days[0].Precipitation);
-    const int PrecTomorrowWidth = wd.WeatherFontSml->Width(wd.Days[1].Precipitation);
-    const int WidthTempToday = std::max(wd.WeatherFontSml->Width(wd.Days[0].TempMax),
-                                        wd.WeatherFontSml->Width(wd.Days[0].TempMin));  // Max width temp today
-    const int WidthTempTomorrow = std::max(wd.WeatherFontSml->Width(wd.Days[1].TempMax),
-                                           wd.WeatherFontSml->Width(wd.Days[1].TempMin));  // Max width temp tomorrow
+    const int TempTodayWidth {wd.WeatherFont->Width(wd.Temp)};
+    const int PrecTodayWidth {wd.WeatherFontSml->Width(wd.Days[0].Precipitation)};
+    const int PrecTomorrowWidth {wd.WeatherFontSml->Width(wd.Days[1].Precipitation)};
+    const int WidthTempToday {std::max(wd.WeatherFontSml->Width(wd.Days[0].TempMax),
+                                       wd.WeatherFontSml->Width(wd.Days[0].TempMin))};  // Max width temp today
+    const int WidthTempTomorrow {std::max(wd.WeatherFontSml->Width(wd.Days[1].TempMax),
+                                          wd.WeatherFontSml->Width(wd.Days[1].TempMin))};  // Max width temp tomorrow
 
 
     // For weather widget use the same margin as for the EPG images

--- a/baserender.c
+++ b/baserender.c
@@ -118,12 +118,15 @@ void cFlatBaseRender::CreateOsd(int Left, int Top, int Width, int Height) {
     dsyslog("flatPlus: cFlatBaseRender::CreateOsd() left: %d, top: %d, size: %dx%d", Left, Top, Width, Height);
 #endif
 
+    // Set Margins only when the OSD size has changed
+    if (m_OsdWidth != Width || m_OsdHeight != Height) {
+        SetMargins(Width, Height);  // Set margins relative to the OSD size
+    }
+
     m_OsdLeft = Left;
     m_OsdTop = Top;
     m_OsdWidth = Width;
     m_OsdHeight = Height;
-
-    SetMargins(Width, Height);  // Set margins relative to the OSD size
 
     m_Osd = cOsdProvider::NewOsd(Left, Top);  // Is always a valid pointer
 
@@ -135,7 +138,7 @@ void cFlatBaseRender::CreateOsd(int Left, int Top, int Width, int Height) {
 void cFlatBaseRender::SetMargins(int Width, int Height) {
     // Set margins relative to the OSD size with an minimum of 3 pixels
     static constexpr int kMinSize {3};  // Minimum margin size
-      // (1920: +3 pixels, 3840: +5 pixels, 7680: +11 pixels)
+    // 1920: +3 pixels, 3840: +5 pixels, 7680: +11 pixels
     int SizeIncrease {static_cast<int>((Width * (1.0 / 720.0)) + 0.5)};
     m_MarginItem = kMinSize + SizeIncrease;
     m_MarginItem2 = m_MarginItem * 2;
@@ -144,7 +147,7 @@ void cFlatBaseRender::SetMargins(int Width, int Height) {
     // Margin for EPG image in EPG info and recording info
     m_MarginEPGImage += SizeIncrease;
 
-    // (1080: +2 pixels, 2160: +4 pixels, 4320: +8 pixels)
+    // 1080: +2 pixels, 2160: +4 pixels, 4320: +8 pixels
     SizeIncrease = static_cast<int>((Height * (1.0 / 576.0)) + 0.5);
     m_LineWidth = kMinSize + SizeIncrease;  // Increase line width for larger OSD heights
     m_LineMargin = m_LineWidth * 2;

--- a/baserender.c
+++ b/baserender.c
@@ -1782,7 +1782,8 @@ bool cFlatBaseRender::BatchReadWeatherData(FontImageWeatherCache &out, time_t &o
             const auto deg = tt.find("°");  // Find the degree sign (UFT-8 char)
             if (deg != std::string_view::npos) {
                 out.TempTodaySign = cString(tt.substr(deg).data());  // Get the sign (°C or °F)
-                out.Temp = out.Temp.Truncate(deg);                   // Remove the sign from the temp string
+                // Check if there's a space before the degree sign and also remove it with the sign
+                out.Temp = out.Temp.Truncate((isspace(deg - 1)) ? deg - 1 : deg);
             } else {
                 out.TempTodaySign = "";
             }

--- a/baserender.c
+++ b/baserender.c
@@ -1778,12 +1778,12 @@ bool cFlatBaseRender::BatchReadWeatherData(FontImageWeatherCache &out, time_t &o
             }
 
             // Temp sign extraction
-            std::string_view tt = *out.Temp;
-            const auto deg = tt.find("°");  // Find the degree sign (UFT-8 char)
+            std::string_view svTemp = *out.Temp;  // Create a string_view for easier manipulation
+            const auto deg = svTemp.find("°");  // Find the degree sign (UFT-8 char)
             if (deg != std::string_view::npos) {
-                out.TempTodaySign = cString(tt.substr(deg).data());  // Get the sign (°C or °F)
+                out.TempTodaySign = cString(svTemp.substr(deg).data());  // Get the sign (°C or °F)
                 // Check if there's a space before the degree sign and also remove it with the sign
-                out.Temp = out.Temp.Truncate((isspace(deg - 1)) ? deg - 1 : deg);
+                out.Temp = out.Temp.Truncate((isspace(svTemp.at(deg - 1)) ? deg - 1 : deg));
             } else {
                 out.TempTodaySign = "";
             }
@@ -1892,7 +1892,8 @@ void cFlatBaseRender::DrawWidgetWeather() {  // Weather widget (repay/channel)
     }
 #ifdef DEBUGFUNCSCALL
     // Log weather cache data for debugging
-    dsyslog("flatPlus: DrawWidgetWeather() Temp: %s, Location: %s", *wd.Temp, *wd.Location);
+    dsyslog("flatPlus: DrawWidgetWeather() Temp: '%s', Sign: '%s', Location: '%s'", *wd.Temp, *wd.TempTodaySign,
+            *wd.Location);
     for (int i = 0; i < 7; i++) {
         if (!isempty(*wd.Days[i].Icon)) {
             dsyslog("   Day %d: Icon: %s, TempMax: %s, TempMin: %s, Precipitation: %s, Summary: %s", i,

--- a/baserender.c
+++ b/baserender.c
@@ -1874,6 +1874,7 @@ static void EnsureWeatherWidgetFonts(FontImageWeatherCache &cache, int fs) {  //
 void cFlatBaseRender::DrawWidgetWeather() {  // Weather widget (repay/channel)
 #ifdef DEBUGFUNCSCALL
     dsyslog("flatPlus: cFlatBaseRender::DrawWidgetWeather()");
+    cTimeMs Timer;  // Start Timer
 #endif
 
     static int LastOsdHeight {0};
@@ -1906,8 +1907,7 @@ void cFlatBaseRender::DrawWidgetWeather() {  // Weather widget (repay/channel)
     }
 #ifdef DEBUGFUNCSCALL
     // Log weather cache data for debugging
-    dsyslog("flatPlus: DrawWidgetWeather() Temp: '%s', Sign: '%s', Location: '%s'", *wd.Temp, *wd.TempTodaySign,
-            *wd.Location);
+    dsyslog("   Temp: '%s', Sign: '%s', Location: '%s'", *wd.Temp, *wd.TempTodaySign, *wd.Location);
     for (int i = 0; i < 7; i++) {
         if (!isempty(*wd.Days[i].Icon)) {
             dsyslog("   Day %d: Icon: %s, TempMax: %s, TempMin: %s, Precipitation: %s, Summary: %s", i,
@@ -1949,7 +1949,7 @@ void cFlatBaseRender::DrawWidgetWeather() {  // Weather widget (repay/channel)
     // Add temperature
     WeatherWidget.AddText(wd.Temp, false, cRect(left, 0, 0, 0), Theme.Color(clrChannelFontEpg),
                           Theme.Color(clrItemCurrentBg), wd.WeatherFont);
-    left += TempTodayWidth;
+    left += TempTodayWidth + (m_MarginItem / 2);
 
     const int t {(wd.FontHeight - wd.FontAscender) - (wd.FontSignHeight - wd.FontSignAscender)};
 
@@ -2022,6 +2022,9 @@ void cFlatBaseRender::DrawWidgetWeather() {  // Weather widget (repay/channel)
 
     WeatherWidget.CreatePixmaps(false);
     WeatherWidget.Draw();
+#ifdef DEBUGFUNCSCALL
+    if (Timer.Elapsed() > 0) dsyslog("   DrawMainMenuWidgetWeather() done in %ld ms", Timer.Elapsed());
+#endif
 }
 
 /**

--- a/baserender.c
+++ b/baserender.c
@@ -1909,7 +1909,7 @@ void cFlatBaseRender::DrawWidgetWeather() {  // Weather widget (repay/channel)
 #ifdef DEBUGFUNCSCALL
     // Log weather cache data for debugging
     dsyslog("   Temp: '%s', Sign: '%s', Location: '%s'", *wd.Temp, *wd.TempTodaySign, *wd.Location);
-    for (int i = 0; i < 7; i++) {
+    for (int i = 0; i < 7; ++i) {
         if (!isempty(*wd.Days[i].Icon)) {
             dsyslog("   Day %d: Icon: %s, TempMax: %s, TempMin: %s, Precipitation: %s, Summary: %s", i,
                     *wd.Days[i].Icon, *wd.Days[i].TempMax, *wd.Days[i].TempMin, *wd.Days[i].Precipitation,

--- a/baserender.h
+++ b/baserender.h
@@ -277,7 +277,7 @@ class cFlatBaseRender {
 // tries to acquire the Timers lock.
 class cRecCountThread : public cThread {
  public:
-    cRecCountThread() : cThread("RecCount") {}
+    cRecCountThread() : cThread("RecCount", true) {}  // Low priority thread
     uint16_t Count() const { return m_NumRecordings.load(std::memory_order_relaxed); }
     void Stop() { Cancel(3); }
 
@@ -285,7 +285,8 @@ class cRecCountThread : public cThread {
     void Action() override {
         while (Running()) {
             uint16_t count {0};
-            { LOCK_TIMERS_READ;
+            {
+                LOCK_TIMERS_READ;
                 for (const cTimer *Timer {Timers->First()}; Timer; Timer = Timers->Next(Timer)) {
                     count += (Timer->HasFlags(tfRecording)) ? 1 : 0;  // Increment count if timer is recording
                 }

--- a/baserender.h
+++ b/baserender.h
@@ -286,7 +286,7 @@ class cRecCountThread : public cThread {
             uint16_t count {0};
             { LOCK_TIMERS_READ;
                 for (const cTimer *Timer {Timers->First()}; Timer; Timer = Timers->Next(Timer)) {
-                    count += (Timer->HasFlags(tfActive)) ? 1 : 0;  // Increment count if timer is active
+                    count += (Timer->HasFlags(tfRecording)) ? 1 : 0;  // Increment count if timer is recording
                 }
             }
             m_NumRecordings.store(count, std::memory_order_relaxed);

--- a/baserender.h
+++ b/baserender.h
@@ -286,7 +286,7 @@ class cRecCountThread : public cThread {
             uint16_t count {0};
             { LOCK_TIMERS_READ;
                 for (const cTimer *Timer {Timers->First()}; Timer; Timer = Timers->Next(Timer)) {
-                    if (Timer->HasFlags(tfRecording)) ++count;
+                    count += (Timer->HasFlags(tfActive)) ? 1 : 0;  // Increment count if timer is active
                 }
             }
             m_NumRecordings.store(count, std::memory_order_relaxed);

--- a/baserender.h
+++ b/baserender.h
@@ -32,6 +32,7 @@ enum eBorder {
     BorderMMWidget
 };
 
+// Decorated border (Left, Top, Width, Height, Size, Type, ColorFg, ColorBg, From)
 struct sDecorBorder {
     int Left {0}, Top {0}, Width {0}, Height {0};
     int Size {0}, Type {0};

--- a/baserender.h
+++ b/baserender.h
@@ -285,7 +285,7 @@ class cRecCountThread : public cThread {
         while (Running()) {
             uint16_t count {0};
             { LOCK_TIMERS_READ;
-                for (const cTimer *Timer = Timers->First(); Timer; Timer = Timers->Next(Timer)) {
+                for (const cTimer *Timer {Timers->First()}; Timer; Timer = Timers->Next(Timer)) {
                     if (Timer->HasFlags(tfRecording)) ++count;
                 }
             }

--- a/complexcontent.c
+++ b/complexcontent.c
@@ -151,7 +151,7 @@ void cComplexContent::AddImageWithFloatedText(cImage *image, int imageAlignment,
     std::string Line {""};
     Line.reserve(128);
     cRect FloatedTextPos {TextPos};
-    const int Top = TextPos.Top();  // Cache TextPos.Top() outside the loop
+    const int Top {TextPos.Top()};  // Cache TextPos.Top() outside the loop
     for (int i {0}; i < Lines; ++i) {  // Add text line by line
         FloatedTextPos.SetTop(Top + (i * m_ScrollSize));
         Line = WrapperFloat.GetLine(i);

--- a/complexcontent.c
+++ b/complexcontent.c
@@ -108,10 +108,9 @@ bool cComplexContent::Scrollable(int height) {
         return false;
     }
 
-    const int total {ScrollTotal()};
     // const int shown = ceil(height * 1.0 / m_ScrollSize);  // Narrowing conversion
     const int shown {(height + m_ScrollSize - 1) / m_ScrollSize};  // Avoid floating-point and use integer division
-    return total > shown;
+    return ScrollTotal() > shown;
 }
 
 void cComplexContent::AddText(const char *Text, bool Multiline, const cRect &Position, tColor ColorFg, tColor ColorBg,

--- a/complexcontent.c
+++ b/complexcontent.c
@@ -63,10 +63,9 @@ void cComplexContent::CreatePixmaps(bool FullFillBackground) {
             PixmapFill(Pixmap, m_ColorBg);
         } else {
             const int HeightContent {ContentHeight(false)};
-            if (HeightContent > 0)  // Only draw background if content height is > 0
-                Pixmap->DrawRectangle(cRect(0, 0, m_Position.Width(), HeightContent), m_ColorBg);
-            else
-                PixmapClear(Pixmap);
+            (HeightContent > 0)  // Only draw background if content height is > 0
+                ? Pixmap->DrawRectangle(cRect(0, 0, m_Position.Width(), HeightContent), m_ColorBg)
+                : PixmapClear(Pixmap);
         }
     } else {  // Log values and return
         esyslog(
@@ -218,10 +217,8 @@ int cComplexContent::ScrollOffset() const {
     int y {Pixmap->DrawPort().Point().Y() * -1};
     const int PositionHeight {m_Position.Height()};
     if (y + PositionHeight + m_ScrollSize > m_DrawPortHeight) {
-        if (y == m_DrawPortHeight - PositionHeight)
-            y += m_ScrollSize;
-        else
-            y = m_DrawPortHeight - PositionHeight - 1;
+        (y == m_DrawPortHeight - PositionHeight) ? y += m_ScrollSize
+                                                 : y = m_DrawPortHeight - PositionHeight - 1;
     }
 
     if (m_DrawPortHeight == 0) {  // Avoid DIV/0

--- a/complexcontent.c
+++ b/complexcontent.c
@@ -151,8 +151,9 @@ void cComplexContent::AddImageWithFloatedText(cImage *image, int imageAlignment,
     std::string Line {""};
     Line.reserve(128);
     cRect FloatedTextPos {TextPos};
+    const int Top = TextPos.Top();  // Cache TextPos.Top() outside the loop
     for (int i {0}; i < Lines; ++i) {  // Add text line by line
-        FloatedTextPos.SetTop(TextPos.Top() + (i * m_ScrollSize));
+        FloatedTextPos.SetTop(Top + (i * m_ScrollSize));
         Line = WrapperFloat.GetLine(i);
         // Last line is not justified
         if (Config.MenuEventRecordingViewJustify == 1 && i < (Lines - 1))
@@ -161,7 +162,7 @@ void cComplexContent::AddImageWithFloatedText(cImage *image, int imageAlignment,
         AddText(Line.c_str(), false, FloatedTextPos, ColorFg, ColorBg, Font, TextWidthFull, TextHeight, TextAlignment);
     }
 
-    const cRect ImagePos {TextPos.Left() + TextWidthLeft + Margin, TextPos.Top(), image->Width(), image->Height()};
+    const cRect ImagePos {TextPos.Left() + TextWidthLeft + Margin, Top, image->Width(), image->Height()};
     AddImage(image, ImagePos);  // Add the image (Currently always on the right side)
 }
 

--- a/complexcontent.h
+++ b/complexcontent.h
@@ -41,8 +41,13 @@ class cSimpleContent {
     cFont *m_Font {nullptr};
 
     void DrawMultilineText(cPixmap *Pixmap) const {
+        // Cache TextPos and TextWidthLeft for better performance
+        const int PositionLeft {m_Position.Left()};
+        const int PositionTop {m_Position.Top()};
+        const int PositionWidth {m_Position.Width()};
+
         cTextFloatingWrapper Wrapper;
-        Wrapper.Set(*m_Text, m_Font, m_Position.Width());
+        Wrapper.Set(*m_Text, m_Font, PositionWidth);
         std::string Line;
         Line.reserve(128);
         const int Lines {Wrapper.Lines()};
@@ -51,9 +56,9 @@ class cSimpleContent {
         for (int i {0}; i < Lines; ++i) {
             Line = Wrapper.GetLine(i);
             if (Config.MenuEventRecordingViewJustify == 1 && i < (Lines - 1)) {
-                JustifyLine(Line, m_Font, m_Position.Width());
+                JustifyLine(Line, m_Font, PositionWidth);
             }
-            Pixmap->DrawText(cPoint(m_Position.Left(), m_Position.Top() + (i * FontHeight)),
+            Pixmap->DrawText(cPoint(PositionLeft, PositionTop + (i * FontHeight)),
                             Line.c_str(), m_ColorFg, m_ColorBg, m_Font,
                             m_TextWidth, m_TextHeight, m_TextAlignment);
         }

--- a/complexcontent.h
+++ b/complexcontent.h
@@ -205,6 +205,13 @@ class cComplexContent {
     bool IsShown() const { return m_IsShown; }
     bool IsScrollingActive() const { return m_IsScrollingActive; }
 
+    // Hide/show the content pixmaps (used by the zapcockpit list views).
+    // The layers correspond to those used in CreatePixmaps()
+    void SetVisible(bool Visible) {
+        if (Pixmap) Pixmap->SetLayer(Visible ? 1 : -1);
+        if (PixmapImage) PixmapImage->SetLayer(Visible ? 2 : -1);
+    }
+
  private:
     std::vector<cSimpleContent> Contents;
 

--- a/config.c
+++ b/config.c
@@ -618,8 +618,7 @@ void cFlatConfig::DecorLoadFile(cString File) {
     dsyslog("flatPlus: Load decor file: %s", *File);
 
     FILE *f {fopen(File, "r")};
-    if (f == nullptr) {
-        // Handle error
+    if (!f) {  // Handle error
         esyslog("flatPlus: Load decor file: %s failed", *File);
         return;
     } else {

--- a/config.c
+++ b/config.c
@@ -463,7 +463,7 @@ bool CompareNumStrings(const cString &a, const cString &b) {
     std::string_view sa = *a;
     std::string_view sb = *b;
     auto get_num = [](std::string_view s) {
-        std::size_t pos = s.find('_');
+        std::size_t pos {s.find('_')};
         if (pos != std::string_view::npos)
             return atoi(std::string(s.substr(0, pos)).c_str());
         return 0;
@@ -472,8 +472,8 @@ bool CompareNumStrings(const cString &a, const cString &b) {
 }
 
 bool StringCompare(const std::string &left, const std::string &right) {
-    auto len = std::min(left.size(), right.size());
-    auto lit = left.cbegin(), rit = right.cbegin();
+    auto len {std::min(left.size(), right.size())};
+    auto lit {left.cbegin()}, rit {right.cbegin()};
     while (len-- > 0) {
         if (tolower(*lit) != tolower(*rit)) return tolower(*lit) < tolower(*rit);
         ++lit;
@@ -518,7 +518,7 @@ int RoundUp(int NumToRound, int multiple) {
 }
 
 void cFlatConfig::DecorDescriptions(cStringList &Decors) {
-    cString DecorPath = cString::sprintf("%s/decors", PLUGINRESOURCEPATH);
+    cString DecorPath {cString::sprintf("%s/decors", PLUGINRESOURCEPATH)};
     std::vector<std::string> files;
     files.reserve(64);  // Set to at least 64 entry's
     Decors.Clear();
@@ -555,7 +555,7 @@ cString cFlatConfig::DecorDescription(cString File) {
         return description;
     }
 
-    FILE *f = fopen(File, "r");
+    FILE *f {fopen(File, "r")};
     if (!f) {
         esyslog("flatPlus: DecorDescription() Unable to open file: %s", *File);
         return description;
@@ -588,7 +588,7 @@ cString cFlatConfig::DecorDescription(cString File) {
 }
 
 void cFlatConfig::DecorLoadCurrent() {
-    cString DecorPath = cString::sprintf("%s/decors", PLUGINRESOURCEPATH);
+    cString DecorPath {cString::sprintf("%s/decors", PLUGINRESOURCEPATH)};
     std::vector<std::string> files;
     files.reserve(64);  // Set to at least 64 entry's
 
@@ -617,7 +617,7 @@ void cFlatConfig::DecorLoadCurrent() {
 void cFlatConfig::DecorLoadFile(cString File) {
     dsyslog("flatPlus: Load decor file: %s", *File);
 
-    FILE *f = fopen(File, "r");
+    FILE *f {fopen(File, "r")};
     if (f == nullptr) {
         // Handle error
         esyslog("flatPlus: Load decor file: %s failed", *File);
@@ -715,8 +715,8 @@ void cFlatConfig::DecorLoadFile(cString File) {
 }
 
 int cFlatConfig::GetRecordingOldValue(const std::string &folder) const {
-    auto it = RecordingOldFolderMap.find(folder);
-    return it != RecordingOldFolderMap.end() ? it->second : -1;
+    auto it {RecordingOldFolderMap.find(folder)};
+    return (it != RecordingOldFolderMap.end()) ? it->second : -1;
 }
 
 void cFlatConfig::RecordingOldLoadConfig() {
@@ -724,7 +724,7 @@ void cFlatConfig::RecordingOldLoadConfig() {
     dsyslog("flatPlus: Load recording old config file: %s", *RecordingOldConfigFile);
 #endif
 
-    FILE *f = fopen(RecordingOldConfigFile, "r");
+    FILE *f {fopen(RecordingOldConfigFile, "r")};
     if (!f) {
 #ifdef DEBUGFUNCSCALL
         dsyslog("flatPlus: Recording old config file not found: %s", *RecordingOldConfigFile);
@@ -777,7 +777,7 @@ void cFlatConfig::Store(const char *Name, double &Value, const char *Filename) {
 }
 
 void cFlatConfig::Store(const char *Name, const char *Value, const char *Filename) {
-    FILE *f = fopen(Filename, "a");
+    FILE *f {fopen(Filename, "a")};
     if (!f) {
         esyslog("flatPlus: Error storing config: %s = %s", Name, Value);
         return;
@@ -787,7 +787,7 @@ void cFlatConfig::Store(const char *Name, const char *Value, const char *Filenam
 }
 
 void cFlatConfig::GetConfigFiles(cStringList &Files) {
-    cString ConfigsPath = cString::sprintf("%s/configs", cPlugin::ConfigDirectory(PLUGIN_NAME_I18N));
+    cString ConfigsPath {cString::sprintf("%s/configs", cPlugin::ConfigDirectory(PLUGIN_NAME_I18N))};
     std::vector<std::string> files;
     files.reserve(64);  // Set to at least 64 entry's
     Files.Clear();

--- a/config.c
+++ b/config.c
@@ -91,6 +91,11 @@ bool cFlatConfig::SetupParse(const char *Name, const char *Value) {
     else if (strcmp(Name, "ChannelSimpleAspectFormat") == 0)            ChannelSimpleAspectFormat = atoi(Value);
     else if (strcmp(Name, "ChannelTimeLeft") == 0)                      ChannelTimeLeft = atoi(Value);
     else if (strcmp(Name, "ChannelWeatherShow") == 0)                   ChannelWeatherShow = atoi(Value);
+    else if (strcmp(Name, "ChannelZapcockpitKeyRightOpensList") == 0)   ChannelZapcockpitKeyRightOpensList = atoi(Value);
+    else if (strcmp(Name, "ChannelZapcockpitListWidth") == 0)           ChannelZapcockpitListWidth = atoi(Value);
+    else if (strcmp(Name, "ChannelZapcockpitFontSize") == 0)            ChannelZapcockpitFontSize = atoi(Value);
+    else if (strcmp(Name, "ChannelZapcockpitFadeTime") == 0)            ChannelZapcockpitFadeTime = atoi(Value);
+    else if (strcmp(Name, "ChannelZapcockpitShiftTime") == 0)           ChannelZapcockpitShiftTime = atoi(Value);
     else if (strcmp(Name, "DecorIndex") == 0)                           DecorIndex = atoi(Value);
     else if (strcmp(Name, "DiskUsageFree") == 0)                        DiskUsageFree = atoi(Value);
     else if (strcmp(Name, "DiskUsageShort") == 0)                       DiskUsageShort = atoi(Value);

--- a/config.h
+++ b/config.h
@@ -340,7 +340,7 @@ class cFlatConfig {
 
         int TVScraperReplayInfoShowPoster {1};
         double TVScraperReplayInfoPosterSize {1.0 / 100};
-        double TVScraperPosterOpacity {0.8 / 100};  // Opacitiy of poster in replay info and channel info (80%)
+        double TVScraperPosterOpacity {0.8 / 100};  // Opacitiy of poster in replay info and channel info (80 %)
 
         int TVScraperSearchLocalPosters {1};  // 0 = do not search, 1 = search, 2 = search only in recording folder
 

--- a/config.h
+++ b/config.h
@@ -220,6 +220,11 @@ class cFlatConfig {
         int ChannelShowStartTime {true};
         int ChannelSimpleAspectFormat {true};
         int ChannelTimeLeft {0};
+        int ChannelZapcockpitKeyRightOpensList {true};  // Zapcockpit: Key right opens channellist (else grouplist)
+        int ChannelZapcockpitListWidth {33};   // Zapcockpit: Width of one list column in % of the OSD width (20-40)
+        int ChannelZapcockpitFontSize {100};   // Zapcockpit: Font size of the list items in % of the OSD font (60-100)
+        int ChannelZapcockpitFadeTime {0};     // Zapcockpit: Fade-in time of the lists in ms (0 = off)
+        int ChannelZapcockpitShiftTime {0};    // Zapcockpit: Shift-in time of the lists in ms (0 = off)
 
         double WeatherFontSize {5.0 / 100};  // Font size for weather (% of OSD height)
         int ChannelWeatherShow {1};

--- a/contrib/Fonts/Droid-Sans/Apache License.txt
+++ b/contrib/Fonts/Droid-Sans/Apache License.txt
@@ -17,7 +17,7 @@ Apache License
       control with that entity. For the purposes of this definition,
       "control" means (i) the power, direct or indirect, to cause the
       direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      otherwise, or (ii) ownership of fifty percent (50 %) or more of the
       outstanding shares, or (iii) beneficial ownership of such entity.
 
       "You" (or "Your") shall mean an individual or Legal Entity

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -159,7 +159,7 @@ void cFlatDisplayChannel::SetChannel(const cChannel *Channel, int Number) {
 
     if (Config.ChannelShowNameWithShadow) {
         PixmapClear(ChanInfoTopPixmap);
-        const int ShadowSize {m_FontBigHeight / 10};  // Shadow size is 10% of font height
+        const int ShadowSize {m_FontBigHeight / 10};  // Shadow size is 10 % of font height
         // Ensure shadow size is reasonable
         const int MinShadowSize {m_MarginItem / 2 + 1};  // Minimum shadow size
         const int MaxShadowSize {m_MarginItem3};         // Shadow should not be too large

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -347,11 +347,11 @@ void cFlatDisplayChannel::SetEvents(const cEvent *Present, const cEvent *Followi
                 TopSeen = m_FontSmlHeight;
                 EpgColor = clrChannelFontEpg;
                 const std::time_t s {(time(0) - Event->StartTime()) / 60};
-                const int sleft {EventDuration - s};
+                const int sleft {static_cast<int>(EventDuration - s)};
 
                 switch (Config.ChannelTimeLeft) {
-                case 0: SeenDur = cString::sprintf("%d-/%d+ %d min", s, sleft, EventDuration); break;
-                case 1: SeenDur = cString::sprintf("%d- %d min", s, EventDuration); break;
+                case 0: SeenDur = cString::sprintf("%ld-/%d+ %d min", s, sleft, EventDuration); break;
+                case 1: SeenDur = cString::sprintf("%ld- %d min", s, EventDuration); break;
                 case 2: SeenDur = cString::sprintf("%d+ %d min", sleft, EventDuration); break;
                 }
             } else {  // Following
@@ -561,7 +561,7 @@ void cFlatDisplayChannel::DvbapiInfoDraw() {
 
     left += FontCache.GetStringWidth(Setup.FontOsd, DvbapiInfoFontHeight, DvbapiInfoText) + m_MarginItem;
 
-    cString IconName = cString::sprintf("crypt_%s", *ecmInfo.cardsystem);
+    cString IconName {cString::sprintf("crypt_%s", *ecmInfo.cardsystem)};
     cImage *img {ImgLoader.GetIcon(*IconName, kIconMaxSize, DvbapiInfoFontHeight)};
     if (!img) {
         img = ImgLoader.GetIcon("crypt_unknown", kIconMaxSize, DvbapiInfoFontHeight);
@@ -608,11 +608,11 @@ void cFlatDisplayChannel::Flush() {
 
 void cFlatDisplayChannel::PreLoadImages() {
     const int height {m_HeightImageLogo - m_MarginItem2};
-    int ImageBgWidth = height * 1.34f;
+    int ImageBgWidth {static_cast<int>(height * 1.34f)};
     int ImageBgHeight {height};
 
     // Load 'logo_background' and determine if logo was found in channel logo path
-    cImage *img = ImgLoader.GetLogo("logo_background", ImageBgWidth, ImageBgHeight);
+    cImage *img {ImgLoader.GetLogo("logo_background", ImageBgWidth, ImageBgHeight)};
     if (img) {
         g_LogoBgOverwrite = true;  // Used for GetLogoBg()
     } else {

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -326,6 +326,7 @@ void cFlatDisplayChannel::SetEvents(const cEvent *Present, const cEvent *Followi
         const cEvent *Event {(IsPresent) ? Present : Following};
         if (Event) {
             StartTime = *Event->GetTimeString();  // Start time (Left side)
+            //? Use of – (EN DASH, U+2013) instead of - (HYPHEN-MINUS, U+002D) for better readability
             StrTime = cString::sprintf("%s - %s", *StartTime, *Event->GetEndTimeString());  // Start - End (Right side)
             StrTimeWidth = FontCache.GetStringWidth(m_FontSmlName, m_FontSmlHeight, "00:00 - 00:00") + SmlSpaceWidth2;
             EventDuration = Event->Duration() / 60;  // Duration in minutes

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -308,13 +308,11 @@ void cFlatDisplayChannel::SetEvents(const cEvent *Present, const cEvent *Followi
     int SeenDurWidth {0}, SeenDurMaxWidth {0};
     int MaxAvailWidth {0};
 
-    bool IsRec {false};
-    const int RecWidth {FontCache.GetStringWidth(m_FontSmlName, m_FontSmlHeight, "REC")};
-
     int left {static_cast<int>(m_HeightImageLogo * 1.34f) + m_MarginItem3};
     const int StartTimeLeft {left};
     int TopSeen {0}, TopEpg {0};
 
+    const int RecWidth {FontCache.GetStringWidth(m_FontSmlName, m_FontSmlHeight, "REC")};
     const int SmlSpaceWidth2 {FontCache.GetStringWidth(m_FontSmlName, m_FontSmlHeight, "  ")};
 
     if (Config.ChannelShowStartTime)
@@ -322,6 +320,7 @@ void cFlatDisplayChannel::SetEvents(const cEvent *Present, const cEvent *Followi
 
     PixmapFill(ChanInfoBottomPixmap, Theme.Color(clrChannelBg));
     for (int8_t i {0}; i < 2; i++) {
+        bool IsRec {false};
         const bool IsPresent {(i) ? false : true};
         const cEvent *Event {(IsPresent) ? Present : Following};
         if (Event) {

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -311,7 +311,7 @@ void cFlatDisplayChannel::SetEvents(const cEvent *Present, const cEvent *Followi
     bool IsRec {false};
     const int RecWidth {FontCache.GetStringWidth(m_FontSmlName, m_FontSmlHeight, "REC")};
 
-    int left = m_HeightImageLogo * 1.34f + m_MarginItem3;  // Narrowing conversion
+    int left {static_cast<int>(m_HeightImageLogo * 1.34f) + m_MarginItem3};
     const int StartTimeLeft {left};
     int TopSeen {0}, TopEpg {0};
 

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -418,8 +418,7 @@ void cFlatDisplayChannel::SetEvents(const cEvent *Present, const cEvent *Followi
         }  // if (Event)
     }  // for
 
-    PixmapClear(ChanIconsPixmap);
-    if (Config.ChannelIconsShow && m_CurChannel) ChannelIconsDraw(m_CurChannel, false);
+    if (Config.ChannelIconsShow && m_CurChannel) ChannelIconsDraw(m_CurChannel, true);
 
     cString MediaPath {""};
     cSize MediaSize {0, 0};  // Width, Height
@@ -585,7 +584,7 @@ void cFlatDisplayChannel::Flush() {
         cDevice::PrimaryDevice()->GetVideoSize(m_ScreenWidth, m_ScreenHeight, m_ScreenAspect);
         if (m_ScreenWidth != m_LastScreenWidth) {
             m_LastScreenWidth = m_ScreenWidth;
-            ChannelIconsDraw(m_CurChannel, true);  // Redraw and clear ChanInfoTopPixmap
+            ChannelIconsDraw(m_CurChannel, true);  // Full redraw when resolution changes
         }
     }
 

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -326,9 +326,10 @@ void cFlatDisplayChannel::SetEvents(const cEvent *Present, const cEvent *Followi
         const cEvent *Event {(IsPresent) ? Present : Following};
         if (Event) {
             StartTime = *Event->GetTimeString();  // Start time (Left side)
-            //? Use of – (EN DASH, U+2013) instead of - (HYPHEN-MINUS, U+002D) for better readability
-            StrTime = cString::sprintf("%s - %s", *StartTime, *Event->GetEndTimeString());  // Start - End (Right side)
-            StrTimeWidth = FontCache.GetStringWidth(m_FontSmlName, m_FontSmlHeight, "00:00 - 00:00") + SmlSpaceWidth2;
+            // Use of – (EN DASH, U+2013) instead of - (HYPHEN-MINUS, U+002D) for better readability
+            // https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Dates_and_numbers#Time_ranges
+            StrTime = cString::sprintf("%s–%s", *StartTime, *Event->GetEndTimeString());  // Start – End (Right side)
+            StrTimeWidth = FontCache.GetStringWidth(m_FontSmlName, m_FontSmlHeight, "00:00–00:00") + SmlSpaceWidth2;
             EventDuration = Event->Duration() / 60;  // Duration in minutes
 
             Epg = Event->Title();

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -516,7 +516,7 @@ void cFlatDisplayChannel::DvbapiInfoDraw() {
     if (!pDVBApi->Service("GetEcmInfo", &ecmInfo)) {
 #ifdef DEBUGFUNCSCALL
         const int *caids = m_CurChannel->Caids();
-        if (caids != nullptr && caids[0] != 0) {
+        if (caids && caids[0] != 0) {
             dsyslog("   No ECM info for channel %s (SID: %d)", m_CurChannel->Name(), m_CurChannel->Sid());
         }
 #endif

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -539,13 +539,12 @@ void cFlatDisplayChannel::DvbapiInfoDraw() {
     const int SignalBarsHeight {Config.decorProgressSignalSize * 2 + m_MarginItem};
     static constexpr uint32_t kCharCode {0x0044};  // U+0044 LATIN CAPITAL LETTER D
 
+    m_DvbapiInfoFont = FontCache.GetFont(Setup.FontOsd, SignalBarsHeight);
+    const int DvbapiInfoFontHeight {FontCache.GetFontHeight(Setup.FontOsd, SignalBarsHeight)};
     const int FontAscender {FontCache.GetFontAscender(Setup.FontOsd, SignalBarsHeight)};
     const int GlyphSize {FontCache.GetGlyphSize(Setup.FontOsd, kCharCode, SignalBarsHeight)};
     const int TopOffset {(FontAscender - GlyphSize) / 2};  // Center vertically
     const int top {m_HeightBottom - SignalBarsHeight - TopOffset - m_MarginItem};
-
-    m_DvbapiInfoFont = FontCache.GetFont(Setup.FontOsd, SignalBarsHeight);
-    const int DvbapiInfoFontHeight {FontCache.GetFontHeight(Setup.FontOsd, SignalBarsHeight)};
 
     cString DvbapiInfoText {"DVBAPI: "};
     ChanInfoBottomPixmap->DrawText(cPoint(left, top), *DvbapiInfoText, Theme.Color(clrChannelSignalFont),

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -47,10 +47,10 @@ cFlatDisplayChannel::cFlatDisplayChannel(bool WithInfo) {
 
     ChanEpgImagesPixmap = CreatePixmap(m_Osd, "ChanEpgImagesPixmap", 2, m_TVSRect);
 
-    // Pixmap for channel logo and background
+    // Pixmap for channel logo and background (4:3 aspect ratio, scaled to height of m_HeightImageLogo)
     const cRect ChanLogoViewPort {Config.decorBorderChannelSize,
-                                  Config.decorBorderChannelSize + m_ChannelHeight - height, m_HeightBottom * 2,
-                                  m_HeightBottom * 2};
+                                  Config.decorBorderChannelSize + m_ChannelHeight - height,
+                                  static_cast<int>(m_HeightImageLogo * 1.34f), m_HeightImageLogo};
     ChanLogoBgPixmap = CreatePixmap(m_Osd, "ChanLogoBGPixmap", 2, ChanLogoViewPort);
     ChanLogoPixmap = CreatePixmap(m_Osd, "ChanLogoPixmap", 3, ChanLogoViewPort);
 
@@ -155,7 +155,7 @@ void cFlatDisplayChannel::SetChannel(const cChannel *Channel, int Number) {
         ChannelName = ChannelString(NULL, 0);
     }  // if (Channel)
 
-    const cString ChannelString = cString::sprintf("%s  %s", *ChannelNumber, *ChannelName);
+    const cString ChannelString {cString::sprintf("%s  %s", *ChannelNumber, *ChannelName)};
 
     if (Config.ChannelShowNameWithShadow) {
         PixmapClear(ChanInfoTopPixmap);

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -346,7 +346,7 @@ void cFlatDisplayChannel::SetEvents(const cEvent *Present, const cEvent *Followi
                 TopEpg = 0;
                 TopSeen = m_FontSmlHeight;
                 EpgColor = clrChannelFontEpg;
-                const int s = (time(0) - Event->StartTime()) / 60;  // Narrowing conversion
+                const std::time_t s {(time(0) - Event->StartTime()) / 60};
                 const int sleft {EventDuration - s};
 
                 switch (Config.ChannelTimeLeft) {

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -10,6 +10,8 @@
 #include <vdr/device.h>
 
 #include <algorithm>
+#include <cstddef>
+#include <string>
 
 #include "./flat.h"
 #include "./fontcache.h"
@@ -87,6 +89,78 @@ cFlatDisplayChannel::cFlatDisplayChannel(bool WithInfo) {
 
     if (Config.ChannelWeatherShow) DrawWidgetWeather();
 
+#ifdef USE_ZAPCOCKPIT
+    // Geometry for the zapcockpit panels: The area between top bar and the
+    // channel info display at the bottom is used for the lists and the
+    // detailed EPG info. The lists are anchored at the side of the pressed
+    // key: The list opened with key 'right' at the left edge, the list opened
+    // with key 'left' at the right edge. With the default setup ('Key right
+    // opens channellist') the channellist is therefore shown at the left and
+    // the grouplist at the right edge (mirrored when the option is disabled).
+    // The channellist of the selected group is shown beside the grouplist and
+    // the EPG info of the selected channel in the remaining space.
+    // For dcChannelInfo (2nd 'Ok') the EPG info uses the full width.
+    // Pixmaps are created lazily when one of the extended views is opened.
+    // While a list view is shown all base OSD elements are hidden, so the
+    // lists and the EPG info beside them can use the full OSD height. Only
+    // the channel hints (shown while entering a channel number) and the full
+    // width EPG info (2nd 'Ok') use the area between top bar and the channel
+    // info display, because there the base OSD elements stay visible.
+    const int ZapTop {m_TopBarHeight + Config.decorBorderTopBarSize * 2 + m_MarginItem};
+    const int ZapBottom {Config.decorBorderChannelSize + m_ChannelHeight - height - m_MarginItem2};
+    const int ZapHeight {std::max(0, ZapBottom - ZapTop)};
+    const int ZapFullHeight {m_OsdHeight};
+    const int ZapLeft {Config.decorBorderChannelSize};
+    const int ZapRight {m_OsdWidth - Config.decorBorderChannelSize};
+    const int ZapListWidthPct {std::clamp(Config.ChannelZapcockpitListWidth, 20, 40)};
+    m_ZapColWidth = (ZapRight - ZapLeft) * ZapListWidthPct / 100;
+
+    // Columns anchored at the left edge (L) and at the right edge (R)
+    const int Lx1 {ZapLeft};                              // 1st column from left
+    const int Lx2 {Lx1 + m_ZapColWidth + m_MarginItem2};  // 2nd column from left
+    const int Lx3 {Lx2 + m_ZapColWidth + m_MarginItem2};  // 3rd column from left
+    const int Rx1 {ZapRight - m_ZapColWidth};             // 1st column from right
+    const int Rx2 {Rx1 - m_MarginItem2 - m_ZapColWidth};  // 2nd column from right
+    const int Rx3 {Rx2 - m_MarginItem2 - m_ZapColWidth};  // 3rd column from right
+
+    // The list items use the same fonts as the channel info display at the
+    // bottom, scaled by the setup option 'Zapcockpit: List font size', so
+    // that more items fit on the screen
+    const int ZapFontPct {std::clamp(Config.ChannelZapcockpitFontSize, 60, 100)};
+    const int ZapFontSize {std::max(1, Setup.FontOsdSize * ZapFontPct / 100)};
+    const int ZapFontSmlSize {std::max(1, Setup.FontSmlSize * ZapFontPct / 100)};
+    m_ZapFont = FontCache.GetFont(Setup.FontOsd, ZapFontSize);
+    m_ZapFontSml = FontCache.GetFont(Setup.FontSml, ZapFontSmlSize);
+    m_ZapFontHeight = FontCache.GetFontHeight(Setup.FontOsd, ZapFontSize);
+    m_ZapFontSmlHeight = FontCache.GetFontHeight(Setup.FontSml, ZapFontSmlSize);
+
+    // Channellist items: Channel logo left, three text lines right of it
+    // (remaining time, title of the running event, following event)
+    m_ZapItemHeightChan = m_ZapFontSmlHeight * 2 + m_ZapFontHeight + m_MarginItem + Config.MenuItemPadding;
+    // Grouplist items: One text line
+    m_ZapItemHeightGroup = m_ZapFontHeight + Config.MenuItemPadding;
+    m_ZapMaxItemsChan = (m_ZapItemHeightChan > 0) ? ZapFullHeight / m_ZapItemHeightChan : 0;
+    m_ZapMaxItemsGroup = (m_ZapItemHeightGroup > 0) ? ZapFullHeight / m_ZapItemHeightGroup : 0;
+
+    if (Config.ChannelZapcockpitKeyRightOpensList) {  // Channellist left, grouplist right
+        m_ZapListRectChan.Set(Lx1, 0, m_ZapColWidth, ZapFullHeight);
+        m_ZapInfoRectChan.Set(Lx2, 0, ZapRight - Lx2, ZapFullHeight);
+        m_ZapListRectGroup.Set(Rx1, 0, m_ZapColWidth, ZapFullHeight);
+        m_ZapList2RectGroup.Set(Rx2, 0, m_ZapColWidth, ZapFullHeight);
+        m_ZapInfoRectGroup.Set(ZapLeft, 0, std::max(0, Rx3 + m_ZapColWidth - m_MarginItem2 - ZapLeft),
+                               ZapFullHeight);
+        m_ZapHintsRect.Set(Lx1, ZapTop, m_ZapColWidth, ZapHeight);
+    } else {  // Channellist right, grouplist left
+        m_ZapListRectChan.Set(Rx1, 0, m_ZapColWidth, ZapFullHeight);
+        m_ZapInfoRectChan.Set(ZapLeft, 0, Rx1 - m_MarginItem2 - ZapLeft, ZapFullHeight);
+        m_ZapListRectGroup.Set(Lx1, 0, m_ZapColWidth, ZapFullHeight);
+        m_ZapList2RectGroup.Set(Lx2, 0, m_ZapColWidth, ZapFullHeight);
+        m_ZapInfoRectGroup.Set(Lx3, 0, std::max(0, ZapRight - Lx3), ZapFullHeight);
+        m_ZapHintsRect.Set(Rx1, ZapTop, m_ZapColWidth, ZapHeight);
+    }
+    m_ZapInfoWideRect.Set(ZapLeft, ZapTop, ZapRight - ZapLeft, ZapHeight);
+#endif
+
     // Decor border depending on setting 'ChannelShowNameWithShadow'
     const sDecorBorder ib {Config.decorBorderChannelSize,
                            ChanInfoTopViewPort.Y() + (Config.ChannelShowNameWithShadow ? HeightTop : 0),
@@ -109,6 +183,11 @@ cFlatDisplayChannel::~cFlatDisplayChannel() {
         m_Osd->DestroyPixmap(ChanLogoPixmap);
         m_Osd->DestroyPixmap(ChanIconsPixmap);
         m_Osd->DestroyPixmap(ChanEpgImagesPixmap);
+#ifdef USE_ZAPCOCKPIT
+        if (ZapListPixmap) m_Osd->DestroyPixmap(ZapListPixmap);
+        if (ZapList2Pixmap) m_Osd->DestroyPixmap(ZapList2Pixmap);
+        if (ZapInfoPixmap) m_Osd->DestroyPixmap(ZapInfoPixmap);
+#endif
     }
 }
 
@@ -118,6 +197,11 @@ void cFlatDisplayChannel::SetChannel(const cChannel *Channel, int Number) {
 #endif
 
     if (!ChanIconsPixmap || !ChanInfoTopPixmap || !ChanLogoBgPixmap || !ChanLogoPixmap) return;
+
+#ifdef USE_ZAPCOCKPIT
+    // Number entry finished: Hide the channel hint list again
+    if (Number == 0 && m_ZapNumHints > 0) ZapHideLists();
+#endif
 
     PixmapClear(ChanIconsPixmap);
     m_LastScreenWidth = -1;
@@ -452,6 +536,510 @@ void cFlatDisplayChannel::SetMessage(eMessageType Type, const char *Text) {
     (Text) ? MessageSet(Type, Text) : MessageClear();
 }
 
+#ifdef USE_ZAPCOCKPIT
+//
+// Zapcockpit (extended channel display)
+// The complete input handling and list logic is implemented in the patched
+// VDR (cDisplayChannelExtended in menu.c). The skin only has to render the
+// channel-/grouplist, the channellist of the selected group, the channel
+// hints and the detailed EPG info of the selected channel.
+//
+
+// Alpha blends Fg over Bg (straight alpha 'over' operator). Used to compose
+// the channel logo on the 'logo_background' image and the list item
+// background in software, because cPixmap::DrawImage() replaces the pixels
+// including their alpha value instead of blending them (in the channel info
+// display at the bottom the blending is done by the OSD composition of the
+// separate logo pixmap layers)
+static tColor ZapAlphaOver(tColor Fg, tColor Bg) {
+    const int Af {static_cast<int>((Fg >> 24) & 0xFF)};
+    if (Af == 255) return Fg;
+    if (Af == 0) return Bg;
+    const int Ab {static_cast<int>((Bg >> 24) & 0xFF)};
+    const int A {Af + Ab * (255 - Af) / 255};
+    if (A == 0) return clrTransparent;
+    const auto Channel = [&](int Shift) -> int {
+        const int Cf {static_cast<int>((Fg >> Shift) & 0xFF)};
+        const int Cb {static_cast<int>((Bg >> Shift) & 0xFF)};
+        return (Cf * Af + Cb * Ab * (255 - Af) / 255) / A;
+    };
+    return (static_cast<tColor>(A) << 24) | (Channel(16) << 16) | (Channel(8) << 8) | Channel(0);
+}
+
+// Blends the given image at the given position over the existing content of
+// the composed image
+static void ZapBlendImage(cImage &Composed, const cImage *Image, int Left, int Top) {  // NOLINT
+    if (!Image) return;
+    const int Width {Image->Width()}, Height {Image->Height()};
+    for (int y {0}; y < Height; ++y) {
+        const int cy {Top + y};
+        if (cy < 0 || cy >= Composed.Height()) continue;
+        for (int x {0}; x < Width; ++x) {
+            const int cx {Left + x};
+            if (cx < 0 || cx >= Composed.Width()) continue;
+            const cPoint Src {x, y}, Dst {cx, cy};
+            Composed.SetPixel(Dst, ZapAlphaOver(Image->GetPixel(Src), Composed.GetPixel(Dst)));
+        }
+    }
+}
+
+// Shortens the given text so that it fits into MaxWidth: If the text is too
+// long, it is cut off (UTF-8 safe) and the end is replaced by '...' - like
+// the truncated texts in the extended channel lists of skindesigner
+static cString ZapShortenText(const char *Text, const cFont *Font, int MaxWidth) {
+    if (!Text || !*Text || Font->Width(Text) <= MaxWidth) return Text;
+
+    const int EllipsisWidth {Font->Width("...")};
+    std::string Shortened {Text};
+    while (!Shortened.empty()) {
+        std::size_t i {Shortened.size()};  // Remove the last UTF-8 character
+        do {
+            --i;
+        } while (i > 0 && (Shortened[i] & 0xC0) == 0x80);  // Skip UTF-8 continuation bytes
+        Shortened.erase(i);
+        if (Font->Width(Shortened.c_str()) + EllipsisWidth <= MaxWidth) break;
+    }
+    return cString::sprintf("%s...", Shortened.c_str());
+}
+
+// Creates the list pixmap if not yet existing and shows it. If the pixmap
+// exists but at a different position (channellist and grouplist are anchored
+// at opposite edges) it is recreated at the given position
+bool cFlatDisplayChannel::ZapEnsureListPixmap(cPixmap *&Pixmap, const char *Name, const cRect &Rect, bool Clear) {
+    if (Pixmap && !(Pixmap->ViewPort() == Rect)) {  // Anchored at the other edge: Recreate
+        m_Osd->DestroyPixmap(Pixmap);
+        Pixmap = nullptr;
+    }
+    bool BecameVisible {false};
+    if (!Pixmap) {
+        Pixmap = CreatePixmap(m_Osd, Name, 5, Rect);
+        PixmapClear(Pixmap);
+        BecameVisible = true;
+    } else if (Clear) {
+        PixmapClear(Pixmap);
+    }
+    if (Pixmap && Pixmap->Layer() < 0) {
+        Pixmap->SetLayer(5);
+        BecameVisible = true;
+    }
+    return BecameVisible;
+}
+
+void cFlatDisplayChannel::ZapCreateInfoPixmap(const cRect &Rect) {
+    if (ZapInfoPixmap && m_Osd) {
+        m_Osd->DestroyPixmap(ZapInfoPixmap);
+        ZapInfoPixmap = nullptr;
+    }
+    if (Rect.Width() <= 0) return;  // No space left (extreme list width setting)
+    ZapInfoPixmap = CreatePixmap(m_Osd, "ZapInfoPixmap", 5, Rect);
+    PixmapFill(ZapInfoPixmap, Theme.Color(clrChannelBg));
+}
+
+void cFlatDisplayChannel::ZapHideList(cPixmap *Pixmap) {
+    if (Pixmap) {
+        PixmapClear(Pixmap);
+        Pixmap->SetLayer(-1);  // Negative layer hides the pixmap
+    }
+}
+
+void cFlatDisplayChannel::ZapHideLists() {
+    ZapHideList(ZapListPixmap);
+    ZapHideList(ZapList2Pixmap);
+    m_ZapNumHints = 0;
+    m_ZapHintIndex = 0;
+    m_ZapAnimPending = false;  // Cancel a pending show animation
+    m_ZapAnimPixmap1 = m_ZapAnimPixmap2 = nullptr;
+}
+
+void cFlatDisplayChannel::ZapHideInfo() {
+    if (ZapInfoPixmap && m_Osd) {
+        m_Osd->DestroyPixmap(ZapInfoPixmap);
+        ZapInfoPixmap = nullptr;
+    }
+}
+
+// Hides all base OSD elements (top bar, channel info display at the bottom,
+// progress bar, decor borders, weather widget and text scrollers) while one
+// of the zapcockpit list views is shown, so that only the lists are visible.
+// The original pixmap layers are stored for restoring in ZapShowBaseElements()
+void cFlatDisplayChannel::ZapHideBaseElements() {
+    if (m_ZapBaseHidden) return;
+    m_ZapBaseHidden = true;
+
+    cPixmap *BasePixmaps[] {TopBarPixmap,     TopBarIconBgPixmap,      TopBarIconPixmap,   ChanInfoTopPixmap,
+                            ChanInfoBottomPixmap, ChanLogoBgPixmap,    ChanLogoPixmap,     ChanIconsPixmap,
+                            ChanEpgImagesPixmap,  ProgressBarPixmapBg, ProgressBarPixmap,  ProgressBarMarkerPixmap,
+                            DecorPixmap};
+    m_ZapHiddenPixmaps.clear();
+    m_ZapHiddenPixmaps.reserve(sizeof(BasePixmaps) / sizeof(BasePixmaps[0]));
+    for (cPixmap *Pixmap : BasePixmaps) {
+        if (Pixmap && Pixmap->Layer() >= 0) {
+            m_ZapHiddenPixmaps.emplace_back(Pixmap, Pixmap->Layer());
+            Pixmap->SetLayer(-1);
+        }
+    }
+    Scrollers.SetVisible(false);
+    WeatherWidget.SetVisible(false);
+}
+
+void cFlatDisplayChannel::ZapShowBaseElements() {
+    if (!m_ZapBaseHidden) return;
+    m_ZapBaseHidden = false;
+
+    for (const auto &Hidden : m_ZapHiddenPixmaps)
+        Hidden.first->SetLayer(Hidden.second);
+    m_ZapHiddenPixmaps.clear();
+
+    Scrollers.SetVisible(true);
+    if (Config.ChannelWeatherShow) WeatherWidget.SetVisible(true);
+}
+
+// Fade-in/shift-in animation for newly shown list panels, executed in
+// Flush() after the panel content has been drawn (like fadetimezapcockpit/
+// shifttimezapcockpit in skindesigner themes). The lists slide in from the
+// edge they are anchored to. Runs blocking for at most one second
+void cFlatDisplayChannel::ZapRunShowAnimation() {
+    m_ZapAnimPending = false;
+    cPixmap *Pixmaps[2] {m_ZapAnimPixmap1, m_ZapAnimPixmap2};
+    m_ZapAnimPixmap1 = m_ZapAnimPixmap2 = nullptr;
+
+    const int ShiftTime {std::clamp(Config.ChannelZapcockpitShiftTime, 0, 1000)};
+    const int FadeTime {std::clamp(Config.ChannelZapcockpitFadeTime, 0, 1000)};
+    const int TotalTime {std::max(ShiftTime, FadeTime)};
+    if (TotalTime <= 0 || (!Pixmaps[0] && !Pixmaps[1])) return;
+
+    static constexpr int FrameTime {10};  // Duration of one animation step in ms
+    for (int t {FrameTime}; t < TotalTime; t += FrameTime) {
+        for (cPixmap *Pixmap : Pixmaps) {
+            if (!Pixmap || Pixmap->Layer() < 0) continue;
+            if (ShiftTime > 0) {  // Slide the content in from the anchored edge
+                const double Progress {std::min(1.0, static_cast<double>(t) / ShiftTime)};
+                const int Offset = static_cast<int>((1.0 - Progress) * Pixmap->ViewPort().Width());
+                const bool LeftAnchored {Pixmap->ViewPort().X() < m_OsdWidth / 2};
+                Pixmap->SetDrawPortPoint(cPoint(LeftAnchored ? -Offset : Offset, 0));
+            }
+            if (FadeTime > 0) {  // Fade the content in
+                const double Progress {std::min(1.0, static_cast<double>(t) / FadeTime)};
+                Pixmap->SetAlpha(static_cast<int>(ALPHA_OPAQUE * Progress));
+            }
+        }
+        m_Osd->Flush();
+        cCondWait::SleepMs(FrameTime);
+    }
+    for (cPixmap *Pixmap : Pixmaps) {  // Ensure the final state
+        if (!Pixmap) continue;
+        Pixmap->SetDrawPortPoint(cPoint(0, 0));
+        Pixmap->SetAlpha(ALPHA_OPAQUE);
+    }
+}
+
+// Shows/hides the panels for the given view. The list contents are only
+// cleared when a view of a different kind is entered, because the VDR state
+// machine partially redraws the lists while scrolling and does not repaint
+// the group list when returning from the group channel list.
+void cFlatDisplayChannel::SetViewType(eDisplaychannelView ViewType) {
+#ifdef DEBUGFUNCSCALL
+    dsyslog("flatPlus: cFlatDisplayChannel::SetViewType(%d)", ViewType);
+#endif
+    const eDisplaychannelView OldViewType {m_ZapViewType};
+    m_ZapViewType = ViewType;
+    switch (ViewType) {
+    case dcDefault:
+        ZapHideLists();
+        ZapHideInfo();
+        ZapShowBaseElements();
+        break;
+    case dcChannelInfo:  // Info pixmap is (re)created in SetChannelInfo()
+        ZapHideLists();
+        ZapShowBaseElements();
+        break;
+    case dcChannelList:
+    case dcChannelListInfo: {
+        // Keep the list content when toggling between list and list + info
+        const bool Clear {(OldViewType != dcChannelList) && (OldViewType != dcChannelListInfo)};
+        if (ZapEnsureListPixmap(ZapListPixmap, "ZapListPixmap", m_ZapListRectChan, Clear)) {
+            m_ZapAnimPending = true;  // Newly shown: Animate in Flush()
+            m_ZapAnimPixmap1 = ZapListPixmap;
+        }
+        ZapHideList(ZapList2Pixmap);
+        if (ViewType == dcChannelList) ZapHideInfo();  // Info pixmap is (re)created in SetChannelInfo()
+        ZapHideBaseElements();
+        break;
+        }
+    case dcGroupsList: {
+        // Keep the group list content when returning from the group channel list
+        const bool Clear {(OldViewType != dcGroupsList) && (OldViewType != dcGroupsChannelList) &&
+                          (OldViewType != dcGroupsChannelListInfo)};
+        if (ZapEnsureListPixmap(ZapListPixmap, "ZapListPixmap", m_ZapListRectGroup, Clear)) {
+            m_ZapAnimPending = true;  // Newly shown: Animate in Flush()
+            m_ZapAnimPixmap1 = ZapListPixmap;
+        }
+        ZapHideList(ZapList2Pixmap);
+        ZapHideInfo();
+        ZapHideBaseElements();
+        break;
+        }
+    case dcGroupsChannelList:
+    case dcGroupsChannelListInfo: {
+        // The group list (1st column) stays visible; the channellist of the
+        // selected group is shown in the 2nd column beside it
+        if (ZapEnsureListPixmap(ZapListPixmap, "ZapListPixmap", m_ZapListRectGroup, false)) {
+            m_ZapAnimPending = true;  // Newly shown: Animate in Flush()
+            m_ZapAnimPixmap1 = ZapListPixmap;
+        }
+        const bool Clear {(OldViewType != dcGroupsChannelList) && (OldViewType != dcGroupsChannelListInfo)};
+        if (ZapEnsureListPixmap(ZapList2Pixmap, "ZapList2Pixmap", m_ZapList2RectGroup, Clear)) {
+            m_ZapAnimPending = true;  // Newly shown: Animate in Flush()
+            m_ZapAnimPixmap2 = ZapList2Pixmap;
+        }
+        if (ViewType == dcGroupsChannelList) ZapHideInfo();  // Info pixmap is (re)created in SetChannelInfo()
+        ZapHideBaseElements();
+        break;
+        }
+    default:
+        break;
+    }
+}
+
+// The grouplist uses single line items, the channellists use higher items
+// with three text lines. MaxItems() is queried by the VDR state machine after
+// SetViewType(), so the value can depend on the current view
+int cFlatDisplayChannel::MaxItems() {
+    return (m_ZapViewType == dcGroupsList) ? m_ZapMaxItemsGroup : m_ZapMaxItemsChan;
+}
+
+bool cFlatDisplayChannel::KeyRightOpensChannellist() {
+    return Config.ChannelZapcockpitKeyRightOpensList;
+}
+
+// Draws one item of a channellist (channellist, group channel list, channel
+// hints): The channel logo at the left (if available) and three text lines
+// right of it: Remaining time of the running event (small font), title of
+// the running event and start-/end time plus title of the following event
+// (small font) - like the extended channel lists of skindesigner
+void cFlatDisplayChannel::ZapDrawChannelItem(cPixmap *Pixmap, const cChannel *Channel, int Index, bool Current) {
+    if (!Pixmap || !Channel || Index < 0) return;
+    // The hints panel is smaller than the full height channellist panels,
+    // so the capacity is calculated from the pixmap actually drawn to
+    if (Index >= Pixmap->ViewPort().Height() / m_ZapItemHeightChan) return;
+
+    const int Width {m_ZapColWidth};
+    const int Top {Index * m_ZapItemHeightChan};
+    const int InnerHeight {m_ZapItemHeightChan - Config.MenuItemPadding};
+    const tColor ColorFg {Theme.Color(Current ? clrItemCurrentFont : clrItemSelableFont)};
+    const tColor ColorBg {Theme.Color(Current ? clrItemCurrentBg : clrItemSelableBg)};
+
+    Pixmap->DrawRectangle(cRect(0, Top, Width, InnerHeight), ColorBg);
+
+    // Channel logo on the 'logo_background' image (like in the channel info
+    // display at the bottom) in a fixed width column at the left, so that
+    // the text lines of all items are aligned. Item background color,
+    // 'logo_background' and the logo are alpha blended in software into one
+    // image, because cPixmap::DrawImage() would replace the pixels including
+    // their alpha value (the semi transparent parts of the images would then
+    // punch through to the live picture instead of showing the layer below)
+    const int LogoHeight {InnerHeight - m_MarginItem2};
+    const int LogoWidth {static_cast<int>(LogoHeight * 1.34f)};  // 1.34 = 4:3
+    int left {m_MarginItem};
+    int BgWidth {LogoWidth}, BgHeight {LogoHeight};
+    cImage *ImgBg {ImgLoader.GetLogoBg(LogoWidth, LogoHeight)};  // Load 'logo_background'
+    if (ImgBg) {
+        BgWidth = ImgBg->Width();
+        BgHeight = ImgBg->Height();
+    }
+    cImage *img {ImgLoader.GetLogo(Channel->Name(), BgWidth - 4, BgHeight - 4)};
+    if (img) {  // Draw background and logo only if a channel logo is available
+        cImage Composed(cSize(BgWidth, BgHeight));
+        Composed.Fill(ColorBg);  // Base: Item background color
+        ZapBlendImage(Composed, ImgBg, 0, 0);  // 'logo_background' over it
+        ZapBlendImage(Composed, img, (BgWidth - img->Width()) / 2, (BgHeight - img->Height()) / 2);  // Logo on top
+        Pixmap->DrawImage(cPoint(left + (LogoWidth - BgWidth) / 2, Top + (InnerHeight - BgHeight) / 2), Composed);
+    }
+    left += LogoWidth + m_MarginItem2;
+    const int MaxTextWidth {Width - left - m_MarginItem};
+
+    // Get the running and the following event of the channel
+    const cEvent *Present {nullptr}, *Following {nullptr};
+    {
+        LOCK_SCHEDULES_READ;  // Creates local const cSchedules *Schedules
+        const cSchedule *Schedule {Schedules->GetSchedule(Channel)};
+        if (Schedule) {
+            Present = Schedule->GetPresentEvent();
+            Following = Schedule->GetFollowingEvent();
+        }
+    }
+
+    int top {Top + m_MarginItem / 2};
+    if (Present) {
+        // 1st line (small font): Remaining time of the running event
+        const int Remaining {static_cast<int>((Present->EndTime() - time(0)) / 60)};
+        const cString StrRemaining {cString::sprintf("+%d min", std::max(0, Remaining))};
+        Pixmap->DrawText(cPoint(left, top), *StrRemaining, ColorFg, ColorBg, m_ZapFontSml, MaxTextWidth);
+        top += m_ZapFontSmlHeight;
+
+        // 2nd line: Title of the running event
+        Pixmap->DrawText(cPoint(left, top), *ZapShortenText(Present->Title(), m_ZapFont, MaxTextWidth), ColorFg,
+                         ColorBg, m_ZapFont, MaxTextWidth);
+        top += m_ZapFontHeight;
+    } else {
+        // No EPG data: Show the channel name instead, so the item is not empty
+        top += m_ZapFontSmlHeight;
+        Pixmap->DrawText(cPoint(left, top), *ZapShortenText(Channel->Name(), m_ZapFont, MaxTextWidth), ColorFg,
+                         ColorBg, m_ZapFont, MaxTextWidth);
+        top += m_ZapFontHeight;
+    }
+
+    if (Following) {
+        // 3rd line (small font): Start-/end time and title of the following event
+        const cString StrFollowing {cString::sprintf("%s–%s: %s", *Following->GetTimeString(),
+                                                      *Following->GetEndTimeString(), Following->Title())};
+        Pixmap->DrawText(cPoint(left, top), *ZapShortenText(*StrFollowing, m_ZapFontSml, MaxTextWidth), ColorFg,
+                         ColorBg, m_ZapFontSml, MaxTextWidth);
+    }
+}
+
+// Draws one item of the grouplist (one text line)
+void cFlatDisplayChannel::ZapDrawGroupItem(cPixmap *Pixmap, const cString &Text, int Index, bool Current) {
+    if (!Pixmap || Index < 0) return;
+    if (Index >= Pixmap->ViewPort().Height() / m_ZapItemHeightGroup) return;
+
+    const int Width {m_ZapColWidth};
+    const int Top {Index * m_ZapItemHeightGroup};
+    const tColor ColorFg {Theme.Color(Current ? clrItemCurrentFont : clrItemSelableFont)};
+    const tColor ColorBg {Theme.Color(Current ? clrItemCurrentBg : clrItemSelableBg)};
+
+    Pixmap->DrawRectangle(cRect(0, Top, Width, m_ZapFontHeight), ColorBg);
+    Pixmap->DrawText(cPoint(m_MarginItem, Top), *ZapShortenText(*Text, m_ZapFont, Width - m_MarginItem2), ColorFg,
+                     ColorBg, m_ZapFont, Width - m_MarginItem2);
+}
+
+// Also used for the channellist of the selected group: The VDR state machine
+// draws that list via SetChannelList() too, so the target panel is selected
+// by the current view type
+void cFlatDisplayChannel::SetChannelList(const cChannel *Channel, int Index, bool Current) {
+    if (!Channel) return;
+    ZapDrawChannelItem(ZapIsGroupChannelView() ? ZapList2Pixmap : ZapListPixmap, Channel, Index, Current);
+}
+
+void cFlatDisplayChannel::SetGroupList(const char *Group, int NumChannels, int Index, bool Current) {
+    const cString Text = cString::sprintf("%s (%d)", Group ? Group : "", NumChannels);
+    ZapDrawGroupItem(ZapListPixmap, Text, Index, Current);
+}
+
+void cFlatDisplayChannel::SetGroupChannelList(const cChannel *Channel, int Index, bool Current) {
+    if (!Channel) return;  // Not called by the current patch, but part of the interface
+    ZapDrawChannelItem(ZapList2Pixmap, Channel, Index, Current);
+}
+
+void cFlatDisplayChannel::ClearList() {
+    PixmapClear(ZapIsGroupChannelView() ? ZapList2Pixmap : ZapListPixmap);
+}
+
+void cFlatDisplayChannel::SetNumChannelHints(int Num) {
+    // Hints are shown in a smaller panel between top bar and channel info
+    // display while entering a channel number; the other OSD elements stay
+    // visible there (unlike in the full height list views)
+    ZapEnsureListPixmap(ZapListPixmap, "ZapListPixmap", m_ZapHintsRect, true);
+    m_ZapNumHints = Num;
+    m_ZapHintIndex = 0;
+}
+
+void cFlatDisplayChannel::SetChannelHint(const cChannel *Channel) {
+    if (!Channel) return;
+    ZapDrawChannelItem(ZapListPixmap, Channel, m_ZapHintIndex++, false);
+}
+
+// Draws the detailed EPG info for the given channel. Depending on the current
+// view type the full width (dcChannelInfo: 2nd 'Ok' on the current channel) or
+// the area beside the visible list panels is used.
+void cFlatDisplayChannel::SetChannelInfo(const cChannel *Channel) {
+    if (!Channel) return;
+
+    const cRect &Rect {(m_ZapViewType == dcChannelInfo)
+                           ? m_ZapInfoWideRect
+                           : (m_ZapViewType == dcGroupsChannelListInfo) ? m_ZapInfoRectGroup : m_ZapInfoRectChan};
+    ZapCreateInfoPixmap(Rect);
+    if (!ZapInfoPixmap) return;
+
+    const int Width {Rect.Width()};
+    const int Height {Rect.Height()};
+    const int MaxTextWidth {Width - m_MarginItem2 * 2};
+    int top {m_MarginItem};
+
+    // Header: Channel number and name
+    const cString Header {cString::sprintf("%d  %s", Channel->Number(), Channel->Name())};
+    ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, top), *ZapShortenText(*Header, m_Font, MaxTextWidth),
+                            Theme.Color(clrChannelFontTitle),
+                            Theme.Color(clrChannelBg), m_Font, MaxTextWidth);
+    top += m_FontHeight;
+    ZapInfoPixmap->DrawRectangle(cRect(m_MarginItem2, top + m_MarginItem / 2, MaxTextWidth, 3),
+                                 Theme.Color(clrChannelFontTitle));
+    top += m_MarginItem2 + 3;
+
+    const cEvent *Present {nullptr}, *Following {nullptr};
+    {
+        LOCK_SCHEDULES_READ;  // Creates local const cSchedules *Schedules
+        const cSchedule *Schedule {Schedules->GetSchedule(Channel)};
+        if (Schedule) {
+            Present = Schedule->GetPresentEvent();
+            Following = Schedule->GetFollowingEvent();
+        }
+    }
+
+    if (!Present) {
+        ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, top), tr("No EPG info available."),
+                                Theme.Color(clrChannelFontEpg), Theme.Color(clrChannelBg), m_FontSml, MaxTextWidth);
+        return;
+    }
+
+    // Reserve one line at the bottom for the following event
+    const int BottomFollowing {(Following) ? Height - m_FontSmlHeight - m_MarginItem : Height};
+
+    // Present event: Time, title, short text and description
+    const cString StrTime {cString::sprintf("%s–%s  (%d min)", *Present->GetTimeString(),
+                                             *Present->GetEndTimeString(), Present->Duration() / 60)};
+    ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, top), *StrTime, Theme.Color(clrChannelFontEpg),
+                            Theme.Color(clrChannelBg), m_FontSml, MaxTextWidth);
+    top += m_FontSmlHeight + m_MarginItem;
+
+    if (top + m_FontHeight <= BottomFollowing) {
+        ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, top), *ZapShortenText(Present->Title(), m_Font, MaxTextWidth),
+                                Theme.Color(clrChannelFontEpg), Theme.Color(clrChannelBg), m_Font, MaxTextWidth);
+        top += m_FontHeight;
+    }
+    if (!isempty(Present->ShortText()) && (top + m_FontSmlHeight <= BottomFollowing)) {
+        ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, top),
+                                *ZapShortenText(Present->ShortText(), m_FontSml, MaxTextWidth),
+                                Theme.Color(clrChannelFontEpgFollow), Theme.Color(clrChannelBg), m_FontSml,
+                                MaxTextWidth);
+        top += m_FontSmlHeight;
+    }
+    top += m_MarginItem;
+
+    if (!isempty(Present->Description())) {  // Description (wrapped, cut off at the bottom)
+        // cTextWrapper Description(Present->Description(), m_FontSml, MaxTextWidth);
+        cTextFloatingWrapper Description;
+        Description.Set(Present->Description(), m_FontSml, MaxTextWidth);
+        for (int i {0}; i < Description.Lines() && (top + m_FontSmlHeight <= BottomFollowing); ++i) {
+            ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, top), Description.GetLine(i),
+                                    Theme.Color(clrChannelFontEpg), Theme.Color(clrChannelBg), m_FontSml,
+                                    MaxTextWidth);
+            top += m_FontSmlHeight;
+        }
+    }
+
+    if (Following) {  // Following event in the reserved line at the bottom
+        const cString Next = cString::sprintf("%s  %s%s%s", *Following->GetTimeString(), Following->Title(),
+                                              isempty(Following->ShortText()) ? "" : " - ",
+                                              isempty(Following->ShortText()) ? "" : Following->ShortText());
+        ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, Height - m_FontSmlHeight),
+                                *ZapShortenText(*Next, m_FontSml, MaxTextWidth),
+                                Theme.Color(clrChannelFontEpgFollow), Theme.Color(clrChannelBg), m_FontSml,
+                                MaxTextWidth);
+    }
+}
+#endif  // USE_ZAPCOCKPIT
+
 void cFlatDisplayChannel::SignalQualityDraw() {
 #ifdef DEBUGFUNCSCALL
     dsyslog("flatPlus: cFlatDisplayChannel::SignalQualityDraw()");
@@ -573,6 +1161,12 @@ void cFlatDisplayChannel::DvbapiInfoDraw() {
 }
 
 void cFlatDisplayChannel::Flush() {
+#ifdef USE_ZAPCOCKPIT
+    // Run a pending show animation of the zapcockpit lists after their
+    // content has been drawn by the VDR state machine
+    if (m_ZapAnimPending) ZapRunShowAnimation();
+#endif
+
     if (m_Present) {
         const time_t now {time(0)};
         const time_t Current {(now > m_Present->StartTime()) ? now - m_Present->StartTime() : 0};

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -535,25 +535,17 @@ void cFlatDisplayChannel::DvbapiInfoDraw() {
 
     if (ecmInfo.hops < 0 || ecmInfo.ecmtime == 0 || ecmInfo.ecmtime > 9999) return;
 
-    int left {m_SignalStrengthRight + m_MarginItem2};
-    static int CachedProgressBarHeight {-1};
-    static int CachedFontAscender {0};
-    static int CachedGlyphSize {0};
-    const int ProgressBarHeight {Config.decorProgressSignalSize * 2 + m_MarginItem};
+    int left {m_SignalStrengthRight + m_MarginItem10};
+    const int SignalBarsHeight {Config.decorProgressSignalSize * 2 + m_MarginItem};
     static constexpr uint32_t kCharCode {0x0044};  // U+0044 LATIN CAPITAL LETTER D
 
-    if (CachedProgressBarHeight != ProgressBarHeight) {
-        CachedProgressBarHeight = ProgressBarHeight;
-        CachedFontAscender = FontCache.GetFontAscender(Setup.FontOsd, ProgressBarHeight);
-        CachedGlyphSize = FontCache.GetGlyphSize(Setup.FontOsd, kCharCode, ProgressBarHeight);
-    }
+    const int FontAscender {FontCache.GetFontAscender(Setup.FontOsd, SignalBarsHeight)};
+    const int GlyphSize {FontCache.GetGlyphSize(Setup.FontOsd, kCharCode, SignalBarsHeight)};
+    const int TopOffset {(FontAscender - GlyphSize) / 2};  // Center vertically
+    const int top {m_HeightBottom - SignalBarsHeight - TopOffset - m_MarginItem};
 
-    const int TopOffset {(CachedFontAscender - CachedGlyphSize) / 2};  // Center vertically
-    const int top {m_HeightBottom - ProgressBarHeight - m_MarginItem -
-                   TopOffset};  // One margin for progress bar to bottom
-
-    m_DvbapiInfoFont = FontCache.GetFont(Setup.FontOsd, ProgressBarHeight);
-    const int DvbapiInfoFontHeight {FontCache.GetFontHeight(Setup.FontOsd, ProgressBarHeight)};
+    m_DvbapiInfoFont = FontCache.GetFont(Setup.FontOsd, SignalBarsHeight);
+    const int DvbapiInfoFontHeight {FontCache.GetFontHeight(Setup.FontOsd, SignalBarsHeight)};
 
     cString DvbapiInfoText {"DVBAPI: "};
     ChanInfoBottomPixmap->DrawText(cPoint(left, top), *DvbapiInfoText, Theme.Color(clrChannelSignalFont),

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -586,9 +586,8 @@ void cFlatDisplayChannel::DvbapiInfoDraw() {
 void cFlatDisplayChannel::Flush() {
     if (m_Present) {
         const time_t now {time(0)};
-        const int Current = (now > m_Present->StartTime()) ? now - m_Present->StartTime() : 0;  // Narrowing conversion
-        const int Total {m_Present->Duration()};
-        ProgressBarDraw(Current, Total);
+        const time_t Current {(now > m_Present->StartTime()) ? now - m_Present->StartTime() : 0};
+        ProgressBarDraw(Current, m_Present->Duration());
     }
 
     if (Config.ChannelIconsShow) {

--- a/displaychannel.h
+++ b/displaychannel.h
@@ -8,9 +8,17 @@
 #pragma once
 
 #include <vdr/status.h>
+
+#include <utility>
+#include <vector>
+
 #include "./baserender.h"
 
+#ifdef USE_ZAPCOCKPIT
+class cFlatDisplayChannel : public cFlatBaseRender, public cSkinDisplayChannelExtended, public cStatus {
+#else
 class cFlatDisplayChannel : public cFlatBaseRender, public cSkinDisplayChannel, public cStatus {
+#endif
  public:
         explicit cFlatDisplayChannel(bool WithInfo);
         ~cFlatDisplayChannel() override;
@@ -18,6 +26,22 @@ class cFlatDisplayChannel : public cFlatBaseRender, public cSkinDisplayChannel, 
         void SetEvents(const cEvent *Present, const cEvent *Following) override;
         void SetMessage(eMessageType Type, const char *Text) override;
         void Flush() override;
+
+#ifdef USE_ZAPCOCKPIT
+        // Zapcockpit (extended channel display) support
+        // The whole input handling is done inside the patched VDR
+        // (cDisplayChannelExtended in menu.c), the skin only renders.
+        void SetViewType(eDisplaychannelView ViewType) override;
+        int MaxItems() override;
+        bool KeyRightOpensChannellist() override;
+        void SetChannelInfo(const cChannel *Channel) override;
+        void SetChannelList(const cChannel *Channel, int Index, bool Current) override;
+        void SetGroupList(const char *Group, int NumChannels, int Index, bool Current) override;
+        void SetGroupChannelList(const cChannel *Channel, int Index, bool Current) override;
+        void ClearList() override;
+        void SetNumChannelHints(int Num) override;
+        void SetChannelHint(const cChannel *Channel) override;
+#endif
 
         void PreLoadImages();
 
@@ -54,6 +78,66 @@ class cFlatDisplayChannel : public cFlatBaseRender, public cSkinDisplayChannel, 
         cTextScrollers Scrollers;
 
         bool m_IsRadioChannel {false};
+
+#ifdef USE_ZAPCOCKPIT
+        // Zapcockpit rendering
+        // The group list and the channellist of the selected group are two
+        // separate panels which are visible side by side, because the VDR
+        // state machine does not redraw the group list when returning from
+        // the group channel list (dcGroupsChannelList -> dcGroupsList).
+        // The lists slide in from the side of the pressed key: The list opened
+        // with 'right' is anchored at the left edge, the list opened with
+        // 'left' at the right edge (mirrored when the setup option
+        // 'Zapcockpit: Key right opens channellist' is disabled).
+        // While a list view is shown, all other OSD elements (top bar and the
+        // channel info display at the bottom) are hidden.
+        cPixmap *ZapListPixmap {nullptr};      // 1st column: Channellist, grouplist, channel hints
+        cPixmap *ZapList2Pixmap {nullptr};     // 2nd column: Channellist of the selected group
+        cPixmap *ZapInfoPixmap {nullptr};      // Detailed EPG info panel (beside the lists or full width)
+
+        eDisplaychannelView m_ZapViewType {dcDefault};
+        cRect m_ZapListRectChan {0, 0, 0, 0};   // Channellist panel
+        cRect m_ZapInfoRectChan {0, 0, 0, 0};   // Info panel beside the channellist
+        cRect m_ZapListRectGroup {0, 0, 0, 0};  // Grouplist panel (opposite side of the channellist)
+        cRect m_ZapList2RectGroup {0, 0, 0, 0};  // Channellist of the selected group (beside the grouplist)
+        cRect m_ZapInfoRectGroup {0, 0, 0, 0};   // Info panel beside the group channel list
+        cRect m_ZapInfoWideRect {0, 0, 0, 0};    // Info panel over the full width (dcChannelInfo)
+        cRect m_ZapHintsRect {0, 0, 0, 0};       // Channel hints panel (base OSD elements stay visible)
+        // Fonts of the list items: The same fonts as in the channel info
+        // display at the bottom, scaled by 'ChannelZapcockpitFontSize'
+        cFont *m_ZapFont {nullptr}, *m_ZapFontSml {nullptr};
+        int m_ZapFontHeight {0}, m_ZapFontSmlHeight {0};
+
+        int m_ZapColWidth {0};                 // Width of one list column
+        int m_ZapItemHeightChan {0};           // Height of one channellist item (logo + 3 text lines)
+        int m_ZapItemHeightGroup {0};          // Height of one grouplist item (one text line)
+        int m_ZapMaxItemsChan {0};             // Number of items fitting into a channellist panel
+        int m_ZapMaxItemsGroup {0};            // Number of items fitting into the grouplist panel
+        int m_ZapHintIndex {0};                // Running index while drawing channel hints
+        int m_ZapNumHints {0};                 // Number of currently displayed channel hints
+
+        bool m_ZapBaseHidden {false};          // Base OSD elements currently hidden?
+        std::vector<std::pair<cPixmap *, int>> m_ZapHiddenPixmaps;  // Hidden pixmaps with their original layer
+
+        // Show animation (fade-in/shift-in of newly shown list panels),
+        // executed in Flush() after the panel content has been drawn
+        bool m_ZapAnimPending {false};
+        cPixmap *m_ZapAnimPixmap1 {nullptr}, *m_ZapAnimPixmap2 {nullptr};
+
+        bool ZapIsGroupChannelView() const {
+            return (m_ZapViewType == dcGroupsChannelList) || (m_ZapViewType == dcGroupsChannelListInfo);
+        }
+        bool ZapEnsureListPixmap(cPixmap *&Pixmap, const char *Name, const cRect &Rect, bool Clear);  // NOLINT
+        void ZapCreateInfoPixmap(const cRect &Rect);
+        void ZapHideList(cPixmap *Pixmap);
+        void ZapHideLists();
+        void ZapHideInfo();
+        void ZapHideBaseElements();
+        void ZapShowBaseElements();
+        void ZapRunShowAnimation();
+        void ZapDrawChannelItem(cPixmap *Pixmap, const cChannel *Channel, int Index, bool Current);
+        void ZapDrawGroupItem(cPixmap *Pixmap, const cString &Text, int Index, bool Current);
+#endif
 
         void SignalQualityDraw();
         void ChannelIconsDraw(const cChannel *Channel, bool Resolution);

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -4272,7 +4272,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetWeather(int wLeft, int wWidth, int Conte
     cImage *ImgUmbrella {ImgLoader.GetIcon("widgets/umbrella", m_FontHeight, m_FontHeight - m_MarginItem2)};
     cImage *img {nullptr};
     const int Middle {(m_FontHeight - m_FontTempSmlHeight) / 2};  // Vertical center
-    const int TempSmlWidth {FontCache.GetStringWidth(m_FontTempSmlName, m_FontTempSmlHeight, "-00,0°C")};  // Width
+    const int TempSmlWidth {FontCache.GetStringWidth(m_FontTempSmlName, m_FontTempSmlHeight, "-00,0 °C")};  // Width
     const int16_t MainMenuWidgetWeatherDays =
         std::min(Config.MainMenuWidgetWeatherDays, wd.kMaxDays);                           // Narrowing conversion
     if (Config.MainMenuWidgetWeatherType == 0) {                                           // Short
@@ -4323,7 +4323,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetWeather(int wLeft, int wWidth, int Conte
         // Space between temperature and precipitation
         const int TempSmlSpaceWidth {FontCache.GetStringWidth(m_FontTempSmlName, m_FontTempSmlHeight, " ")};
         // Max. width of precipitation string
-        const int TempSmlPrecWidth {FontCache.GetStringWidth(m_FontTempSmlName, m_FontTempSmlHeight, "100%")};
+        const int TempSmlPrecWidth {FontCache.GetStringWidth(m_FontTempSmlName, m_FontTempSmlHeight, "100 %")};
         const int DayStringWidth {FontCache.GetStringWidth(m_FontName, m_FontHeight, "Mon")};  // Mon, Mo.
         for (int16_t i {0}; i < MainMenuWidgetWeatherDays; ++i) {
             if (ContentTop + m_MarginItem > MenuPixmapViewPortHeight) break;

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -3138,13 +3138,11 @@ cString cFlatDisplayMenu::GetRecCounts() const {
     if (!isempty(*m_RecFolder) && m_LastItemRecordingLevel > 0) {
         const int RecordingLevel {m_LastItemRecordingLevel - 1};  // Folder where the recording is stored in
         cString RecFolder2 {""};
-        std::string_view sv1 {*m_RecFolder}, sv2;  // For efficient comparison
         if (m_MenuCategory == mcRecording) {
             LOCK_RECORDINGS_READ;  // Creates local const cRecordings *Recordings
             for (const cRecording *Rec {Recordings->First()}; Rec; Rec = Recordings->Next(Rec)) {
                 RecFolder2 = *GetRecordingName(Rec, RecordingLevel);
-                sv2 = *RecFolder2;
-                if (sv1 == sv2) {  // Compare recording folder with current folder
+                if (strcmp(*m_RecFolder, *RecFolder2) == 0) {  // Compare recording folder with current folder
                     ++RecCount;
                     if (Rec->IsNew()) ++RecNewCount;
                 }
@@ -3155,8 +3153,7 @@ cString cFlatDisplayMenu::GetRecCounts() const {
             LOCK_DELETEDRECORDINGS_READ;  // Creates local const cRecordings *DeletedRecordings
             for (const cRecording *Rec {DeletedRecordings->First()}; Rec; Rec = DeletedRecordings->Next(Rec)) {
                 RecFolder2 = *GetRecordingName(Rec, RecordingLevel);
-                sv2 = *RecFolder2;
-                if (sv1 == sv2) {  // Compare recording folder with current folder
+                if (strcmp(*m_RecFolder, *RecFolder2) == 0) {  // Compare recording folder with current folder
                     ++RecCount;
                     if (Rec->IsNew()) ++RecNewCount;
                 }

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -18,7 +18,6 @@
 #include <vdr/videodir.h>
 
 #include <dirent.h>
-#include <functional>  // std::less
 #include <locale>
 #include <sstream>
 #include <string_view>
@@ -3386,6 +3385,17 @@ void cFlatDisplayMenu::DrawProgressBarFromText(const cRect &rec, const cRect &re
 }
 
 /* Widgets */
+
+// Static widget entry: position, pointer to enable flag, member function pointer
+struct WidgetEntry {
+    int position;
+    int *enableFlag;
+    int (cFlatDisplayMenu::*drawFn)(int, int, int, int);
+};
+
+// Comparator for sorting WidgetEntry by position
+static bool WidgetEntryCompare(const WidgetEntry &a, const WidgetEntry &b) { return a.position < b.position; }
+
 void cFlatDisplayMenu::DrawMainMenuWidgets() {
 #ifdef DEBUGFUNCSCALL
     dsyslog("flatPlus: cFlatDisplayMenu::DrawMainMenuWidgets()");
@@ -3399,7 +3409,6 @@ void cFlatDisplayMenu::DrawMainMenuWidgets() {
                      Config.decorBorderMenuContentSize + Config.decorBorderMenuItemSize};
     const int wTop {m_TopBarHeight + m_MarginItem + Config.decorBorderTopBarSize * 2 +
                     Config.decorBorderMenuContentSize};
-
     const int wWidth {m_OsdWidth - wLeft - Config.decorBorderMenuContentSize};
     const int wHeight {MenuPixmapViewPortHeight - m_MarginItem2};
 
@@ -3409,94 +3418,37 @@ void cFlatDisplayMenu::DrawMainMenuWidgets() {
     ContentWidget.SetBGColor(Theme.Color(clrMenuRecBg));
     ContentWidget.SetScrollingActive(false);
 
-    std::vector<std::pair<int, const char *>> widgets;
-    widgets.reserve(10);  // Set to at least 10 entry's
+    // Build a static table of all possible widgets with their draw function pointers.
+    // 'position' is the configured position; we sort by it at runtime.
+    WidgetEntry entries[9] {
+        {Config.MainMenuWidgetDVBDevicesPosition, &Config.MainMenuWidgetDVBDevicesShow,
+         &cFlatDisplayMenu::DrawMainMenuWidgetDVBDevices},
+        {Config.MainMenuWidgetActiveTimerPosition, &Config.MainMenuWidgetActiveTimerShow,
+         &cFlatDisplayMenu::DrawMainMenuWidgetActiveTimers},
+        {Config.MainMenuWidgetLastRecPosition, &Config.MainMenuWidgetLastRecShow,
+         &cFlatDisplayMenu::DrawMainMenuWidgetLastRecordings},
+        {Config.MainMenuWidgetSystemInfoPosition, &Config.MainMenuWidgetSystemInfoShow,
+         &cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation},
+        {Config.MainMenuWidgetSystemUpdatesPosition, &Config.MainMenuWidgetSystemUpdatesShow,
+         &cFlatDisplayMenu::DrawMainMenuWidgetSystemUpdates},
+        {Config.MainMenuWidgetTemperaturesPosition, &Config.MainMenuWidgetTemperaturesShow,
+         &cFlatDisplayMenu::DrawMainMenuWidgetTemperatures},
+        {Config.MainMenuWidgetTimerConflictsPosition, &Config.MainMenuWidgetTimerConflictsShow,
+         &cFlatDisplayMenu::DrawMainMenuWidgetTimerConflicts},
+        {Config.MainMenuWidgetCommandPosition, &Config.MainMenuWidgetCommandShow,
+         &cFlatDisplayMenu::DrawMainMenuWidgetCommand},
+        {Config.MainMenuWidgetWeatherPosition, &Config.MainMenuWidgetWeatherShow,
+         &cFlatDisplayMenu::DrawMainMenuWidgetWeather}};
 
-    struct WidgetConfig {
-        int &ShowFlag;
-        int &position;
-        const char *name;
-    };
-
-    const WidgetConfig WidgetConfigs[] {
-        {Config.MainMenuWidgetDVBDevicesShow, Config.MainMenuWidgetDVBDevicesPosition, "dvb_devices"},
-        {Config.MainMenuWidgetActiveTimerShow, Config.MainMenuWidgetActiveTimerPosition, "active_timer"},
-        {Config.MainMenuWidgetLastRecShow, Config.MainMenuWidgetLastRecPosition, "last_recordings"},
-        {Config.MainMenuWidgetSystemInfoShow, Config.MainMenuWidgetSystemInfoPosition, "system_information"},
-        {Config.MainMenuWidgetSystemUpdatesShow, Config.MainMenuWidgetSystemUpdatesPosition, "system_updates"},
-        {Config.MainMenuWidgetTemperaturesShow, Config.MainMenuWidgetTemperaturesPosition, "temperatures"},
-        {Config.MainMenuWidgetTimerConflictsShow, Config.MainMenuWidgetTimerConflictsPosition, "timer_conflicts"},
-        {Config.MainMenuWidgetCommandShow, Config.MainMenuWidgetCommandPosition, "custom_command"},
-        {Config.MainMenuWidgetWeatherShow, Config.MainMenuWidgetWeatherPosition, "weather"}};
-
-    // Populates the widgets vector with enabled widgets based on configuration
-    // Iterates through predefined widget configurations and adds widgets to the vector
-    // if their corresponding show flag is enabled, preserving their configured position
-    for (const auto &cfg : WidgetConfigs) {
-        if (cfg.ShowFlag) { widgets.emplace_back(std::make_pair(cfg.position, cfg.name)); }
-    }
-
-    // Define a type for the widget drawing functions
-    using WidgetDrawFunction = std::function<int(int, int, int, int)>;
-
-    // Create a map that associates widget names with their drawing functions
-    // Works as long all strings are different. Else we must use std::string
-    std::unordered_map<const char *, WidgetDrawFunction> WidgetDrawers {
-        {"dvb_devices",
-         [this](int left, int width, int top, int MenuPixmapViewPortHeight) {
-             return DrawMainMenuWidgetDVBDevices(left, width, top, MenuPixmapViewPortHeight);
-         }},
-        {"active_timer",
-         [this](int left, int width, int top, int MenuPixmapViewPortHeight) {
-             return DrawMainMenuWidgetActiveTimers(left, width, top, MenuPixmapViewPortHeight);
-         }},
-        {"last_recordings",
-         [this](int left, int width, int top, int MenuPixmapViewPortHeight) {
-             return DrawMainMenuWidgetLastRecordings(left, width, top, MenuPixmapViewPortHeight);
-         }},
-        {"system_information",
-         [this](int left, int width, int top, int MenuPixmapViewPortHeight) {
-             return DrawMainMenuWidgetSystemInformation(left, width, top, MenuPixmapViewPortHeight);
-         }},
-        {"system_updates",
-         [this](int left, int width, int top, int MenuPixmapViewPortHeight) {
-             return DrawMainMenuWidgetSystemUpdates(left, width, top, MenuPixmapViewPortHeight);
-         }},
-        {"temperatures",
-         [this](int left, int width, int top, int MenuPixmapViewPortHeight) {
-             return DrawMainMenuWidgetTemperatures(left, width, top, MenuPixmapViewPortHeight);
-         }},
-        {"timer_conflicts",
-         [this](int left, int width, int top, int MenuPixmapViewPortHeight) {
-             return DrawMainMenuWidgetTimerConflicts(left, width, top, MenuPixmapViewPortHeight);
-         }},
-        {"custom_command",
-         [this](int left, int width, int top, int MenuPixmapViewPortHeight) {
-             return DrawMainMenuWidgetCommand(left, width, top, MenuPixmapViewPortHeight);
-         }},
-        {"weather", [this](int left, int width, int top, int MenuPixmapViewPortHeight) {
-             return DrawMainMenuWidgetWeather(left, width, top, MenuPixmapViewPortHeight);
-         }}};
-
-    // Sort the widgets based on their positions
-    std::sort(widgets.begin(), widgets.end(), PairCompareIntString);
+    // Sort entries by configured 'position'
+    std::sort(std::begin(entries), std::end(entries), WidgetEntryCompare);
 
     int AddHeight {0}, ContentTop {0};
-    // Process widgets
-    for (const auto &PairWidget : widgets) {
-        std::string_view widget {PairWidget.second};
-
-        // Look up the widget drawer function
-        auto drawerIt {WidgetDrawers.find(widget.data())};
-        if (drawerIt != WidgetDrawers.end()) {
-            // Call the drawer function and update ContentTop
-            AddHeight = drawerIt->second(wLeft, wWidth, ContentTop, MenuPixmapViewPortHeight);
-            if (AddHeight > 0) ContentTop = AddHeight + m_MarginItem;
-        } else {
-            // Handle unknown widget type
-            esyslog("flatPlus: DrawMainMenuWidget() Unknown widget type: %s", widget.data());
-        }
-    }  // for widgets
+    for (const auto &e : entries) {
+        if (!*(e.enableFlag)) continue;  // Widget not enabled — skip
+        AddHeight = (this->*(e.drawFn))(wLeft, wWidth, ContentTop, MenuPixmapViewPortHeight);
+        if (AddHeight > 0) ContentTop = AddHeight + m_MarginItem;
+    }
 
     ContentWidget.CreatePixmaps(false);
     ContentWidget.Draw();

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -1488,7 +1488,7 @@ void cFlatDisplayMenu::DrawRecordingStateIcon(const cRecording *Recording, int L
         if (Current) img = ImgLoader.GetIcon("recording_new_cur", m_FontHeight, m_FontHeight);
         if (!img) img = ImgLoader.GetIcon("recording_new", m_FontHeight, m_FontHeight);
     } else {
-        const cString IconName = *GetRecordingSeenIcon(Recording->NumFrames(), Recording->GetResume());
+        const cString IconName {GetRecordingSeenIcon(Recording->NumFrames(), Recording->GetResume())};
         if (Current) {
             const cString IconNameCur = cString::sprintf("%s_cur", *IconName);
             img = ImgLoader.GetIcon(*IconNameCur, m_FontHeight, m_FontHeight);
@@ -1510,8 +1510,8 @@ void cFlatDisplayMenu::DrawRecordingStateIcon(const cRecording *Recording, int L
  */
 void cFlatDisplayMenu::DrawRecordingFormatIcon(const cRecording *Recording, int Left, int Top) {
     static constexpr float kIconFormatHeightRatio {1.0 / 3.0};
-    const cString IconName = *GetRecordingFormatIcon(Recording);    // Show video format icon (SD, HD, UHD)
-    const int ImageHeight = m_FontHeight * kIconFormatHeightRatio;  // 1/3 height. Narrowing conversion
+    const cString IconName {GetRecordingFormatIcon(Recording)};    // Show video format icon (SD, HD, UHD)
+    const int ImageHeight {static_cast<int>(m_FontHeight * kIconFormatHeightRatio)};  // 1/3 height of font height
     const cImage *img {ImgLoader.GetIcon(*IconName, kIconMaxSize, ImageHeight)};
     if (img) {
         const int ImageTop {Top + m_FontHeight - m_FontAscender};
@@ -1533,10 +1533,10 @@ void cFlatDisplayMenu::DrawRecordingFormatIcon(const cRecording *Recording, int 
  * @param Current Boolean indicating whether the recording is the current item.
  */
 void cFlatDisplayMenu::DrawRecordingErrorIcon(const cRecording *Recording, int Left, int Top, bool Current) {
-    const cString IconName = *GetRecordingErrorIcon(Recording->Info()->Errors());
+    const cString IconName {GetRecordingErrorIcon(Recording->Info()->Errors())};
     cImage *img {nullptr};
     if (Current) {
-        const cString IconNameCur = cString::sprintf("%s_cur", *IconName);
+        const cString IconNameCur {cString::sprintf("%s_cur", *IconName)};
         img = ImgLoader.GetIcon(*IconNameCur, m_FontHeight, m_FontHeight);
     }
     if (!img) img = ImgLoader.GetIcon(*IconName, m_FontHeight, m_FontHeight);
@@ -1559,7 +1559,7 @@ void cFlatDisplayMenu::DrawRecordingErrorIcon(const cRecording *Recording, int L
 int cFlatDisplayMenu::DrawRecordingIcon(const char *IconName, int Left, int Top, bool Current) {
     cImage *img {nullptr};
     if (Current) {
-        const cString IconNameCur = cString::sprintf("%s_cur", IconName);
+        const cString IconNameCur {cString::sprintf("%s_cur", IconName)};
         img = ImgLoader.GetIcon(*IconNameCur, m_FontHeight, m_FontHeight);
     }
     if (!img) img = ImgLoader.GetIcon(IconName, m_FontHeight, m_FontHeight);
@@ -1595,7 +1595,7 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
         m_LastItemRecordingLevel = Level;
         LastMenuCategory = m_MenuCategory;
         m_RecCounts = *GetRecCounts();
-        const cString NewTitle = cString::sprintf("%s %s", *m_LastTitle, *m_RecCounts);
+        const cString NewTitle {cString::sprintf("%s %s", *m_LastTitle, *m_RecCounts)};
         TopBarSetTitle(*NewTitle, false);  // Do not clear
     }
 
@@ -1640,7 +1640,7 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
     int Left {Config.decorBorderMenuItemSize + m_MarginItem};
     int Top {y};
     const bool IsRecording {Total == 0};  // Recording or a folder
-    cString RecName = *GetRecordingName(Recording, Level);
+    cString RecName {GetRecordingName(Recording, Level)};
     if (Config.MenuItemRecordingClearPercent && IsRecording) {  // Remove leading percent sign(s) from RecName
         while (!isempty(*RecName) && RecName[0] == '%')
             RecName = cString(*RecName + 1);
@@ -1655,7 +1655,7 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
             Left = DrawRecordingIcon("recording", Left, Top, Current);
 
             const div_t TimeHM {std::div((Recording->LengthInSeconds() + 30) / 60, 60)};
-            const cString Length = cString::sprintf("%02d:%02d", TimeHM.quot, TimeHM.rem);
+            const cString Length {cString::sprintf("%02d:%02d", TimeHM.quot, TimeHM.rem)};
             Buffer = cString::sprintf("%s  %s  Σ%s ", *ShortDateString(Recording->Start()),
                                       *TimeString(Recording->Start()), *Length);
 
@@ -1764,7 +1764,7 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
             }
 
             const div_t TimeHM {std::div((Recording->LengthInSeconds() + 30) / 60, 60)};
-            const cString Length = cString::sprintf("%02d:%02d", TimeHM.quot, TimeHM.rem);
+            const cString Length {cString::sprintf("%02d:%02d", TimeHM.quot, TimeHM.rem)};
             Buffer = cString::sprintf("%s  %s  Σ%s ", *ShortDateString(Recording->Start()),
                                       *TimeString(Recording->Start()), *Length);
 
@@ -2026,7 +2026,8 @@ void cFlatDisplayMenu::DrawEventInfo(const cEvent *Event) {
         }  // if Components
     }  // EpgAdditionalInfoShow
 
-    const int HeadIconLeft = DrawContentHeadFskGenre(Fsk, GenreIcons);
+    // Draw FSK and genre icons and get the left position for the title
+    const int HeadIconLeft {DrawContentHeadFskGenre(Fsk, GenreIcons)};
 
 #ifdef DEBUGEPGTIME
     dsyslog("flatPlus: DrawEventInfo() Infotext time @ %ld ms", Timer.Elapsed());
@@ -2181,11 +2182,11 @@ void cFlatDisplayMenu::DrawEventInfo(const cEvent *Event) {
     PixmapClear(ContentHeadPixmap);
     ContentHeadPixmap->DrawRectangle(cRect(0, 0, m_MenuWidth, m_chHeight), Theme.Color(clrScrollbarBg));
 
-    const cString StrTime =
-        cString::sprintf("%s  %s–%s", *Event->GetDateString(), *Event->GetTimeString(), *Event->GetEndTimeString());
+    const cString StrTime {
+        cString::sprintf("%s  %s–%s", *Event->GetDateString(), *Event->GetTimeString(), *Event->GetEndTimeString())};
 
-    const cString Title = Event->Title();
-    const cString ShortText = (Event->ShortText()) ? Event->ShortText() : "";  // No short text. Show empty string
+    const cString Title {Event->Title()};
+    const cString ShortText {(Event->ShortText()) ? Event->ShortText() : ""};  // No short text. Show empty string
     const int ShortTextWidth {m_FontSml->Width(*ShortText)};
     const int MaxWidth {HeadIconLeft - m_MarginItem};
     int left {m_MarginItem};
@@ -2338,7 +2339,7 @@ void cFlatDisplayMenu::DrawItemExtraRecording(const cRecording *Recording, const
             MediaWidth = m_cWidth / 2 - m_MarginItem3;
 
         if (MediaPath[0] == '\0' && Config.TVScraperSearchLocalPosters) {  // Prio for tvscraper poster
-            const cString RecPath = Recording->FileName();
+            const cString RecPath {Recording->FileName()};
             if (ImgLoader.SearchRecordingPoster(RecPath, MediaPath)) {
                 img = ImgLoader.GetFile(*MediaPath, m_cWidth - m_MarginItem2, MediaHeight);
                 if (img) {
@@ -2621,7 +2622,7 @@ void cFlatDisplayMenu::DrawRecordingInfo(const cRecording *Recording) {
         if (FirstRun && (Config.TVScraperRecInfoShowPoster || Config.TVScraperRecInfoShowActors)) {
             GetScraperMedia(MediaPath, SeriesInfo, MovieInfo, Actors, nullptr, Recording);
             if (MediaPath[0] == '\0' && Config.TVScraperSearchLocalPosters) {  // Prio for tvscraper poster
-                const cString RecPath = Recording->FileName();
+                const cString RecPath {Recording->FileName()};
                 ImgLoader.SearchRecordingPoster(RecPath, MediaPath);
             }
         }
@@ -2713,14 +2714,14 @@ void cFlatDisplayMenu::DrawRecordingInfo(const cRecording *Recording) {
     PixmapClear(ContentHeadPixmap);
     ContentHeadPixmap->DrawRectangle(cRect(0, 0, m_MenuWidth, m_chHeight), Theme.Color(clrScrollbarBg));
 
-    const cString StrTime =
-        cString::sprintf("%s  %s  %s", *DateString(Recording->Start()), *TimeString(Recording->Start()),
-                         (RecInfo->ChannelName()) ? RecInfo->ChannelName() : "");
+    const cString StrTime {cString::sprintf("%s  %s  %s", *DateString(Recording->Start()),
+                                            *TimeString(Recording->Start()),
+                                            (RecInfo->ChannelName()) ? RecInfo->ChannelName() : "")};
 
-    cString Title = RecInfo->Title();
+    cString Title {RecInfo->Title()};
     if (isempty(*Title)) Title = Recording->Name();
 
-    const cString ShortText = (RecInfo->ShortText() ? RecInfo->ShortText() : " - ");  // No short text. Show ' - '
+    const cString ShortText {RecInfo->ShortText() ? RecInfo->ShortText() : " - "};  // No short text. Show ' - '
     const int ShortTextWidth {m_FontSml->Width(*ShortText)};
     int MaxWidth {HeadIconLeft - m_MarginItem};
     int left {m_MarginItem};
@@ -2762,7 +2763,7 @@ void cFlatDisplayMenu::DrawRecordingInfo(const cRecording *Recording) {
 
 #if APIVERSNUM >= 20505
     if (Config.MenuItemRecordingShowRecordingErrors) {  // TODO: Separate config option?
-        const cString RecErrIcon = cString::sprintf("%s_replay", *GetRecordingErrorIcon(RecInfo->Errors()));
+        const cString RecErrIcon {cString::sprintf("%s_replay", *GetRecordingErrorIcon(RecInfo->Errors()))};
 
         img = ImgLoader.GetIcon(*RecErrIcon, kIconMaxSize, m_FontSmlHeight);  // Small image
         if (img) {
@@ -2904,7 +2905,7 @@ void cFlatDisplayMenu::Flush() {
         if (m_LastTimerActiveCount != TimerActiveCount || m_LastTimerCount != TimerCount) {
             m_LastTimerActiveCount = TimerActiveCount;
             m_LastTimerCount = TimerCount;
-            const cString NewTitle = cString::sprintf("%s (%d/%d)", *m_LastTitle, TimerActiveCount, TimerCount);
+            const cString NewTitle {cString::sprintf("%s (%d/%d)", *m_LastTitle, TimerActiveCount, TimerCount)};
             TopBarSetTitle(*NewTitle, false);  // Do not clear
         }
     }
@@ -3929,7 +3930,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetLastRecordings(int wLeft, int wWidth, in
 
     // Sort by RecStart and add entrys to ContentWidget
     // Use 'partial_sort()' to limit the number of entries to Config.MainMenuWidgetLastRecMaxCount
-    const std::size_t LastRecMaxCount = Config.MainMenuWidgetLastRecMaxCount;
+    const std::size_t LastRecMaxCount {static_cast<std::size_t>(Config.MainMenuWidgetLastRecMaxCount)};
     std::partial_sort(Recs.begin(), Recs.begin() + LastRecMaxCount, Recs.end(), PairCompareTimeString);
     for (std::size_t i {0}; i < LastRecMaxCount && i < Recs.size(); ++i) {
         if (ContentTop + m_MarginItem > MenuPixmapViewPortHeight)
@@ -3968,7 +3969,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetTimerConflicts(int wLeft, int wWidth, in
             tr("no timer conflicts"), false, cRect(m_MarginItem, ContentTop, wWidth - m_MarginItem2, m_FontSmlHeight),
             Theme.Color(clrMenuEventFontInfo), Theme.Color(clrMenuEventBg), m_FontSml, wWidth - m_MarginItem2);
     } else {
-        cString str = cString::sprintf("%s: %d", tr("timer conflicts"), NumConflicts);
+        const cString str {cString::sprintf("%s: %d", tr("timer conflicts"), NumConflicts)};
         ContentWidget.AddText(*str, false, cRect(m_MarginItem, ContentTop, wWidth - m_MarginItem2, m_FontSmlHeight),
                               Theme.Color(clrMenuEventFontInfo), Theme.Color(clrMenuEventBg), m_FontSml,
                               wWidth - m_MarginItem2);
@@ -3990,13 +3991,13 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation(int wLeft, int wWidth,
     if (ContentTop + m_FontHeight + m_LineMargin + m_FontSmlHeight > MenuPixmapViewPortHeight)
         return -1;  // Not enough space to display anything meaningful
 
-    static const cString ExecFile = cString::sprintf("\"%s/system_information/system_information\"", WIDGETFOLDER);
+    static const cString ExecFile {cString::sprintf("\"%s/system_information/system_information\"", WIDGETFOLDER)};
     if (system(*ExecFile) != 0) {  // If the system call fails, indicate that the widget cannot be displayed
         dsyslog("flatPlus: cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation() system() failed!");
         return -1;
     }
 
-    static const cString ConfigsPath = cString::sprintf("%s/system_information/", WIDGETOUTPUTPATH);
+    static const cString ConfigsPath {cString::sprintf("%s/system_information/", WIDGETOUTPUTPATH)};
 
     cReadDir d(*ConfigsPath);
     if (d.Ok() == false) {
@@ -4110,7 +4111,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemUpdates(int wLeft, int wWidth, int
     if (ContentTop + m_FontHeight + m_LineMargin + m_FontSmlHeight > MenuPixmapViewPortHeight)
         return -1;  // Not enough space to display anything meaningful
 
-    cString Content = *ReadAndExtractData(cString::sprintf("%s/system_updatestatus/updates", WIDGETOUTPUTPATH));
+    cString Content {ReadAndExtractData(cString::sprintf("%s/system_updatestatus/updates", WIDGETOUTPUTPATH))};
     const int updates {(!isempty(*Content)) ? -1 : atoi(*Content)};
 
     Content = *ReadAndExtractData(cString::sprintf("%s/system_updatestatus/security_updates", WIDGETOUTPUTPATH));
@@ -4126,7 +4127,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemUpdates(int wLeft, int wWidth, int
                               Theme.Color(clrMenuEventFontInfo), Theme.Color(clrMenuEventBg), m_FontSml,
                               wWidth - m_MarginItem2);
     } else {
-        cString str = cString::sprintf("%s: %d", tr("Updates"), updates);
+        cString str {cString::sprintf("%s: %d", tr("Updates"), updates)};
         ContentWidget.AddText(*str, false, cRect(m_MarginItem, ContentTop, wWidth - m_MarginItem2, m_FontSmlHeight),
                               Theme.Color(clrMenuEventFontInfo), Theme.Color(clrMenuEventBg), m_FontSml,
                               wWidth - m_MarginItem2);
@@ -4152,8 +4153,8 @@ int cFlatDisplayMenu::DrawMainMenuWidgetTemperatures(int wLeft, int wWidth, int 
     if (ContentTop + m_FontHeight + m_LineMargin + m_FontSmlHeight > MenuPixmapViewPortHeight)
         return -1;  // Not enough space to display anything meaningful
 
-    static const cString ExecFile =
-        cString::sprintf("cd \"%s/temperatures\"; \"%s/temperatures/temperatures\"", WIDGETFOLDER, WIDGETFOLDER);
+    static const cString ExecFile {
+        cString::sprintf("cd \"%s/temperatures\"; \"%s/temperatures/temperatures\"", WIDGETFOLDER, WIDGETFOLDER)};
     if (system(*ExecFile) != 0) {  // If the system call fails, indicate that the widget cannot be displayed
         dsyslog("flatPlus: cFlatDisplayMenu::DrawMainMenuWidgetTemperatures() system() failed!");
         return -1;
@@ -4161,16 +4162,16 @@ int cFlatDisplayMenu::DrawMainMenuWidgetTemperatures(int wLeft, int wWidth, int 
     ContentTop = AddWidgetHeader("widgets/temperatures", tr("Temperatures"), ContentTop, wWidth);
     int CountTemps {0};
 
-    const cString TempCPU = *ReadAndExtractData(cString::sprintf("%s/temperatures/cpu", WIDGETOUTPUTPATH));
+    const cString TempCPU {ReadAndExtractData(cString::sprintf("%s/temperatures/cpu", WIDGETOUTPUTPATH))};
     if (!isempty(*TempCPU)) ++CountTemps;
 
-    const cString TempCase = *ReadAndExtractData(cString::sprintf("%s/temperatures/pccase", WIDGETOUTPUTPATH));
+    const cString TempCase {ReadAndExtractData(cString::sprintf("%s/temperatures/pccase", WIDGETOUTPUTPATH))};
     if (!isempty(*TempCase)) ++CountTemps;
 
-    const cString TempMB = *ReadAndExtractData(cString::sprintf("%s/temperatures/motherboard", WIDGETOUTPUTPATH));
+    const cString TempMB {ReadAndExtractData(cString::sprintf("%s/temperatures/motherboard", WIDGETOUTPUTPATH))};
     if (!isempty(*TempMB)) ++CountTemps;
 
-    const cString TempGPU = *ReadAndExtractData(cString::sprintf("%s/temperatures/gpu", WIDGETOUTPUTPATH));
+    const cString TempGPU {ReadAndExtractData(cString::sprintf("%s/temperatures/gpu", WIDGETOUTPUTPATH))};
     if (!isempty(*TempGPU)) ++CountTemps;
 
     if (CountTemps == 0) {
@@ -4226,19 +4227,19 @@ int cFlatDisplayMenu::DrawMainMenuWidgetCommand(int wLeft, int wWidth, int Conte
     if (ContentTop + m_FontHeight + m_LineMargin + m_FontSmlHeight > MenuPixmapViewPortHeight)
         return -1;  // Not enough space to display anything meaningful
 
-    static const cString ExecFile = cString::sprintf("\"%s/command_output/command\"", WIDGETFOLDER);
+    static const cString ExecFile {cString::sprintf("\"%s/command_output/command\"", WIDGETFOLDER)};
     if (system(*ExecFile) != 0) {  // If the system call fails, indicate that the widget cannot be displayed
         dsyslog("flatPlus: cFlatDisplayMenu::DrawMainMenuWidgetCommand() system() failed!");
         return -1;
     }
 
-    cString Title = *ReadAndExtractData(cString::sprintf("%s/command_output/title", WIDGETOUTPUTPATH));
+    cString Title {ReadAndExtractData(cString::sprintf("%s/command_output/title", WIDGETOUTPUTPATH))};
     if (!isempty(*Title)) Title = tr("no title available");
 
     ContentTop = AddWidgetHeader("widgets/command_output", *Title, ContentTop, wWidth);
 
     const char *s {nullptr};
-    static const cString ItemFilename = cString::sprintf("%s/command_output/output", WIDGETOUTPUTPATH);
+    static const cString ItemFilename {cString::sprintf("%s/command_output/output", WIDGETOUTPUTPATH)};
     FILE *f = fopen(*ItemFilename, "r");
     if (f) {
         cReadLine ReadLine;
@@ -4289,8 +4290,8 @@ int cFlatDisplayMenu::DrawMainMenuWidgetWeather(int wLeft, int wWidth, int Conte
 
     const auto &wd = WeatherCache;  // Weather data reference
 
-    const cString TempToday = cString::sprintf("%s %s", *wd.Temp, *wd.TempTodaySign);  // Read temperature
-    const cString Title = cString::sprintf("%s - %s %s", tr("Weather"), *wd.Location, *TempToday);
+    const cString TempToday {cString::sprintf("%s %s", *wd.Temp, *wd.TempTodaySign)};  // Read temperature
+    const cString Title {cString::sprintf("%s - %s %s", tr("Weather"), *wd.Location, *TempToday)};
     ContentTop = AddWidgetHeader("widgets/weather", *Title, ContentTop, wWidth);
 
     int left {m_MarginItem};
@@ -4406,7 +4407,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetWeather(int wLeft, int wWidth, int Conte
 void cFlatDisplayMenu::PreLoadImages() {
     // Menu icons
     const int ImageHeight {m_FontHeight};
-    const cString Path = cString::sprintf("%s/%s/menuIcons", *Config.IconPath, Setup.OSDTheme);
+    const cString Path {cString::sprintf("%s/%s/menuIcons", *Config.IconPath, Setup.OSDTheme)};
     std::string File {""};
     File.reserve(256);
     cString FileName {""};
@@ -4434,7 +4435,7 @@ void cFlatDisplayMenu::PreLoadImages() {
     // Channel icons
     int ImageBgHeight {ImageHeight};
     int ImageBgWidth {static_cast<int>(ImageHeight * 1.34f)};
-    cImage *img = ImgLoader.GetLogoBg(ImageBgWidth, ImageBgHeight);  // Load 'logo_background'
+    cImage *img {ImgLoader.GetLogoBg(ImageBgWidth, ImageBgHeight)};  // Load 'logo_background'
     if (img) {
         ImageBgHeight = img->Height();
         ImageBgWidth = img->Width();

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -3335,15 +3335,13 @@ time_t cFlatDisplayMenu::GetLastRecTimeFromFolder(const cRecording *Recording, i
     const cString RecFolder {*GetRecordingName(Recording, Level)};
     if (isempty(*RecFolder)) return RecStart;  // No folder
 
-    std::string_view sv1 {*RecFolder}, sv2;
     cString RecFolder2 {""};
     const time_t now {time(0)};
     time_t RecNewest {0}, RecOldest {now};
     LOCK_RECORDINGS_READ;  // Creates local const cRecordings *Recordings
     for (const cRecording *Rec {Recordings->First()}; Rec; Rec = Recordings->Next(Rec)) {
         RecFolder2 = *GetRecordingName(Rec, Level);
-        sv2 = *RecFolder2;
-        if (sv1 == sv2) {  // Recordings must be in the same folder
+        if (strcmp(*RecFolder, *RecFolder2) == 0) {  // Recordings must be in the same folder
             RecNewest = std::max(RecNewest, Rec->Start());
             RecOldest = std::min(RecOldest, Rec->Start());
         }

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -491,12 +491,12 @@ void cFlatDisplayMenu::SetItem(const char *Text, int Index, bool Current, bool S
                      .Size = Config.decorBorderMenuItemSize,
                      .Type = Config.decorBorderMenuItemType};
 
-    if (Selectable) {  // Most items are selectable, so check this first to avoid unnecessary checks for Current
-        ib.ColorFg = Config.decorBorderMenuItemSelFg;
-        ib.ColorBg = Config.decorBorderMenuItemSelBg;
-    } else if (Current) {
+    if (Current) {  // Must check first for Current, because Selectable ia also true
         ib.ColorFg = Config.decorBorderMenuItemCurFg;
         ib.ColorBg = Config.decorBorderMenuItemCurBg;
+    } else if (Selectable) {
+        ib.ColorFg = Config.decorBorderMenuItemSelFg;
+        ib.ColorBg = Config.decorBorderMenuItemSelBg;
     } else {
         ib.ColorFg = Config.decorBorderMenuItemFg;
         ib.ColorBg = Config.decorBorderMenuItemBg;
@@ -719,12 +719,12 @@ bool cFlatDisplayMenu::SetItemChannel(const cChannel *Channel, int Index, bool C
                      .Size = Config.decorBorderMenuItemSize,
                      .Type = Config.decorBorderMenuItemType};
 
-    if (Selectable) {  // Most items are selectable, so check this first to avoid unnecessary checks for Current
-        ib.ColorFg = Config.decorBorderMenuItemSelFg;
-        ib.ColorBg = Config.decorBorderMenuItemSelBg;
-    } else if (Current) {
+    if (Current) {  // Must check first for Current, because Selectable ia also true
         ib.ColorFg = Config.decorBorderMenuItemCurFg;
         ib.ColorBg = Config.decorBorderMenuItemCurBg;
+    } else if (Selectable) {
+        ib.ColorFg = Config.decorBorderMenuItemSelFg;
+        ib.ColorBg = Config.decorBorderMenuItemSelBg;
     } else {
         ib.ColorFg = Config.decorBorderMenuItemFg;
         ib.ColorBg = Config.decorBorderMenuItemBg;
@@ -1028,7 +1028,8 @@ bool cFlatDisplayMenu::SetItemTimer(const cTimer *Timer, int Index, bool Current
         if (Current && m_FontSml->Width(File) > (m_MenuItemWidth - Left - m_MarginItem) && Config.ScrollerEnable) {
             MenuItemScroller.AddScroller(File,
                                          cRect(Left, Top + m_FontHeight + m_MenuTop,  // TODO: Mismatch when scrolling
-                                               m_MenuItemWidth - Left - m_MarginItem - m_WidthScrollBar,
+                                               // m_MenuItemWidth - Left - m_MarginItem - m_WidthScrollBar,
+                                               m_MenuItemWidth - Left - m_MarginItem,
                                                m_FontSmlHeight),
                                          ColorFg, clrTransparent, m_FontSml, ColorExtraTextFg);
         } else {
@@ -1063,12 +1064,12 @@ bool cFlatDisplayMenu::SetItemTimer(const cTimer *Timer, int Index, bool Current
                      .Size = Config.decorBorderMenuItemSize,
                      .Type = Config.decorBorderMenuItemType};
 
-    if (Selectable) {  // Most items are selectable, so check this first to avoid unnecessary checks for Current
-        ib.ColorFg = Config.decorBorderMenuItemSelFg;
-        ib.ColorBg = Config.decorBorderMenuItemSelBg;
-    } else if (Current) {
+    if (Current) {  // Must check first for Current, because Selectable ia also true
         ib.ColorFg = Config.decorBorderMenuItemCurFg;
         ib.ColorBg = Config.decorBorderMenuItemCurBg;
+    } else if (Selectable) {
+        ib.ColorFg = Config.decorBorderMenuItemSelFg;
+        ib.ColorBg = Config.decorBorderMenuItemSelBg;
     } else {
         ib.ColorFg = Config.decorBorderMenuItemFg;
         ib.ColorBg = Config.decorBorderMenuItemBg;
@@ -1079,7 +1080,7 @@ bool cFlatDisplayMenu::SetItemTimer(const cTimer *Timer, int Index, bool Current
 
     if (!m_IsScrolling) ItemBorderInsertUnique(ib);
 
-    if (Config.MenuTimerView == 3 && Current) {  // flatPlus short
+    if (Config.MenuTimerView == 3 && Current) {  // flatPlus short + EPG
         const cEvent *Event {Timer->Event()};
         DrawItemExtraEvent(Event, tr("timer not enabled"));
     }
@@ -1437,12 +1438,12 @@ bool cFlatDisplayMenu::SetItemEvent(const cEvent *Event, int Index, bool Current
                      .Size = Config.decorBorderMenuItemSize,
                      .Type = Config.decorBorderMenuItemType};
 
-    if (Selectable) {  // Most items are selectable, so check this first to avoid unnecessary checks for Current
-        ib.ColorFg = Config.decorBorderMenuItemSelFg;
-        ib.ColorBg = Config.decorBorderMenuItemSelBg;
-    } else if (Current) {
+    if (Current) {  // Must check first for Current, because Selectable ia also true
         ib.ColorFg = Config.decorBorderMenuItemCurFg;
         ib.ColorBg = Config.decorBorderMenuItemCurBg;
+    } else if (Selectable) {
+        ib.ColorFg = Config.decorBorderMenuItemSelFg;
+        ib.ColorBg = Config.decorBorderMenuItemSelBg;
     } else {
         ib.ColorFg = Config.decorBorderMenuItemFg;
         ib.ColorBg = Config.decorBorderMenuItemBg;
@@ -1847,12 +1848,12 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
                      .Size = Config.decorBorderMenuItemSize,
                      .Type = Config.decorBorderMenuItemType};
 
-    if (Selectable) {  // Most items are selectable, so check this first to avoid unnecessary checks for Current
-        ib.ColorFg = Config.decorBorderMenuItemSelFg;
-        ib.ColorBg = Config.decorBorderMenuItemSelBg;
-    } else if (Current) {
+    if (Current) {  // Must check first for Current, because Selectable ia also true
         ib.ColorFg = Config.decorBorderMenuItemCurFg;
         ib.ColorBg = Config.decorBorderMenuItemCurBg;
+    } else if (Selectable) {
+        ib.ColorFg = Config.decorBorderMenuItemSelFg;
+        ib.ColorBg = Config.decorBorderMenuItemSelBg;
     } else {
         ib.ColorFg = Config.decorBorderMenuItemFg;
         ib.ColorBg = Config.decorBorderMenuItemBg;

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -768,7 +768,7 @@ void cFlatDisplayMenu::DrawItemExtraEvent(const cEvent *Event, const cString Emp
         }
 
         if (Config.EpgAdditionalInfoShow) {
-            if (Text[0] != '\0') Text.Append("\n");
+            if (Text[0] != '\0') Text.Append('\n');
             InsertGenreInfo(Event, Text);  // Add genre info
 
             if (Event->ParentalRating())  // FSK
@@ -1999,7 +1999,7 @@ void cFlatDisplayMenu::DrawEventInfo(const cEvent *Event) {
     }
 
     if (Config.EpgAdditionalInfoShow) {
-        if (Text[0] != '\0') Text.Append("\n");
+        if (Text[0] != '\0') Text.Append('\n');
         // Genre
         InsertGenreInfo(Event, Text, GenreIcons);  // Add genre info
 
@@ -2015,11 +2015,11 @@ void cFlatDisplayMenu::DrawEventInfo(const cEvent *Event) {
             InsertComponents(Components, TextAdditional, Audio, Subtitle);  // Get info for audio/video and subtitle
 
             if (Audio[0] != '\0') {
-                if (TextAdditional[0] != '\0') TextAdditional.Append("\n");
+                if (TextAdditional[0] != '\0') TextAdditional.Append('\n');
                 TextAdditional.Append(cString::sprintf("%s: %s", tr("Audio"), *Audio));
             }
             if (Subtitle[0] != '\0') {
-                if (TextAdditional[0] != '\0') TextAdditional.Append("\n");
+                if (TextAdditional[0] != '\0') TextAdditional.Append('\n');
                 TextAdditional.Append(cString::sprintf("\n%s: %s", tr("Subtitle"), *Subtitle));
             }
         }  // if Components
@@ -2068,7 +2068,7 @@ void cFlatDisplayMenu::DrawEventInfo(const cEvent *Event) {
                         Reruns.Append(cString::sprintf(":  %s", r->event->Title()));
                         // if (!isempty(r->event->ShortText()))
                         //    Reruns.Append(cString::sprintf("~%s", r->event->ShortText()));
-                        Reruns.Append("\n");
+                        Reruns.Append('\n');
                     }  // for
                     delete list;
                 }  // if list
@@ -2292,7 +2292,7 @@ void cFlatDisplayMenu::DrawItemExtraRecording(const cRecording *Recording, const
             if (Event) {
                 InsertGenreInfo(Event, Text);  // Add genre info
 
-                if (Event->Contents(0)) Text.Append("\n");
+                if (Event->Contents(0)) Text.Append('\n');
 
                 if (Event->ParentalRating())  // FSK
                     Text.Append(cString::sprintf("%s: %s\n", tr("FSK"), *Event->GetParentalRatingString()));
@@ -2537,13 +2537,13 @@ void cFlatDisplayMenu::DrawRecordingInfo(const cRecording *Recording) {
     cString Fsk {""};
     // Lent from skinelchi
     if (Config.RecordingAdditionalInfoShow) {
-        if (Text[0] != '\0') Text.Append("\n");
+        if (Text[0] != '\0') Text.Append('\n');
         const cEvent *Event {RecInfo->GetEvent()};
         if (Event) {
             // Genre
             InsertGenreInfo(Event, Text, GenreIcons);  // Add genre info
 
-            if (Event->Contents(0)) Text.Append("\n");
+            if (Event->Contents(0)) Text.Append('\n');
             // FSK
             if (Event->ParentalRating()) {
                 Fsk = *Event->GetParentalRatingString();
@@ -2579,11 +2579,11 @@ void cFlatDisplayMenu::DrawRecordingInfo(const cRecording *Recording) {
             InsertComponents(Components, TextAdditional, Audio, Subtitle);  // Get info for audio/video and subtitle
 
             if (Audio[0] != '\0') {
-                if (TextAdditional[0] != '\0') TextAdditional.Append("\n");
+                if (TextAdditional[0] != '\0') TextAdditional.Append('\n');
                 TextAdditional.Append(cString::sprintf("%s: %s", tr("Audio"), *Audio));
             }
             if (Subtitle[0] != '\0') {
-                if (TextAdditional[0] != '\0') TextAdditional.Append("\n");
+                if (TextAdditional[0] != '\0') TextAdditional.Append('\n');
                 TextAdditional.Append(cString::sprintf("\n%s: %s", tr("Subtitle"), *Subtitle));
             }
         }

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -3010,9 +3010,9 @@ cString cFlatDisplayMenu::GetIconName(const cString &element) const {
         cPlugin *p {cPluginManager::GetPlugin(i)};
 #ifdef DEBUGFUNCSCALL
         dsyslog("   Plugin %ld: %p", i, p);
-        if (p != nullptr) dsyslog("     Plugin name '%s', menu entry '%s'", p->Name(), p->MainMenuEntry());
+        if (p) dsyslog("     Plugin name '%s', menu entry '%s'", p->Name(), p->MainMenuEntry());
 #endif
-        if (p != nullptr) {                      // Plugin found
+        if (p) {                                 // Plugin found
             MainMenuEntry = p->MainMenuEntry();  // Get main menu entry of plugin
             if (!isempty(MainMenuEntry)) {       // Plugin has a main menu entry
                 if (svElement == MainMenuEntry) {
@@ -3956,7 +3956,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation(int wLeft, int wWidth,
     cString num {""};
     std::string_view svFileName {""};  // Also used later when extracting the item name from the file name
     std::size_t found {std::string_view::npos};
-    while ((entry = d.Next()) != nullptr) {
+    while (entry = d.Next()) {
         svFileName = entry->d_name;
         found = svFileName.find('_');
         if (found != std::string_view::npos) {               // File name contains '_'
@@ -4188,7 +4188,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetCommand(int wLeft, int wWidth, int Conte
     FILE *f {fopen(*ItemFilename, "r")};
     if (f) {
         cReadLine ReadLine;
-        while ((s = ReadLine.Read(f)) != nullptr) {
+        while (s = ReadLine.Read(f)) {
             if (ContentTop + m_MarginItem > MenuPixmapViewPortHeight) break;
             ContentWidget.AddText(
                 s, false, cRect(m_MarginItem, ContentTop, wWidth - m_MarginItem2, m_FontSmlHeight),
@@ -4364,7 +4364,7 @@ void cFlatDisplayMenu::PreLoadImages() {
     }
 
     struct dirent *e;
-    while ((e = d.Next()) != nullptr) {
+    while (e = d.Next()) {
         File = e->d_name;
         if (File.find("vdrlogo") == 0)  // Skip vdrlogo* files
             continue;

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -491,7 +491,7 @@ void cFlatDisplayMenu::SetItem(const char *Text, int Index, bool Current, bool S
                      .Size = Config.decorBorderMenuItemSize,
                      .Type = Config.decorBorderMenuItemType};
 
-    if (Current) {  // Must check first for Current, because Selectable ia also true
+    if (Current) {  // Must check first for Current, because Selectable is also true
         ib.ColorFg = Config.decorBorderMenuItemCurFg;
         ib.ColorBg = Config.decorBorderMenuItemCurBg;
     } else if (Selectable) {
@@ -604,7 +604,7 @@ bool cFlatDisplayMenu::SetItemChannel(const cChannel *Channel, int Index, bool C
             if (Event) {
                 // Calculate progress bar
                 const time_t now {time(0)};
-                const double duration {static_cast<double>(Event->Duration())};
+                const int duration {Event->Duration()};
                 progress = (duration > 0) ? std::clamp((now - Event->StartTime()) * 100.0 / duration, 0.0, 100.0) : 0.0;
                 EventTitle = Event->Title();
             }
@@ -628,7 +628,7 @@ bool cFlatDisplayMenu::SetItemChannel(const cChannel *Channel, int Index, bool C
             MenuPixmap->DrawText(cPoint(Left + (m_MenuItemWidth / 10 * 2), Top), *GroupName, ColorFg, ColorBg, m_Font,
                                  0, 0, taCenter);
         } else {
-            if (Current && m_Font->Width(*Buffer) > (Width) && Config.ScrollerEnable) {
+            if (Current && Config.ScrollerEnable && m_Font->Width(*Buffer) >  Width) {
                 MenuItemScroller.AddScroller(*Buffer, cRect(LeftName, Top + m_MenuTop, Width, m_FontHeight), ColorFg,
                                              clrTransparent, m_Font);
             } else {
@@ -649,7 +649,7 @@ bool cFlatDisplayMenu::SetItemChannel(const cChannel *Channel, int Index, bool C
             MenuPixmap->DrawText(cPoint(Left + (m_MenuItemWidth / 10 * 2), Top), *GroupName, ColorFg, ColorBg, m_Font,
                                  0, 0, taCenter);
         } else {
-            if (Current && m_Font->Width(*Buffer) > (Width) && Config.ScrollerEnable) {
+            if (Current && Config.ScrollerEnable && m_Font->Width(*Buffer) > Width) {
                 MenuItemScroller.AddScroller(*Buffer, cRect(LeftName, Top + m_MenuTop, Width, m_FontHeight), ColorFg,
                                              clrTransparent, m_Font);
             } else {
@@ -687,8 +687,8 @@ bool cFlatDisplayMenu::SetItemChannel(const cChannel *Channel, int Index, bool C
                 Left = LeftName;
                 Top += m_FontHeight;
 
-                if (Current && m_FontSml->Width(*EventTitle) > (m_MenuItemWidth - Left - m_MarginItem) &&
-                    Config.ScrollerEnable) {
+                if (Current && Config.ScrollerEnable &&
+                    m_FontSml->Width(*EventTitle) > (m_MenuItemWidth - Left - m_MarginItem)) {
                     MenuItemScroller.AddScroller(
                         *EventTitle,
                         cRect(Left, Top + m_MenuTop, m_MenuItemWidth - Left - m_MarginItem, m_FontSmlHeight), ColorFg,
@@ -698,8 +698,8 @@ bool cFlatDisplayMenu::SetItemChannel(const cChannel *Channel, int Index, bool C
                                          m_MenuItemWidth - Left - m_MarginItem);
                 }
             } else {
-                if (Current && m_Font->Width(*EventTitle) > (m_MenuItemWidth - Left - m_MarginItem) &&
-                    Config.ScrollerEnable) {
+                if (Current && Config.ScrollerEnable &&
+                    m_Font->Width(*EventTitle) > (m_MenuItemWidth - Left - m_MarginItem)) {
                     MenuItemScroller.AddScroller(
                         *EventTitle, cRect(Left, Top + m_MenuTop, m_MenuItemWidth - Left - m_MarginItem, m_FontHeight),
                         ColorFg, clrTransparent, m_Font);
@@ -719,7 +719,7 @@ bool cFlatDisplayMenu::SetItemChannel(const cChannel *Channel, int Index, bool C
                      .Size = Config.decorBorderMenuItemSize,
                      .Type = Config.decorBorderMenuItemType};
 
-    if (Current) {  // Must check first for Current, because Selectable ia also true
+    if (Current) {  // Must check first for Current, because Selectable is also true
         ib.ColorFg = Config.decorBorderMenuItemCurFg;
         ib.ColorBg = Config.decorBorderMenuItemCurBg;
     } else if (Selectable) {
@@ -776,8 +776,8 @@ void cFlatDisplayMenu::DrawItemExtraEvent(const cEvent *Event, const cString Emp
                 cString Audio {""}, Subtitle {""};
                 InsertComponents(Components, Text, Audio, Subtitle, true);  // Get info for audio/video and subtitle
 
-                if (Audio[0] != '\0') Text.Append(cString::sprintf("\n%s: %s", tr("Audio"), *Audio));
-                if (Subtitle[0] != '\0') Text.Append(cString::sprintf("\n%s: %s", tr("Subtitle"), *Subtitle));
+                // if (Audio[0] != '\0') Text.Append(cString::sprintf("\n%s: %s", tr("Audio"), *Audio));
+                // if (Subtitle[0] != '\0') Text.Append(cString::sprintf("\n%s: %s", tr("Subtitle"), *Subtitle));
             }  // if Components
         }  // EpgAdditionalInfoShow
     } else {
@@ -994,7 +994,7 @@ bool cFlatDisplayMenu::SetItemTimer(const cTimer *Timer, int Index, bool Current
                              m_MenuItemWidth - Left - m_MarginItem);
         Left += FontCache.GetStringWidth(m_FontName, m_FontHeight, "00:00–00:00  ");
 
-        if (Current && m_Font->Width(File) > (m_MenuItemWidth - Left - m_MarginItem) && Config.ScrollerEnable) {
+        if (Current && Config.ScrollerEnable && m_Font->Width(File) > (m_MenuItemWidth - Left - m_MarginItem)) {
             MenuItemScroller.AddScroller(
                 File, cRect(Left, Top + m_MenuTop, m_MenuItemWidth - Left - m_MarginItem, m_FontHeight), ColorFg,
                 clrTransparent, m_Font, ColorExtraTextFg);
@@ -1025,7 +1025,7 @@ bool cFlatDisplayMenu::SetItemTimer(const cTimer *Timer, int Index, bool Current
         MenuPixmap->DrawText(cPoint(Left, Top), *Buffer, ColorFg, ColorBg, m_Font,
                              m_MenuItemWidth - Left - m_MarginItem);
 
-        if (Current && m_FontSml->Width(File) > (m_MenuItemWidth - Left - m_MarginItem) && Config.ScrollerEnable) {
+        if (Current && Config.ScrollerEnable && m_FontSml->Width(File) > (m_MenuItemWidth - Left - m_MarginItem)) {
             MenuItemScroller.AddScroller(File,
                                          cRect(Left, Top + m_FontHeight + m_MenuTop,  // TODO: Mismatch when scrolling
                                                // m_MenuItemWidth - Left - m_MarginItem - m_WidthScrollBar,
@@ -1064,7 +1064,7 @@ bool cFlatDisplayMenu::SetItemTimer(const cTimer *Timer, int Index, bool Current
                      .Size = Config.decorBorderMenuItemSize,
                      .Type = Config.decorBorderMenuItemType};
 
-    if (Current) {  // Must check first for Current, because Selectable ia also true
+    if (Current) {  // Must check first for Current, because Selectable is also true
         ib.ColorFg = Config.decorBorderMenuItemCurFg;
         ib.ColorBg = Config.decorBorderMenuItemCurBg;
     } else if (Selectable) {
@@ -1209,7 +1209,7 @@ bool cFlatDisplayMenu::SetItemEvent(const cEvent *Event, int Index, bool Current
                 const time_t total {Event->EndTime() - EventStartTime};
                 if (total >= 0) {
                     // Calculate progress bar
-                    const double duration {static_cast<double>(Event->Duration())};
+                    const int duration {Event->Duration()};
                     const double progress {
                         (duration > 0) ? std::clamp((now - EventStartTime) * 100.0 / duration, 0.0, 100.0) : 0.0};
 
@@ -1313,7 +1313,7 @@ bool cFlatDisplayMenu::SetItemEvent(const cEvent *Event, int Index, bool Current
             if (Current) {
                 if (ShortText[0] != '\0') {
                     Buffer = cString::sprintf("%s~%s", *Title, *ShortText);
-                    if (m_FontSml->Width(*Buffer) > (m_MenuItemWidth - Left - m_MarginItem) && Config.ScrollerEnable) {
+                    if (Config.ScrollerEnable && m_FontSml->Width(*Buffer) > (m_MenuItemWidth - Left - m_MarginItem)) {
                         MenuItemScroller.AddScroller(
                             *Buffer,
                             cRect(Left, Top + m_MenuTop, m_MenuItemWidth - Left - m_MarginItem, m_FontSmlHeight),
@@ -1327,7 +1327,7 @@ bool cFlatDisplayMenu::SetItemEvent(const cEvent *Event, int Index, bool Current
                                              m_MenuItemWidth - Left - m_MarginItem);
                     }
                 } else {
-                    if (m_FontSml->Width(*Title) > (m_MenuItemWidth - Left - m_MarginItem) && Config.ScrollerEnable) {
+                    if (Config.ScrollerEnable && m_FontSml->Width(*Title) > (m_MenuItemWidth - Left - m_MarginItem)) {
                         MenuItemScroller.AddScroller(
                             *Title,
                             cRect(Left, Top + m_MenuTop, m_MenuItemWidth - Left - m_MarginItem, m_FontSmlHeight),
@@ -1347,7 +1347,7 @@ bool cFlatDisplayMenu::SetItemEvent(const cEvent *Event, int Index, bool Current
                 }
             }
         } else if (MenuEventViewShort) {  // flatPlus short, flatPlus short + EPG
-            if (Current && m_Font->Width(*Title) > (m_MenuItemWidth - Left - m_MarginItem) && Config.ScrollerEnable) {
+            if (Current && Config.ScrollerEnable && m_Font->Width(*Title) > (m_MenuItemWidth - Left - m_MarginItem)) {
                 MenuItemScroller.AddScroller(
                     *Title, cRect(Left, Top + m_MenuTop, m_MenuItemWidth - Left - m_MarginItem, m_FontHeight), ColorFg,
                     clrTransparent, m_Font);
@@ -1357,8 +1357,8 @@ bool cFlatDisplayMenu::SetItemEvent(const cEvent *Event, int Index, bool Current
             }
             if (ShortText[0] != '\0') {
                 Top += m_FontHeight;
-                if (Current && m_FontSml->Width(*ShortText) > (m_MenuItemWidth - Left - m_MarginItem) &&
-                    Config.ScrollerEnable) {
+                if (Current && Config.ScrollerEnable &&
+                    m_FontSml->Width(*ShortText) > (m_MenuItemWidth - Left - m_MarginItem)) {
                     MenuItemScroller.AddScroller(
                         *ShortText, cRect(Left, Top + m_MenuTop, m_MenuItemWidth - Left - m_MarginItem, m_FontHeight),
                         ColorExtraTextFg, clrTransparent, m_FontSml);
@@ -1438,7 +1438,7 @@ bool cFlatDisplayMenu::SetItemEvent(const cEvent *Event, int Index, bool Current
                      .Size = Config.decorBorderMenuItemSize,
                      .Type = Config.decorBorderMenuItemType};
 
-    if (Current) {  // Must check first for Current, because Selectable ia also true
+    if (Current) {  // Must check first for Current, because Selectable is also true
         ib.ColorFg = Config.decorBorderMenuItemCurFg;
         ib.ColorBg = Config.decorBorderMenuItemCurBg;
     } else if (Selectable) {
@@ -1473,17 +1473,16 @@ bool cFlatDisplayMenu::SetItemEvent(const cEvent *Event, int Index, bool Current
  */
 void cFlatDisplayMenu::DrawRecordingStateIcon(const cRecording *Recording, int Left, int Top, bool Current) {
     cImage *img {nullptr};
-    const int RecordingIsInUse {Recording->IsInUse()};
-    if ((RecordingIsInUse & ruTimer) != 0) {  // The recording is currently written to by a timer
-        if (Current) img = ImgLoader.GetIcon("timerRecording_cur", m_FontHeight, m_FontHeight);
-        if (!img) img = ImgLoader.GetIcon("timerRecording", m_FontHeight, m_FontHeight);
-    } else if ((RecordingIsInUse & ruReplay) != 0) {  // The recording is being replayed
+    if (Recording->IsNew()) {
+        if (Current) img = ImgLoader.GetIcon("recording_new_cur", m_FontHeight, m_FontHeight);
+        if (!img) img = ImgLoader.GetIcon("recording_new", m_FontHeight, m_FontHeight);
+    } else if ((Recording->IsInUse() & ruReplay) != 0) {  // The recording is being replayed
         if (Current) img = ImgLoader.GetIcon("play", m_FontHeight, m_FontHeight);
         if (!img) img = ImgLoader.GetIcon("play_sel", m_FontHeight, m_FontHeight);
         // img = ImgLoader.GetIcon("recording_replay", m_FontHeight, m_FontHeight);
-    } else if (Recording->IsNew()) {
-        if (Current) img = ImgLoader.GetIcon("recording_new_cur", m_FontHeight, m_FontHeight);
-        if (!img) img = ImgLoader.GetIcon("recording_new", m_FontHeight, m_FontHeight);
+    } else if ((Recording->IsInUse() & ruTimer) != 0) {  // The recording is currently written to by a timer
+        if (Current) img = ImgLoader.GetIcon("timerRecording_cur", m_FontHeight, m_FontHeight);
+        if (!img) img = ImgLoader.GetIcon("timerRecording", m_FontHeight, m_FontHeight);
     } else {
         const cString IconName {GetRecordingSeenIcon(Recording->NumFrames(), Recording->GetResume())};
         if (Current) {
@@ -1551,18 +1550,20 @@ void cFlatDisplayMenu::DrawRecordingErrorIcon(const cRecording *Recording, int L
  * @param Left The x-coordinate where the icon will be drawn.
  * @param Top The y-coordinate where the icon will be drawn.
  * @param Current A boolean indicating whether the icon is the current one.
+ * @param Small A boolean indicating whether the icon should be drawn small. Default is false.
  * @return Updated x-coordinate value
  */
-int cFlatDisplayMenu::DrawRecordingIcon(const char *IconName, int Left, int Top, bool Current) {
+int cFlatDisplayMenu::DrawRecordingIcon(const char *IconName, int Left, int Top, bool Current, bool Small) {
     cImage *img {nullptr};
+    const int IconSize {Small ? m_FontSmlHeight : m_FontHeight};
     if (Current) {
         const cString IconNameCur {cString::sprintf("%s_cur", IconName)};
-        img = ImgLoader.GetIcon(*IconNameCur, m_FontHeight, m_FontHeight);
+        img = ImgLoader.GetIcon(*IconNameCur, IconSize, IconSize);
     }
-    if (!img) img = ImgLoader.GetIcon(IconName, m_FontHeight, m_FontHeight);
+    if (!img) img = ImgLoader.GetIcon(IconName, IconSize, IconSize);
     if (img) {
         MenuIconsPixmap->DrawImage(cPoint(Left, Top), *img);
-        Left += m_FontHeight + m_MarginItem;
+        Left += IconSize + m_MarginItem;
     }
     return Left;
 }
@@ -1601,7 +1602,7 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
     int Height {m_FontHeight};
     m_MenuItemWidth = m_MenuWidth - Config.decorBorderMenuItemSize * 2;
     if (Config.MenuRecordingView == 2 || Config.MenuRecordingView == 3) {  // flatPlus short, flatPlus short + EPG
-        Height = m_FontHeight + m_FontSmlHeight + m_MarginItem;
+        Height += m_FontSmlHeight + m_MarginItem;
         m_MenuItemWidth /= 2;
     }
 
@@ -1619,61 +1620,58 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
     if (y + m_ItemRecordingHeight > m_MenuItemLastHeight) m_MenuItemLastHeight = y + m_ItemRecordingHeight;
 
     MenuPixmap->DrawRectangle(cRect(Config.decorBorderMenuItemSize, y, m_MenuItemWidth, Height), ColorBg);
-    static constexpr float kIconCutHeightRatio {2.0 / 3.0};
-    const int ImgRecNewHeight {Config.MenuRecordingView == 1 ? m_FontHeight : m_FontSmlHeight};
-    //* Preload for calculation of position
-    cImage *ImgRecCut {nullptr}, *ImgRecNew {nullptr};
-    if (Current) {
-        ImgRecNew = ImgLoader.GetIcon("recording_new_cur", ImgRecNewHeight, ImgRecNewHeight);
-        ImgRecCut = ImgLoader.GetIcon("recording_cutted_cur", m_FontHeight, m_FontHeight * kIconCutHeightRatio);
-    }
-    if (!ImgRecNew) ImgRecNew = ImgLoader.GetIcon("recording_new", ImgRecNewHeight, ImgRecNewHeight);
-    if (!ImgRecCut) ImgRecCut = ImgLoader.GetIcon("recording_cutted", m_FontHeight, m_FontHeight * kIconCutHeightRatio);
 
-    const int ImgRecNewWidth {(ImgRecNew) ? ImgRecNew->Width() : 0};
-    const int ImgRecCutWidth {(ImgRecCut) ? ImgRecCut->Width() : 0};
-    const int ImgRecCutHeight {(ImgRecCut) ? ImgRecCut->Height() : 0};
+    static constexpr float kIconCutHeightRatio {2.0 / 3.0};
+    const int ImgRecCutHeight {static_cast<int>(m_FontHeight * kIconCutHeightRatio)};  // 2/3 of font height
+    const int ImgRecCutWidth {ImgRecCutHeight};  // Square cut recording image
+    const bool IsRecording {Total == 0};         // Recording or a folder
+    bool IsEdited {false};
+    cImage *ImgRecCut {nullptr};
+    if (IsRecording && Recording->IsEdited()) {  // Preload icon only when needed
+        IsEdited = true;
+
+        if (Current) { ImgRecCut = ImgLoader.GetIcon("recording_cutted_cur", ImgRecCutWidth, ImgRecCutHeight); }
+        if (!ImgRecCut) { ImgRecCut = ImgLoader.GetIcon("recording_cutted", ImgRecCutWidth, ImgRecCutHeight); }
+    }
+
+    cString RecName {GetRecordingName(Recording, Level)};
+    if (IsRecording && Config.MenuItemRecordingClearPercent) {  // Remove leading percent sign(s) from RecName
+        while (!isempty(*RecName) && RecName[0] == '%')
+        RecName = cString(*RecName + 1);
+#ifdef DEBUGFUNCSCALL
+        dsyslog("   RecName for display '%s'", *RecName);
+#endif
+    }
 
     int Left {Config.decorBorderMenuItemSize + m_MarginItem};
     int Top {y};
-    const bool IsRecording {Total == 0};  // Recording or a folder
-    cString RecName {GetRecordingName(Recording, Level)};
-    if (Config.MenuItemRecordingClearPercent && IsRecording) {  // Remove leading percent sign(s) from RecName
-        while (!isempty(*RecName) && RecName[0] == '%')
-            RecName = cString(*RecName + 1);
-    }
-#ifdef DEBUGFUNCSCALL
-    dsyslog("   RecName for display '%s'", *RecName);
-#endif
-
+    const div_t TimeHM {std::div((Recording->LengthInSeconds() + 30) / 60, 60)};
+    const cString Length {cString::sprintf("%02d:%02d", TimeHM.quot, TimeHM.rem)};  // Length in minutes and seconds
     cString Buffer {""};
-    if (Config.MenuRecordingView == 1) {  // flatPlus long
+    if (Config.MenuRecordingView == 1) {  //* flatPlus long
         if (IsRecording) {                // Recording
             Left = DrawRecordingIcon("recording", Left, Top, Current);
-
-            const div_t TimeHM {std::div((Recording->LengthInSeconds() + 30) / 60, 60)};
-            const cString Length {cString::sprintf("%02d:%02d", TimeHM.quot, TimeHM.rem)};
-            Buffer = cString::sprintf("%s  %s  Σ%s ", *ShortDateString(Recording->Start()),
+            Buffer = cString::sprintf("%s %s Σ %s ", *ShortDateString(Recording->Start()),
                                       *TimeString(Recording->Start()), *Length);
-
             MenuPixmap->DrawText(cPoint(Left, Top), *Buffer, ColorFg, ColorBg, m_Font,
                                  m_MenuItemWidth - Left - m_MarginItem);
-            Left += FontCache.GetStringWidth(m_FontName, m_FontHeight, "00.00.00  00:00  Σ00:00") + m_MarginItem;
+            Left += FontCache.GetStringWidth(m_FontName, m_FontHeight, "00.00.00 00:00 Σ 00:00") + m_MarginItem;
 
-            // Show if recording is still in progress (ruTimer), or played (ruReplay)
+            // Show recording status: New, still in progress (ruTimer), played (ruReplay) or seen (resume)
             DrawRecordingStateIcon(Recording, Left, Top, Current);
 #if APIVERSNUM >= 20505
+            // Show recording errors if enabled in config (Drwan as overlay icon)
             if (Config.MenuItemRecordingShowRecordingErrors) DrawRecordingErrorIcon(Recording, Left, Top, Current);
 #endif
 
-            Left += ImgRecNewWidth + m_MarginItem;
-            if (Recording->IsEdited() && ImgRecCut) {
+            Left += m_FontHeight + m_MarginItem;
+            if (IsEdited && ImgRecCut) {
                 const int ImageTop {Top + m_FontHeight - ImgRecCutHeight};  // 2/3 image height
                 MenuIconsPixmap->DrawImage(cPoint(Left, ImageTop), *ImgRecCut);
             }
 
             if (Config.MenuItemRecordingShowFormatIcons)
-                DrawRecordingFormatIcon(Recording, Left, Top);  // Show (SD), HD or UHD Logo
+                DrawRecordingFormatIcon(Recording, Left, Top);  // Show (SD), HD or UHD Logo (Overlay icon)
 
             Left += ImgRecCutWidth + (ImgRecCutWidth / 2) + m_MarginItem;  // Ensures exact 100% increase
 
@@ -1695,14 +1693,13 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
                                  taLeft);
             Left += DigitsMaxWidth;
 
-            if (ImgRecNew) MenuIconsPixmap->DrawImage(cPoint(Left, Top), *ImgRecNew);
+            Left = DrawRecordingIcon("recording_new", Left, Top, Current);  // Draw recording new icon
 
-            Left += ImgRecNewWidth + m_MarginItem;
             Buffer = itoa(New);
             MenuPixmap->DrawText(cPoint(Left, Top), *Buffer, ColorFg, ColorBg, m_Font, DigitsMaxWidth, m_FontHeight);
 
             Left += DigitsMaxWidth;
-            int LeftWidth {Config.decorBorderMenuItemSize + m_FontHeight + (DigitsWidth * 2) + ImgRecNewWidth +
+            int LeftWidth {Config.decorBorderMenuItemSize + m_FontHeight + (DigitsWidth * 2) + m_FontHeight +
                            m_MarginItem * 5};  // For folder with recordings
 
             if (Config.MenuItemRecordingShowFolderDate > 0) {
@@ -1717,8 +1714,8 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
                 Left += m_FontHeight + m_MarginItem;  // Increase 'Left' even if no image is drawn
             }
 
-            if (Current && m_Font->Width(*RecName) > (m_MenuItemWidth - LeftWidth - m_MarginItem) &&
-                Config.ScrollerEnable) {
+            if (Current && Config.ScrollerEnable &&
+                m_Font->Width(*RecName) > (m_MenuItemWidth - LeftWidth - m_MarginItem)) {
                 MenuItemScroller.AddScroller(
                     *RecName,
                     cRect(LeftWidth, Top + m_MenuTop, m_MenuItemWidth - LeftWidth - m_MarginItem, m_FontHeight),
@@ -1731,8 +1728,8 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
         } else if (Total == -1) {  // Folder without recordings
             Left = DrawRecordingIcon("folder", Left, Top, Current);
 
-            if (Current && m_Font->Width(Recording->FileName()) > (m_MenuItemWidth - Left - m_MarginItem) &&
-                Config.ScrollerEnable) {
+            if (Current && Config.ScrollerEnable &&
+                m_Font->Width(Recording->FileName()) > (m_MenuItemWidth - Left - m_MarginItem)) {
                 MenuItemScroller.AddScroller(
                     Recording->FileName(),
                     cRect(Left, Top + m_MenuTop, m_MenuItemWidth - Left - m_MarginItem, m_FontHeight), ColorFg,
@@ -1742,15 +1739,14 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
                                      m_MenuItemWidth - Left - m_MarginItem);
             }
         }
-    } else {                // flatPlus short
+    } else {                //* flatPlus short
         if (IsRecording) {  // Recording
             Left = DrawRecordingIcon("recording", Left, Top, Current);
 
-            int ImagesWidth {ImgRecNewWidth + ImgRecCutWidth + m_MarginItem2 + m_WidthScrollBar};
-            if (m_IsScrolling) ImagesWidth -= m_WidthScrollBar;
+            const int ImagesWidth {m_FontHeight2 + m_MarginItem2 + (m_IsScrolling ? 0 : m_WidthScrollBar)};
 
-            if (Current && m_Font->Width(*RecName) > (m_MenuItemWidth - Left - m_MarginItem - ImagesWidth) &&
-                Config.ScrollerEnable) {
+            if (Current && Config.ScrollerEnable &&
+                m_Font->Width(*RecName) > (m_MenuItemWidth - Left - m_MarginItem - ImagesWidth)) {
                 MenuItemScroller.AddScroller(
                     *RecName,
                     cRect(Left, Top + m_MenuTop, m_MenuItemWidth - Left - m_MarginItem - ImagesWidth, m_FontHeight),
@@ -1760,38 +1756,35 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
                                      m_MenuItemWidth - Left - m_MarginItem - ImagesWidth);
             }
 
-            const div_t TimeHM {std::div((Recording->LengthInSeconds() + 30) / 60, 60)};
-            const cString Length {cString::sprintf("%02d:%02d", TimeHM.quot, TimeHM.rem)};
-            Buffer = cString::sprintf("%s  %s  Σ%s ", *ShortDateString(Recording->Start()),
+            Buffer = cString::sprintf("%s  %s  Σ %s ", *ShortDateString(Recording->Start()),
                                       *TimeString(Recording->Start()), *Length);
-
             Top += m_FontHeight;
             MenuPixmap->DrawText(cPoint(Left, Top), *Buffer, ColorFg, ColorBg, m_FontSml,
                                  m_MenuItemWidth - Left - m_MarginItem);
 
             Left = m_MenuItemWidth - ImagesWidth;
             Top -= m_FontHeight;
-            // Show if recording is still in progress (ruTimer), or played (ruReplay)
+            // Show recording status: New, still in progress (ruTimer), played (ruReplay) or seen (resume)
             DrawRecordingStateIcon(Recording, Left, Top, Current);
 #if APIVERSNUM >= 20505
+            // Show recording errors if enabled in config (Drwan as overlay icon)
             if (Config.MenuItemRecordingShowRecordingErrors) DrawRecordingErrorIcon(Recording, Left, Top, Current);
 #endif
 
-            Left += ImgRecNewWidth + m_MarginItem;
-            if (Recording->IsEdited() && ImgRecCut) {
+            Left += m_FontSmlHeight + m_MarginItem;
+            if (IsEdited && ImgRecCut) {
                 const int ImageTop {Top + m_FontHeight - ImgRecCutHeight};  // 2/3 image height
                 MenuIconsPixmap->DrawImage(cPoint(Left, ImageTop), *ImgRecCut);
             }
 
             if (Config.MenuItemRecordingShowFormatIcons)
-                DrawRecordingFormatIcon(Recording, Left, Top);  // Show (SD), HD or UHD Logo
+                DrawRecordingFormatIcon(Recording, Left, Top);  // Show (SD), HD or UHD Logo (Overlay icon)
 
-            Left += ImgRecCutWidth + (ImgRecCutWidth / 2) + m_MarginItem;  // Ensures exact 100% increase
-
+            // Left += ImgRecCutWidth + (ImgRecCutWidth / 2) + m_MarginItem;  // Ensures exact 100% increase
         } else if (Total > 0) {  // Folder with recordings
             Left = DrawRecordingIcon("folder", Left, Top, Current);
 
-            if (Current && m_Font->Width(*RecName) > (m_MenuItemWidth - Left - m_MarginItem) && Config.ScrollerEnable) {
+            if (Current && Config.ScrollerEnable && m_Font->Width(*RecName) > (m_MenuItemWidth - Left - m_MarginItem)) {
                 MenuItemScroller.AddScroller(
                     *RecName, cRect(Left, Top + m_MenuTop, m_MenuItemWidth - Left - m_MarginItem, m_FontHeight),
                     ColorFg, clrTransparent, m_Font);
@@ -1803,14 +1796,14 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
             Top += m_FontHeight;
             const int DigitsMaxWidth {FontCache.GetStringWidth(m_FontSmlName, m_FontSmlHeight, "0000") +
                                       m_MarginItem};  // Use same width for recs and new recs
-            Buffer = itoa(Total);
+            // Total recordings in folder preceeded by Σ (Sigma) symbol
+            Buffer = cString::sprintf("Σ %d", Total);
             MenuPixmap->DrawText(cPoint(Left, Top), *Buffer, ColorFg, ColorBg, m_FontSml, DigitsMaxWidth,
                                  m_FontSmlHeight, taRight);
-            Left += DigitsMaxWidth;
+            Left += DigitsMaxWidth + m_MarginItem3;  // Add margin between total and new recordings
 
-            if (ImgRecNew) MenuIconsPixmap->DrawImage(cPoint(Left, Top), *ImgRecNew);
+            Left = DrawRecordingIcon("recording_new", Left, Top, Current, true);  // Draw small new icon
 
-            Left += ImgRecNewWidth + m_MarginItem;
             Buffer = itoa(New);
             MenuPixmap->DrawText(cPoint(Left, Top), *Buffer, ColorFg, ColorBg, m_FontSml, DigitsMaxWidth,
                                  m_FontSmlHeight);
@@ -1821,14 +1814,14 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
                 MenuPixmap->DrawText(cPoint(Left, Top), *Buffer, ColorExtraTextFg, ColorBg, m_FontSml);
                 if (IsRecordingOld(Recording, Level)) {
                     Left += FontCache.GetStringWidth(m_FontSmlName, m_FontSmlHeight, "00.00.00");
-                    Left = DrawRecordingIcon("recording_old", Left, Top, Current);
+                    Left = DrawRecordingIcon("recording_old", Left, Top, Current, true);
                 }
             }
         } else if (Total == -1) {  // Folder without recordings
             Left = DrawRecordingIcon("folder", Left, Top, Current);
 
-            if (Current && m_Font->Width(Recording->FileName()) > (m_MenuItemWidth - Left - m_MarginItem) &&
-                Config.ScrollerEnable) {
+            if (Current && Config.ScrollerEnable &&
+                m_Font->Width(Recording->FileName()) > (m_MenuItemWidth - Left - m_MarginItem)) {
                 MenuItemScroller.AddScroller(
                     Recording->FileName(),
                     cRect(Left, Top + m_MenuTop, m_MenuItemWidth - Left - m_MarginItem, m_FontHeight), ColorFg,
@@ -1848,7 +1841,7 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
                      .Size = Config.decorBorderMenuItemSize,
                      .Type = Config.decorBorderMenuItemType};
 
-    if (Current) {  // Must check first for Current, because Selectable ia also true
+    if (Current) {  // Must check first for Current, because Selectable is also true
         ib.ColorFg = Config.decorBorderMenuItemCurFg;
         ib.ColorBg = Config.decorBorderMenuItemCurBg;
     } else if (Selectable) {
@@ -2012,14 +2005,14 @@ void cFlatDisplayMenu::DrawEventInfo(const cEvent *Event) {
             cString Audio {""}, Subtitle {""};
             InsertComponents(Components, TextAdditional, Audio, Subtitle);  // Get info for audio/video and subtitle
 
-            if (Audio[0] != '\0') {
+            /* if (Audio[0] != '\0') {
                 if (TextAdditional[0] != '\0') TextAdditional.Append('\n');
                 TextAdditional.Append(cString::sprintf("%s: %s", tr("Audio"), *Audio));
             }
             if (Subtitle[0] != '\0') {
                 if (TextAdditional[0] != '\0') TextAdditional.Append('\n');
                 TextAdditional.Append(cString::sprintf("\n%s: %s", tr("Subtitle"), *Subtitle));
-            }
+            } */
         }  // if Components
     }  // EpgAdditionalInfoShow
 
@@ -2308,8 +2301,8 @@ void cFlatDisplayMenu::DrawItemExtraRecording(const cRecording *Recording, const
                 cString Audio {""}, Subtitle {""};
                 InsertComponents(Components, Text, Audio, Subtitle, true);  // Get info for audio/video and subtitle
 
-                if (Audio[0] != '\0') Text.Append(cString::sprintf("\n%s: %s", tr("Audio"), *Audio));
-                if (Subtitle[0] != '\0') Text.Append(cString::sprintf("\n%s: %s", tr("Subtitle"), *Subtitle));
+                // if (Audio[0] != '\0') Text.Append(cString::sprintf("\n%s: %s", tr("Audio"), *Audio));
+                // if (Subtitle[0] != '\0') Text.Append(cString::sprintf("\n%s: %s", tr("Subtitle"), *Subtitle));
             }
             if (RecInfo->Aux()) InsertAuxInfos(RecInfo, Text, true);  // Insert aux infos with info line
         }  // if Config.RecordingAdditionalInfoShow
@@ -2415,9 +2408,8 @@ void cFlatDisplayMenu::AddActors(cComplexContent &ComplexContent, std::vector<sA
 
     // Setting for TVScraperEPGInfoShowActors and TVScraperRecInfoShowActors
     const int ShowMaxActors {Config.TVScraperShowMaxActors};
-    if (ShowMaxActors == 0) return;  // Do not show actors
-    if (ShowMaxActors > 0 && ShowMaxActors < NumActors)
-        NumActors = ShowMaxActors;  // Limit to ShowMaxActors (-1 = Show all actors)
+    if (ShowMaxActors == 0) return;  // Do not show actors (-1 = Show all actors)
+    if (ShowMaxActors > 0) NumActors = std::min(NumActors, ShowMaxActors);  // Limit to ShowMaxActors
 
     int ContentTop {0};  // Calculated by 'AddExtraInfo()'
     AddExtraInfo(tr("Actors"), "", ComplexContent, ContentTop, IsEvent);
@@ -2428,7 +2420,7 @@ void cFlatDisplayMenu::AddActors(cComplexContent &ComplexContent, std::vector<sA
     cImage *img {nullptr};
     cString Role {""};  // Actor role
     int Actor {0};
-    const int ActorsPerLine {6};                                    // TODO: Config option?
+    const int ActorsPerLine {6};  // TODO: Config option?
     const int ActorWidth {m_cWidth / ActorsPerLine - m_MarginItem2};
     const int ActorMargin {((m_cWidth - m_MarginItem2) - ActorWidth * ActorsPerLine) / (ActorsPerLine - 1)};
     const int PicLines {NumActors / ActorsPerLine + (NumActors % ActorsPerLine != 0)};  // Number of lines needed
@@ -2457,7 +2449,6 @@ void cFlatDisplayMenu::AddActors(cComplexContent &ComplexContent, std::vector<sA
             ++Actor;
         }  // for col
         x = m_MarginItem;
-        // y = ComplexContent.BottomContent() + m_FontHeight;
         y += MaxImgHeight + m_MarginItem + (m_FontTinyHeight * 2) + m_FontHeight;
         MaxImgHeight = 0;  // Reset value for next row
     }  // for row
@@ -2577,14 +2568,14 @@ void cFlatDisplayMenu::DrawRecordingInfo(const cRecording *Recording) {
             cString Audio {""}, Subtitle {""};
             InsertComponents(Components, TextAdditional, Audio, Subtitle);  // Get info for audio/video and subtitle
 
-            if (Audio[0] != '\0') {
+            /* if (Audio[0] != '\0') {
                 if (TextAdditional[0] != '\0') TextAdditional.Append('\n');
                 TextAdditional.Append(cString::sprintf("%s: %s", tr("Audio"), *Audio));
             }
             if (Subtitle[0] != '\0') {
                 if (TextAdditional[0] != '\0') TextAdditional.Append('\n');
                 TextAdditional.Append(cString::sprintf("\n%s: %s", tr("Subtitle"), *Subtitle));
-            }
+            } */
         }
         if (RecInfo->Aux()) InsertAuxInfos(RecInfo, RecAdditional, false);  // Insert aux infos without info line
     }  // if Config.RecordingAdditionalInfoShow
@@ -3437,9 +3428,10 @@ void cFlatDisplayMenu::DrawMainMenuWidgets() {
 
     int AddHeight {0}, ContentTop {0};
     for (const auto &e : entries) {
-        if (!*(e.enableFlag)) continue;  // Widget not enabled — skip
-        AddHeight = (this->*(e.drawFn))(wLeft, wWidth, ContentTop, MenuPixmapViewPortHeight);
-        if (AddHeight > 0) ContentTop = AddHeight + m_MarginItem;
+        if (*(e.enableFlag)) {  // Widget enabled — draw it
+            AddHeight = (this->*(e.drawFn))(wLeft, wWidth, ContentTop, MenuPixmapViewPortHeight);
+            if (AddHeight > 0) ContentTop = AddHeight + m_MarginItem;
+        }
     }
 
     ContentWidget.CreatePixmaps(false);
@@ -3568,10 +3560,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetDVBDevices(int wLeft, int wWidth, int Co
             }
         }
 
-        if (Config.MainMenuWidgetDVBDevicesNativeNumbering)
-            str = itoa(i);  // Display Tuners 0..3
-        else
-            str = itoa(i + 1);  // Display Tuners 1..4
+        str = (Config.MainMenuWidgetDVBDevicesNativeNumbering) ? itoa(i) : itoa(i + 1);  // Display Tuners 0..3 or 1..4
 
         int left {m_MarginItem};
         const int FontSmlWidthDigit {FontCache.GetStringWidth(m_FontSmlName, m_FontSmlHeight, "0")};
@@ -3600,7 +3589,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetDVBDevices(int wLeft, int wWidth, int Co
         ContentTop += m_FontSmlHeight;
     }  // for NumDevices
 
-    if (FoundTuner == false) {
+    if (!FoundTuner) {
         dsyslog("flatPlus: DrawMainMenuWidgetDVBDevices() No DVB devices found");
         ContentWidget.AddText(tr("No DVB devices found"), false,
                               cRect(m_MarginItem, ContentTop, wWidth - m_MarginItem2, m_FontSmlHeight),
@@ -3857,7 +3846,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetLastRecordings(int wLeft, int wWidth, in
             RecStart = Rec->Start();
             TimeHM = std::div((Rec->LengthInSeconds() + 30) / 60, 60);
             Length = cString::sprintf("%02d:%02d", TimeHM.quot, TimeHM.rem);
-            DateTime = cString::sprintf("%s %s Σ%s", *ShortDateString(RecStart), *TimeString(RecStart), *Length);
+            DateTime = cString::sprintf("%s %s Σ %s", *ShortDateString(RecStart), *TimeString(RecStart), *Length);
             StrRec = cString::sprintf("%s - %s", *DateTime, Rec->Name());
             Recs.emplace_back(std::make_pair(RecStart, StrRec));
         }

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -18,7 +18,6 @@
 #include <vdr/videodir.h>
 
 #include <dirent.h>
-#include <fstream>
 #include <functional>  // std::less
 #include <locale>
 #include <sstream>
@@ -4216,19 +4215,19 @@ int cFlatDisplayMenu::DrawMainMenuWidgetCommand(int wLeft, int wWidth, int Conte
 
     ContentTop = AddWidgetHeader("widgets/command_output", *Title, ContentTop, wWidth);
 
-    std::string Output {""};
-    Output.reserve(32);
+    const char *s {nullptr};
     static const cString ItemFilename = cString::sprintf("%s/command_output/output", WIDGETOUTPUTPATH);
-    std::ifstream file(*ItemFilename);
-    if (file.is_open()) {
-        for (; std::getline(file, Output);) {
+    FILE *f = fopen(*ItemFilename, "r");
+    if (f) {
+        cReadLine ReadLine;
+        while ((s = ReadLine.Read(f)) != nullptr) {
             if (ContentTop + m_MarginItem > MenuPixmapViewPortHeight) break;
             ContentWidget.AddText(
-                Output.c_str(), false, cRect(m_MarginItem, ContentTop, wWidth - m_MarginItem2, m_FontSmlHeight),
+                s, false, cRect(m_MarginItem, ContentTop, wWidth - m_MarginItem2, m_FontSmlHeight),
                 Theme.Color(clrMenuEventFontInfo), Theme.Color(clrMenuEventBg), m_FontSml, wWidth - m_MarginItem2);
             ContentTop += m_FontSmlHeight;
         }
-        file.close();
+        fclose(f);
     } else {
         ContentWidget.AddText(
             tr("no output available"), false, cRect(m_MarginItem, ContentTop, wWidth - m_MarginItem2, m_FontSmlHeight),

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -994,10 +994,10 @@ bool cFlatDisplayMenu::SetItemTimer(const cTimer *Timer, int Index, bool Current
                              m_MenuItemWidth - Left - m_MarginItem);
         Left += FontCache.GetStringWidth(m_FontName, m_FontHeight, "MMM 00.  ");
         Buffer =
-            cString::sprintf("%02d:%02d - %02d:%02d", TimerStart.quot, TimerStart.rem, TimerStop.quot, TimerStop.rem);
+            cString::sprintf("%02d:%02d–%02d:%02d", TimerStart.quot, TimerStart.rem, TimerStop.quot, TimerStop.rem);
         MenuPixmap->DrawText(cPoint(Left, Top), *Buffer, ColorFg, ColorBg, m_Font,
                              m_MenuItemWidth - Left - m_MarginItem);
-        Left += FontCache.GetStringWidth(m_FontName, m_FontHeight, "00:00 - 00:00  ");
+        Left += FontCache.GetStringWidth(m_FontName, m_FontHeight, "00:00–00:00  ");
 
         if (Current && m_Font->Width(File) > (m_MenuItemWidth - Left - m_MarginItem) && Config.ScrollerEnable) {
             MenuItemScroller.AddScroller(
@@ -1025,7 +1025,7 @@ bool cFlatDisplayMenu::SetItemTimer(const cTimer *Timer, int Index, bool Current
             }
         }
     } else if (Config.MenuTimerView == 2 || Config.MenuTimerView == 3) {  // flatPlus short, flatPlus short + EPG
-        Buffer = cString::sprintf("%s%s%s.  %02d:%02d - %02d:%02d", *name, *name && **name ? " " : "", *day,
+        Buffer = cString::sprintf("%s%s%s.  %02d:%02d–%02d:%02d", *name, *name && **name ? " " : "", *day,
                                   TimerStart.quot, TimerStart.rem, TimerStop.quot, TimerStop.rem);
         MenuPixmap->DrawText(cPoint(Left, Top), *Buffer, ColorFg, ColorBg, m_Font,
                              m_MenuItemWidth - Left - m_MarginItem);
@@ -2183,7 +2183,7 @@ void cFlatDisplayMenu::DrawEventInfo(const cEvent *Event) {
     ContentHeadPixmap->DrawRectangle(cRect(0, 0, m_MenuWidth, m_chHeight), Theme.Color(clrScrollbarBg));
 
     const cString StrTime =
-        cString::sprintf("%s  %s - %s", *Event->GetDateString(), *Event->GetTimeString(), *Event->GetEndTimeString());
+        cString::sprintf("%s  %s–%s", *Event->GetDateString(), *Event->GetTimeString(), *Event->GetEndTimeString());
 
     const cString Title = Event->Title();
     const cString ShortText = (Event->ShortText()) ? Event->ShortText() : "";  // No short text. Show empty string

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -1209,7 +1209,7 @@ bool cFlatDisplayMenu::SetItemEvent(const cEvent *Event, int Index, bool Current
             const time_t EventStartTime {Event->StartTime()};
             static constexpr int kTwoMinutes {2 * 60};
             if ((now >= (EventStartTime - kTwoMinutes))) {
-                const int total = Event->EndTime() - EventStartTime;  // Narrowing conversion
+                const time_t total {Event->EndTime() - EventStartTime};
                 if (total >= 0) {
                     // Calculate progress bar
                     const double duration = Event->Duration();

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -2411,6 +2411,7 @@ void cFlatDisplayMenu::AddActors(cComplexContent &ComplexContent, std::vector<sA
                                  bool IsEvent) {
 #ifdef DEBUGFUNCSCALL
     dsyslog("flatPlus: cFlatDisplayMenu::AddActors()");
+    cTimeMs Timer;  // Set Timer
 #endif
 
     // Setting for TVScraperEPGInfoShowActors and TVScraperRecInfoShowActors
@@ -2435,10 +2436,6 @@ void cFlatDisplayMenu::AddActors(cComplexContent &ComplexContent, std::vector<sA
     int ImgHeight {0}, MaxImgHeight {0};
     int x {m_MarginItem};
     int y {ContentTop};
-#ifdef DEBUGFUNCSCALL
-    int y2 {ContentTop};  //! y2 is for testing
-    dsyslog("   ActorWidth/ActorMargin: %d/%d", ActorWidth, ActorMargin);
-#endif
     if (NumActors > 48) isyslog("flatPlus: First display of %d actor images will probably be slow!", NumActors);
 
     for (std::size_t row {0}; row < PicLines; ++row) {
@@ -2455,9 +2452,6 @@ void cFlatDisplayMenu::AddActors(cComplexContent &ComplexContent, std::vector<sA
                 ComplexContent.AddText(
                     *Role, false, cRect(x, y + ImgHeight + m_MarginItem + m_FontTinyHeight, ActorWidth, 0),
                     ColorMenuFontInfo, ColorMenuBg, m_FontTiny, ActorWidth, m_FontTinyHeight, taCenter);
-#ifdef DEBUGFUNCSCALL
-                if (ImgHeight > MaxImgHeight) { dsyslog("   Column %ld: MaxImgHeight changed to %d", col, ImgHeight); }
-#endif
                 MaxImgHeight = std::max(MaxImgHeight, ImgHeight);  // In case images have different size
             }
             x += ActorWidth + ActorMargin;
@@ -2466,13 +2460,11 @@ void cFlatDisplayMenu::AddActors(cComplexContent &ComplexContent, std::vector<sA
         x = m_MarginItem;
         // y = ComplexContent.BottomContent() + m_FontHeight;
         y += MaxImgHeight + m_MarginItem + (m_FontTinyHeight * 2) + m_FontHeight;
-#ifdef DEBUGFUNCSCALL
-        // Alternate way to get y
-        y2 += MaxImgHeight + m_MarginItem + (m_FontTinyHeight * 2) + m_FontHeight;
-        dsyslog("   y/y2 BottomContent()/Calculation: %d/%d", ComplexContent.BottomContent() + m_FontHeight, y2);
-#endif
         MaxImgHeight = 0;  // Reset value for next row
     }  // for row
+#ifdef DEBUGFUNCSCALL
+    dsyslog("flatPlus: AddActors() time: %ld ms", Timer.Elapsed());
+#endif
 }
 
 /**

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -3945,7 +3945,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation(int wLeft, int wWidth,
 
     static const cString ExecFile {cString::sprintf("\"%s/system_information/system_information\"", WIDGETFOLDER)};
     if (system(*ExecFile) != 0) {  // If the system call fails, indicate that the widget cannot be displayed
-        dsyslog("flatPlus: cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation() system() failed!");
+        dsyslog("flatPlus: cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation() system call failed!");
         return -1;
     }
 
@@ -3962,19 +3962,21 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation(int wLeft, int wWidth,
 
     struct dirent *entry;
     cString num {""};
-    std::string_view FileName {""};
+    std::string_view svFileName {""};  // Also used later when extracting the item name from the file name
     std::size_t found {std::string_view::npos};
     while ((entry = d.Next()) != nullptr) {
-        FileName = entry->d_name;
-        found = FileName.find('_');
+        svFileName = entry->d_name;
+        found = svFileName.find('_');
         if (found != std::string_view::npos) {               // File name contains '_'
-            num = cString(FileName.data()).Truncate(found);  // Truncate the string to the number part
+            num = cString(svFileName.data()).Truncate(found);  // Truncate the string to the number part
             if (atoi(*num) > 0)                              // Number is greater than zero
-                files.emplace_back(FileName.data());         // Store the file name
+                files.emplace_back(svFileName.data());         // Store the file name
         }
     }
+#ifdef DEBUGFUNCSCALL
+    dsyslog("flatPlus: DrawMainMenuWidgetSystemInfomation() Found %ld files @ %ld ms", files.size(), Timer.Elapsed());
+#endif
 
-    // dsyslog("flatPlus: DrawMainMenuWidgetSystemInfomation() Found %ld files", files.size());
     std::sort(files.begin(), files.end(), CompareNumStrings);  // Sort the files by number
 
     ContentTop = AddWidgetHeader("widgets/system_information", tr("System Information"), ContentTop, wWidth);
@@ -4011,7 +4013,6 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation(int wLeft, int wWidth,
                    {"security_updates", trNOOP("Security Updates")}};
 
         cString item {""}, ItemContent {""}, ItemFilename {""};
-        std::string_view svFileName {""};  // Use std::string_view for better performance
         int Column {1};
         int ContentLeft {m_MarginItem};
         for (const cString &FileName : files) {
@@ -4108,7 +4109,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetTemperatures(int wLeft, int wWidth, int 
     static const cString ExecFile {
         cString::sprintf("cd \"%s/temperatures\"; \"%s/temperatures/temperatures\"", WIDGETFOLDER, WIDGETFOLDER)};
     if (system(*ExecFile) != 0) {  // If the system call fails, indicate that the widget cannot be displayed
-        dsyslog("flatPlus: cFlatDisplayMenu::DrawMainMenuWidgetTemperatures() system() failed!");
+        dsyslog("flatPlus: cFlatDisplayMenu::DrawMainMenuWidgetTemperatures() system call failed!");
         return -1;
     }
     ContentTop = AddWidgetHeader("widgets/temperatures", tr("Temperatures"), ContentTop, wWidth);
@@ -4181,7 +4182,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetCommand(int wLeft, int wWidth, int Conte
 
     static const cString ExecFile {cString::sprintf("\"%s/command_output/command\"", WIDGETFOLDER)};
     if (system(*ExecFile) != 0) {  // If the system call fails, indicate that the widget cannot be displayed
-        dsyslog("flatPlus: cFlatDisplayMenu::DrawMainMenuWidgetCommand() system() failed!");
+        dsyslog("flatPlus: cFlatDisplayMenu::DrawMainMenuWidgetCommand() system call failed!");
         return -1;
     }
 

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -4020,7 +4020,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation(int wLeft, int wWidth,
             svFileName = *FileName;  // Convert cString to std::string_view
             found = svFileName.find('_');
             item = svFileName.substr(found + 1).data();  // Extract the item name
-            ItemFilename = cString::sprintf("%s/system_information/%s", WIDGETOUTPUTPATH, svFileName.data());
+            ItemFilename = cString::sprintf("%s/system_information/%s", WIDGETOUTPUTPATH, *FileName);
 
             ItemContent = ReadAndExtractData(ItemFilename);
             if (isempty(*ItemContent)) continue;

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -491,12 +491,12 @@ void cFlatDisplayMenu::SetItem(const char *Text, int Index, bool Current, bool S
                      .Size = Config.decorBorderMenuItemSize,
                      .Type = Config.decorBorderMenuItemType};
 
-    if (Current) {
-        ib.ColorFg = Config.decorBorderMenuItemCurFg;
-        ib.ColorBg = Config.decorBorderMenuItemCurBg;
-    } else if (Selectable) {
+    if (Selectable) {  // Most items are selectable, so check this first to avoid unnecessary checks for Current
         ib.ColorFg = Config.decorBorderMenuItemSelFg;
         ib.ColorBg = Config.decorBorderMenuItemSelBg;
+    } else if (Current) {
+        ib.ColorFg = Config.decorBorderMenuItemCurFg;
+        ib.ColorBg = Config.decorBorderMenuItemCurBg;
     } else {
         ib.ColorFg = Config.decorBorderMenuItemFg;
         ib.ColorBg = Config.decorBorderMenuItemBg;
@@ -719,12 +719,12 @@ bool cFlatDisplayMenu::SetItemChannel(const cChannel *Channel, int Index, bool C
                      .Size = Config.decorBorderMenuItemSize,
                      .Type = Config.decorBorderMenuItemType};
 
-    if (Current) {
-        ib.ColorFg = Config.decorBorderMenuItemCurFg;
-        ib.ColorBg = Config.decorBorderMenuItemCurBg;
-    } else if (Selectable) {
+    if (Selectable) {  // Most items are selectable, so check this first to avoid unnecessary checks for Current
         ib.ColorFg = Config.decorBorderMenuItemSelFg;
         ib.ColorBg = Config.decorBorderMenuItemSelBg;
+    } else if (Current) {
+        ib.ColorFg = Config.decorBorderMenuItemCurFg;
+        ib.ColorBg = Config.decorBorderMenuItemCurBg;
     } else {
         ib.ColorFg = Config.decorBorderMenuItemFg;
         ib.ColorBg = Config.decorBorderMenuItemBg;
@@ -1063,12 +1063,12 @@ bool cFlatDisplayMenu::SetItemTimer(const cTimer *Timer, int Index, bool Current
                      .Size = Config.decorBorderMenuItemSize,
                      .Type = Config.decorBorderMenuItemType};
 
-    if (Current) {
-        ib.ColorFg = Config.decorBorderMenuItemCurFg;
-        ib.ColorBg = Config.decorBorderMenuItemCurBg;
-    } else if (Selectable) {
+    if (Selectable) {  // Most items are selectable, so check this first to avoid unnecessary checks for Current
         ib.ColorFg = Config.decorBorderMenuItemSelFg;
         ib.ColorBg = Config.decorBorderMenuItemSelBg;
+    } else if (Current) {
+        ib.ColorFg = Config.decorBorderMenuItemCurFg;
+        ib.ColorBg = Config.decorBorderMenuItemCurBg;
     } else {
         ib.ColorFg = Config.decorBorderMenuItemFg;
         ib.ColorBg = Config.decorBorderMenuItemBg;
@@ -1437,12 +1437,12 @@ bool cFlatDisplayMenu::SetItemEvent(const cEvent *Event, int Index, bool Current
                      .Size = Config.decorBorderMenuItemSize,
                      .Type = Config.decorBorderMenuItemType};
 
-    if (Current) {
-        ib.ColorFg = Config.decorBorderMenuItemCurFg;
-        ib.ColorBg = Config.decorBorderMenuItemCurBg;
-    } else if (Selectable) {
+    if (Selectable) {  // Most items are selectable, so check this first to avoid unnecessary checks for Current
         ib.ColorFg = Config.decorBorderMenuItemSelFg;
         ib.ColorBg = Config.decorBorderMenuItemSelBg;
+    } else if (Current) {
+        ib.ColorFg = Config.decorBorderMenuItemCurFg;
+        ib.ColorBg = Config.decorBorderMenuItemCurBg;
     } else {
         ib.ColorFg = Config.decorBorderMenuItemFg;
         ib.ColorBg = Config.decorBorderMenuItemBg;
@@ -1847,12 +1847,12 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
                      .Size = Config.decorBorderMenuItemSize,
                      .Type = Config.decorBorderMenuItemType};
 
-    if (Current) {
-        ib.ColorFg = Config.decorBorderMenuItemCurFg;
-        ib.ColorBg = Config.decorBorderMenuItemCurBg;
-    } else if (Selectable) {
+    if (Selectable) {  // Most items are selectable, so check this first to avoid unnecessary checks for Current
         ib.ColorFg = Config.decorBorderMenuItemSelFg;
         ib.ColorBg = Config.decorBorderMenuItemSelBg;
+    } else if (Current) {
+        ib.ColorFg = Config.decorBorderMenuItemCurFg;
+        ib.ColorBg = Config.decorBorderMenuItemCurBg;
     } else {
         ib.ColorFg = Config.decorBorderMenuItemFg;
         ib.ColorBg = Config.decorBorderMenuItemBg;

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -3144,7 +3144,7 @@ cString cFlatDisplayMenu::GetRecCounts() const {
                 RecFolder2 = *GetRecordingName(Rec, RecordingLevel);
                 if (strcmp(*m_RecFolder, *RecFolder2) == 0) {  // Compare recording folder with current folder
                     ++RecCount;
-                    if (Rec->IsNew()) ++RecNewCount;
+                    RecNewCount += (Rec->IsNew()) ? 1 : 0;  // Increment RecNewCount if recording is new
                 }
             }  // for
         }
@@ -3155,7 +3155,7 @@ cString cFlatDisplayMenu::GetRecCounts() const {
                 RecFolder2 = *GetRecordingName(Rec, RecordingLevel);
                 if (strcmp(*m_RecFolder, *RecFolder2) == 0) {  // Compare recording folder with current folder
                     ++RecCount;
-                    if (Rec->IsNew()) ++RecNewCount;
+                    RecNewCount += (Rec->IsNew()) ? 1 : 0;  // Increment RecNewCount if recording is new
                 }
             }  // for
         }
@@ -3165,7 +3165,7 @@ cString cFlatDisplayMenu::GetRecCounts() const {
             LOCK_RECORDINGS_READ;  // Creates local const cRecordings *Recordings
             for (const cRecording *Rec {Recordings->First()}; Rec; Rec = Recordings->Next(Rec)) {
                 ++RecCount;
-                if (Rec->IsNew()) ++RecNewCount;
+                RecNewCount += (Rec->IsNew()) ? 1 : 0;  // Increment RecNewCount if recording is new
             }
         }
 #if APIVERSNUM >= 30012
@@ -3173,7 +3173,7 @@ cString cFlatDisplayMenu::GetRecCounts() const {
             LOCK_DELETEDRECORDINGS_READ;  // Creates local const cRecordings *DeletedRecordings
             for (const cRecording *Rec {DeletedRecordings->First()}; Rec; Rec = DeletedRecordings->Next(Rec)) {
                 ++RecCount;
-                if (Rec->IsNew()) ++RecNewCount;
+                RecNewCount += (Rec->IsNew()) ? 1 : 0;  // Increment RecNewCount if recording is new
             }
         }
 #endif
@@ -3207,7 +3207,7 @@ void cFlatDisplayMenu::UpdateTimerCounts(uint16_t &TimerActiveCount, uint16_t &T
     LOCK_TIMERS_READ;  // Creates local const cTimers *Timers
     for (const cTimer *Timer {Timers->First()}; Timer; Timer = Timers->Next(Timer)) {
         ++TimerCount;
-        if (Timer->HasFlags(tfActive)) ++TimerActiveCount;
+        TimerActiveCount += (Timer->HasFlags(tfActive)) ? 1 : 0;  // Increment TimerActiveCount if timer is active
     }
 #ifdef DEBUGFUNCSCALL
     dsyslog("   TimerActiveCount: %d, TimerCount: %d, time: %ld ms", TimerActiveCount, TimerCount, Timer.Elapsed());
@@ -3374,7 +3374,7 @@ void cFlatDisplayMenu::DrawProgressBarFromText(const cRect &rec, const cRect &re
     const char *p {bar + 1};
     uint16_t now {0}, total {0};
     while (*p != ']') {
-        if (*p == '|') ++now;
+        now += (*p == '|') ? 1 : 0;  // Increment now if character is '|'
         ++total;
         ++p;
     }
@@ -4116,16 +4116,16 @@ int cFlatDisplayMenu::DrawMainMenuWidgetTemperatures(int wLeft, int wWidth, int 
     int CountTemps {0};
 
     const cString TempCPU {ReadAndExtractData(cString::sprintf("%s/temperatures/cpu", WIDGETOUTPUTPATH))};
-    if (!isempty(*TempCPU)) ++CountTemps;
+    CountTemps += (!isempty(*TempCPU)) ? 1 : 0;
 
     const cString TempCase {ReadAndExtractData(cString::sprintf("%s/temperatures/pccase", WIDGETOUTPUTPATH))};
-    if (!isempty(*TempCase)) ++CountTemps;
+    CountTemps += (!isempty(*TempCase)) ? 1 : 0;
 
     const cString TempMB {ReadAndExtractData(cString::sprintf("%s/temperatures/motherboard", WIDGETOUTPUTPATH))};
-    if (!isempty(*TempMB)) ++CountTemps;
+    CountTemps += (!isempty(*TempMB)) ? 1 : 0;
 
     const cString TempGPU {ReadAndExtractData(cString::sprintf("%s/temperatures/gpu", WIDGETOUTPUTPATH))};
-    if (!isempty(*TempGPU)) ++CountTemps;
+    CountTemps += (!isempty(*TempGPU)) ? 1 : 0;
 
     if (CountTemps == 0) {
         ContentWidget.AddText(tr("Temperatures not available please check the widget"), false,
@@ -4400,7 +4400,7 @@ void cFlatDisplayMenu::PreLoadImages() {
     for (const cChannel *Channel {Channels->First()}; Channel && i < kLogoPreCache; Channel = Channels->Next(Channel)) {
         if (!Channel->GroupSep()) {  // Don't cache named channel group logo
             img = ImgLoader.GetLogo(Channel->Name(), ImageBgWidth - 4, ImageBgHeight - 4);
-            if (img) ++i;
+            i += (img ? 1 : 0);
         }
     }  // for channel
 

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -2086,6 +2086,14 @@ void cFlatDisplayMenu::DrawEventInfo(const cEvent *Event) {
     bool FirstRun {true};
     bool Scrollable {false};
 
+    // Get media information from TVScraper if enabled in config
+    if (Config.TVScraperEPGInfoShowPoster || Config.TVScraperEPGInfoShowActors) {
+        GetScraperMedia(MediaPath, SeriesInfo, MovieInfo, Actors, Event);
+    }
+#ifdef DEBUGEPGTIME
+    dsyslog("flatPlus: DrawEventInfo() TVScraper time @ %ld ms", Timer.Elapsed());
+#endif
+
     // First run setup
     m_cWidth -= m_WidthScrollBar;  // Assume that we need scrollbar most of the time
 
@@ -2097,13 +2105,6 @@ void cFlatDisplayMenu::DrawEventInfo(const cEvent *Event) {
         ComplexContent.SetScrollSize(m_FontHeight);
         ComplexContent.SetScrollingActive(true);
 
-        // Call scraper plugin only at first run and reuse data at second run
-        if (FirstRun && (Config.TVScraperEPGInfoShowPoster || Config.TVScraperEPGInfoShowActors)) {
-            GetScraperMedia(MediaPath, SeriesInfo, MovieInfo, Actors, Event);
-        }
-#ifdef DEBUGEPGTIME
-        dsyslog("flatPlus: DrawEventInfo() TVScraper time @ %ld ms", Timer.Elapsed());
-#endif
         ContentTop = m_MarginItem;
 
         // Add description header if needed
@@ -2603,6 +2604,18 @@ void cFlatDisplayMenu::DrawRecordingInfo(const cRecording *Recording) {
     bool FirstRun {true};
     bool Scrollable {false};
 
+    // Get media information from TVScraper if enabled in config
+    if (Config.TVScraperRecInfoShowPoster || Config.TVScraperRecInfoShowActors) {
+        GetScraperMedia(MediaPath, SeriesInfo, MovieInfo, Actors, nullptr, Recording);
+        if (MediaPath[0] == '\0' && Config.TVScraperSearchLocalPosters) {  // Prio for tvscraper poster
+            const cString RecPath {Recording->FileName()};
+            ImgLoader.SearchRecordingPoster(RecPath, MediaPath);
+        }
+    }
+#ifdef DEBUGEPGTIME
+    dsyslog("flatPlus: DrawRecordingInfo() TVSscraper time @ %ld ms", Timer.Elapsed());
+#endif
+
     // First run setup
     m_cWidth -= m_WidthScrollBar;  // Assume that we need scrollbar most of the time
 
@@ -2614,17 +2627,6 @@ void cFlatDisplayMenu::DrawRecordingInfo(const cRecording *Recording) {
         ComplexContent.SetScrollSize(m_FontHeight);
         ComplexContent.SetScrollingActive(true);
 
-        // Call scraper plugin only at first run and reuse data at second run
-        if (FirstRun && (Config.TVScraperRecInfoShowPoster || Config.TVScraperRecInfoShowActors)) {
-            GetScraperMedia(MediaPath, SeriesInfo, MovieInfo, Actors, nullptr, Recording);
-            if (MediaPath[0] == '\0' && Config.TVScraperSearchLocalPosters) {  // Prio for tvscraper poster
-                const cString RecPath {Recording->FileName()};
-                ImgLoader.SearchRecordingPoster(RecPath, MediaPath);
-            }
-        }
-#ifdef DEBUGEPGTIME
-        dsyslog("flatPlus: DrawRecordingInfo() TVSscraper time @ %ld ms", Timer.Elapsed());
-#endif
         MediaWidth = m_cWidth / 2 - m_MarginItem2;
         ContentTop = m_MarginItem;
 

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -559,7 +559,7 @@ bool cFlatDisplayMenu::SetItemChannel(const cChannel *Channel, int Index, bool C
 
     int ImageLeft {Left};
     int ImageTop {Top};
-    int ImageBgWidth = m_FontHeight * 1.34f;  // Narrowing conversion
+    int ImageBgWidth {static_cast<int>(m_FontHeight * 1.34f)};
     int ImageBgHeight {m_FontHeight};
 
     cImage *img {nullptr};
@@ -938,7 +938,7 @@ bool cFlatDisplayMenu::SetItemTimer(const cTimer *Timer, int Index, bool Current
     Left += Width + m_MarginItem;
 
     ImageLeft = Left;
-    int ImageBgWidth = ImageHeight * 1.34f;  // Narrowing conversion
+    int ImageBgWidth {static_cast<int>(ImageHeight * 1.34f)};
     int ImageBgHeight {ImageHeight};
     img = ImgLoader.GetLogoBg(ImageBgWidth, ImageBgHeight);  // Load 'logo_background'
     if (img) {
@@ -1146,7 +1146,7 @@ bool cFlatDisplayMenu::SetItemEvent(const cEvent *Event, int Index, bool Current
         if (Current) m_ItemEventLastChannelName = ChannelName;
 
         int ImageLeft {Left};
-        int ImageBgWidth = m_FontHeight * 1.34f;  // Narrowing conversion
+        int ImageBgWidth {static_cast<int>(m_FontHeight * 1.34f)};
         int ImageBgHeight {m_FontHeight};
         if (!IsGroup) {
             img = ImgLoader.GetLogoBg(ImageBgWidth, ImageBgHeight);  // Load 'logo_background'
@@ -1884,7 +1884,7 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
  *                      and duplicates are removed before drawing.
  */
 int cFlatDisplayMenu::DrawContentHeadFskGenre(const cString &Fsk, std::vector<std::string> &GenreIcons) {
-    const int IconHeight = (m_chHeight - m_MarginItem2) * Config.EpgFskGenreIconSize * 100.0;  // Narrowing conversion
+    const int IconHeight {static_cast<int>((m_chHeight - m_MarginItem2) * Config.EpgFskGenreIconSize * 100.0)};
     const int HeadIconTop {m_chHeight - IconHeight - m_MarginItem};  // Position for fsk/genre image
     int HeadIconLeft {m_chWidth - IconHeight - m_MarginItem};
 
@@ -2148,7 +2148,7 @@ void cFlatDisplayMenu::DrawEventInfo(const cEvent *Event) {
 #endif
 
         // Add actors if available
-        const int NumActors = Actors.size();  // Narrowing conversion
+        const std::size_t NumActors {Actors.size()};
         if (Config.TVScraperEPGInfoShowActors && NumActors > 0)
             AddActors(ComplexContent, Actors, NumActors, true);
 #ifdef DEBUGEPGTIME
@@ -2342,7 +2342,7 @@ void cFlatDisplayMenu::DrawItemExtraRecording(const cRecording *Recording, const
             if (ImgLoader.SearchRecordingPoster(RecPath, MediaPath)) {
                 img = ImgLoader.GetFile(*MediaPath, m_cWidth - m_MarginItem2, MediaHeight);
                 if (img) {
-                    const uint16_t Aspect = img->Width() / img->Height();  // Narrowing conversion
+                    const int Aspect {img->Width() / img->Height()};
                     if (Aspect < 1) {                                      //* Poster (For example 680x1000 = 0.68)
                         MediaWidth = m_cWidth / 2 - m_MarginItem3;
                         MediaType = 2;
@@ -2429,10 +2429,10 @@ void cFlatDisplayMenu::AddActors(cComplexContent &ComplexContent, std::vector<sA
     cImage *img {nullptr};
     cString Role {""};  // Actor role
     int Actor {0};
-    const uint16_t ActorsPerLine {6};                                    // TODO: Config option?
-    const int ActorWidth = m_cWidth / ActorsPerLine - m_MarginItem2;  // Narrowing conversion
-    const int ActorMargin = ((m_cWidth - m_MarginItem2) - ActorWidth * ActorsPerLine) / (ActorsPerLine - 1);
-    const uint16_t PicLines = NumActors / ActorsPerLine + (NumActors % ActorsPerLine != 0);  // Number of lines needed
+    const int ActorsPerLine {6};                                    // TODO: Config option?
+    const int ActorWidth {m_cWidth / ActorsPerLine - m_MarginItem2};
+    const int ActorMargin {((m_cWidth - m_MarginItem2) - ActorWidth * ActorsPerLine) / (ActorsPerLine - 1)};
+    const int PicLines {NumActors / ActorsPerLine + (NumActors % ActorsPerLine != 0)};  // Number of lines needed
     int ImgHeight {0}, MaxImgHeight {0};
     int x {m_MarginItem};
     int y {ContentTop};
@@ -2645,7 +2645,7 @@ void cFlatDisplayMenu::DrawRecordingInfo(const cRecording *Recording) {
             img = ImgLoader.GetFile(*MediaPath, MediaWidth, MediaHeight);
             //* Make portrait smaller than poster or banner to prevent wasting of space
             if (img) {
-                const uint16_t Aspect = img->Width() / img->Height();  // Narrowing conversion
+                const int Aspect {img->Width() / img->Height()};
                 if (Aspect > 1 && Aspect < 4) {                        //* Portrait (For example 1920x1080)
                     // dsyslog("flatPlus: SetRecording() Portrait image %dx%d (%d) found! Setting to 2/3 size.",
                     //         img->Width(), img->Height(), Aspect);
@@ -2679,7 +2679,7 @@ void cFlatDisplayMenu::DrawRecordingInfo(const cRecording *Recording) {
 #endif
 
         // Add actors if available
-        const int NumActors = Actors.size();  // Narrowing conversion
+        const std::size_t NumActors {Actors.size()};
         if (Config.TVScraperRecInfoShowActors && NumActors > 0)
             AddActors(ComplexContent, Actors, NumActors);
 #ifdef DEBUGEPGTIME
@@ -3394,8 +3394,8 @@ void cFlatDisplayMenu::DrawMainMenuWidgets() {
     if (!MenuPixmap) return;
 
     const int MenuPixmapViewPortHeight {MenuPixmap->ViewPort().Height()};
-    const int wLeft = (m_OsdWidth * Config.MainMenuItemScale) + m_MarginItem + Config.decorBorderMenuContentSize +
-                      Config.decorBorderMenuItemSize;  // Narrowing conversion
+    const int wLeft {static_cast<int>(m_OsdWidth * Config.MainMenuItemScale) + m_MarginItem +
+                     Config.decorBorderMenuContentSize + Config.decorBorderMenuItemSize};
     const int wTop {m_TopBarHeight + m_MarginItem + Config.decorBorderTopBarSize * 2 +
                     Config.decorBorderMenuContentSize};
 
@@ -4299,8 +4299,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetWeather(int wLeft, int wWidth, int Conte
     cImage *img {nullptr};
     const int Middle {(m_FontHeight - m_FontTempSmlHeight) / 2};  // Vertical center
     const int TempSmlWidth {FontCache.GetStringWidth(m_FontTempSmlName, m_FontTempSmlHeight, "-00,0 °C")};  // Width
-    const int16_t MainMenuWidgetWeatherDays =
-        std::min(Config.MainMenuWidgetWeatherDays, wd.kMaxDays);                           // Narrowing conversion
+    const int MainMenuWidgetWeatherDays {std::min(Config.MainMenuWidgetWeatherDays, wd.kMaxDays)};
     if (Config.MainMenuWidgetWeatherType == 0) {                                           // Short
         const int TempBarWidth {FontCache.GetStringWidth(m_FontName, m_FontHeight, "|")};  // Width of the char '|'
         // Width to fit the temperature string in
@@ -4434,7 +4433,7 @@ void cFlatDisplayMenu::PreLoadImages() {
 
     // Channel icons
     int ImageBgHeight {ImageHeight};
-    int ImageBgWidth = ImageHeight * 1.34f;  // Narrowing conversion
+    int ImageBgWidth {static_cast<int>(ImageHeight * 1.34f)};
     cImage *img = ImgLoader.GetLogoBg(ImageBgWidth, ImageBgHeight);  // Load 'logo_background'
     if (img) {
         ImageBgHeight = img->Height();

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -207,8 +207,7 @@ void cFlatDisplayMenu::DrawScrollbar(int Total, int Offset, int Shown, int Top, 
 void cFlatDisplayMenu::Scroll(bool Up, bool Page) {
     // Is the menu scrolling or content?
     if (ComplexContent.IsShown() && ComplexContent.IsScrollingActive() && ComplexContent.Scrollable()) {
-        const bool IsScrolled {ComplexContent.Scroll(Up, Page)};
-        if (IsScrolled) {
+        if (ComplexContent.Scroll(Up, Page)) {
             const int ScrollOffset {ComplexContent.ScrollOffset()};  // Cache value
             DrawScrollbar(ComplexContent.ScrollTotal(), ScrollOffset, ComplexContent.ScrollShown(),
                           ComplexContent.Top() - m_ScrollBarTop, ComplexContent.Height(), ScrollOffset > 0,
@@ -676,14 +675,12 @@ bool cFlatDisplayMenu::SetItemChannel(const cChannel *Channel, int Index, bool C
             //? m_WidthScrollBar is already substarcted
             Width = (m_MenuItemWidth + (m_IsScrolling ? m_WidthScrollBar : 0)) / 10;
             const cRect ProgressBarSize {PBLeft, PBTop, PBWidth, Config.decorProgressMenuItemSize};
-            if (Current)
-                ProgressBarDrawRaw(MenuPixmap, MenuPixmap, ProgressBarSize, ProgressBarSize, progress, 100,
-                                    Config.decorProgressMenuItemCurFg, Config.decorProgressMenuItemCurBarFg,
-                                    Config.decorProgressMenuItemCurBg, Config.decorProgressMenuItemType, false);
-            else
-                ProgressBarDrawRaw(MenuPixmap, MenuPixmap, ProgressBarSize, ProgressBarSize, progress, 100,
-                                    Config.decorProgressMenuItemFg, Config.decorProgressMenuItemBarFg,
-                                    Config.decorProgressMenuItemBg, Config.decorProgressMenuItemType, false);
+            (Current) ? ProgressBarDrawRaw(MenuPixmap, MenuPixmap, ProgressBarSize, ProgressBarSize, progress, 100,
+                                           Config.decorProgressMenuItemCurFg, Config.decorProgressMenuItemCurBarFg,
+                                           Config.decorProgressMenuItemCurBg, Config.decorProgressMenuItemType, false)
+                      : ProgressBarDrawRaw(MenuPixmap, MenuPixmap, ProgressBarSize, ProgressBarSize, progress, 100,
+                                           Config.decorProgressMenuItemFg, Config.decorProgressMenuItemBarFg,
+                                           Config.decorProgressMenuItemBg, Config.decorProgressMenuItemType, false);
             Left += Width + m_MarginItem;
 
             if (MenuChannelViewShort) {  // flatPlus short, flatPlus short + EPG
@@ -2991,7 +2988,7 @@ cString cFlatDisplayMenu::GetIconName(const cString &element) const {
     std::string_view svElement {*element}, sv;
 
     // Check if the element matches any name in the cache
-    auto it {cache.find(svElement.data())};
+    const auto it {cache.find(svElement.data())};
     if (it != cache.end()) return *it->second;  // Return cached icon name including path
 
     cache.reserve(32);  // Reserve space for 32 entries to avoid rehashing
@@ -3287,11 +3284,7 @@ void cFlatDisplayMenu::InsertGenreInfo(const cEvent *Event, cString &Text) const
     for (std::size_t i {0}; Event->Contents(i); ++i) {
         ContentString = Event->ContentToString(Event->Contents(i));
         if (ContentString[0] != '\0') {  // Skip empty (user defined) content
-            if (!FirstContent)
-                Text.Append(", ");
-            else
-                Text.Append(cString::sprintf("\n%s: ", tr("Genre")));
-
+            Text.Append((FirstContent) ? cString::sprintf("\n%s: ", tr("Genre")) : ", ");
             Text.Append(ContentString);
             FirstContent = false;
         }
@@ -3304,11 +3297,7 @@ void cFlatDisplayMenu::InsertGenreInfo(const cEvent *Event, cString &Text, std::
     for (std::size_t i {0}; Event->Contents(i); ++i) {
         ContentString = Event->ContentToString(Event->Contents(i));
         if (ContentString[0] != '\0') {  // Skip empty (user defined) content
-            if (!FirstContent)
-                Text.Append(", ");
-            else
-                Text.Append(cString::sprintf("\n%s: ", tr("Genre")));
-
+            Text.Append((FirstContent) ? cString::sprintf("\n%s: ", tr("Genre")) : ", ");
             Text.Append(ContentString);
             FirstContent = false;
             GenreIcons.emplace_back(GetGenreIcon(Event->Contents(i)));
@@ -4116,16 +4105,16 @@ int cFlatDisplayMenu::DrawMainMenuWidgetTemperatures(int wLeft, int wWidth, int 
     int CountTemps {0};
 
     const cString TempCPU {ReadAndExtractData(cString::sprintf("%s/temperatures/cpu", WIDGETOUTPUTPATH))};
-    CountTemps += (!isempty(*TempCPU)) ? 1 : 0;
+    CountTemps += (isempty(*TempCPU)) ? 0 : 1;
 
     const cString TempCase {ReadAndExtractData(cString::sprintf("%s/temperatures/pccase", WIDGETOUTPUTPATH))};
-    CountTemps += (!isempty(*TempCase)) ? 1 : 0;
+    CountTemps += (isempty(*TempCase)) ? 0 : 1;
 
     const cString TempMB {ReadAndExtractData(cString::sprintf("%s/temperatures/motherboard", WIDGETOUTPUTPATH))};
-    CountTemps += (!isempty(*TempMB)) ? 1 : 0;
+    CountTemps += (isempty(*TempMB)) ? 0 : 1;
 
     const cString TempGPU {ReadAndExtractData(cString::sprintf("%s/temperatures/gpu", WIDGETOUTPUTPATH))};
-    CountTemps += (!isempty(*TempGPU)) ? 1 : 0;
+    CountTemps += (isempty(*TempGPU)) ? 0 : 1;
 
     if (CountTemps == 0) {
         ContentWidget.AddText(tr("Temperatures not available please check the widget"), false,

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -293,7 +293,7 @@ void cFlatDisplayMenu::SetTitle(const char *Title) {
 #endif
 
     m_LastTitle = Title;
-    cString NewTitle = Title;
+    cString NewTitle {Title};
 
     switch (m_MenuCategory) {
     case mcMain: NewTitle = ""; break;
@@ -426,10 +426,10 @@ void cFlatDisplayMenu::SetItem(const char *Text, int Index, bool Current, bool S
             } else {  // Not EPGsearch timer menu
                 if ((m_MenuCategory == mcMain || m_MenuCategory == mcSetup) && Config.MenuItemIconsShow) {
                     const int IconSize {m_FontHeight - m_MarginItem2};
-                    const cString IconName = *GetIconName(*MainMenuText(s));
+                    const cString IconName {GetIconName(*MainMenuText(s))};
                     cImage *img {nullptr};
                     if (Current) {
-                        const cString IconNameCur = cString::sprintf("%s_cur", *IconName);
+                        const cString IconNameCur {cString::sprintf("%s_cur", *IconName)};
                         img = ImgLoader.GetIcon(*IconNameCur, IconSize, IconSize);
                     }
                     if (!img) img = ImgLoader.GetIcon(*IconName, IconSize, IconSize);
@@ -545,7 +545,7 @@ bool cFlatDisplayMenu::SetItemChannel(const cChannel *Channel, int Index, bool C
     int Left {Config.decorBorderMenuItemSize + m_MarginItem};
     int Top {y};
     //* At least four digits because of different sort modes
-    int Width = FontCache.GetStringWidth(m_FontName, m_FontHeight, "0000");
+    int Width {FontCache.GetStringWidth(m_FontName, m_FontHeight, "0000")};
     const bool IsGroup {Channel->GroupSep()};
     cString Buffer {""};
     if (!IsGroup) {  // Show channel number for channels only
@@ -606,7 +606,7 @@ bool cFlatDisplayMenu::SetItemChannel(const cChannel *Channel, int Index, bool C
             if (Event) {
                 // Calculate progress bar
                 const time_t now {time(0)};
-                const double duration = Event->Duration();
+                const double duration {static_cast<double>(Event->Duration())};
                 progress = (duration > 0) ? std::clamp((now - Event->StartTime()) * 100.0 / duration, 0.0, 100.0) : 0.0;
                 EventTitle = Event->Title();
             }
@@ -626,7 +626,7 @@ bool cFlatDisplayMenu::SetItemChannel(const cChannel *Channel, int Index, bool C
             // dsyslog("flatPlus: SetItemChannel() LineTop: %d, m_LineWidth: %d, m_FontHeight: %d", LineTop,
             //        m_LineWidth, m_FontHeight);
             MenuPixmap->DrawRectangle(cRect(Left, LineTop, m_MenuItemWidth - Left, m_LineWidth), ColorFg);
-            const cString GroupName = cString::sprintf(" %s ", *Buffer);
+            const cString GroupName {cString::sprintf(" %s ", *Buffer)};
             MenuPixmap->DrawText(cPoint(Left + (m_MenuItemWidth / 10 * 2), Top), *GroupName, ColorFg, ColorBg, m_Font,
                                  0, 0, taCenter);
         } else {
@@ -647,7 +647,7 @@ bool cFlatDisplayMenu::SetItemChannel(const cChannel *Channel, int Index, bool C
         if (IsGroup) {
             const int LineTop {Top + (m_FontHeight - m_LineWidth / 2) / 2};
             MenuPixmap->DrawRectangle(cRect(Left, LineTop, m_MenuItemWidth - Left, m_LineWidth), ColorFg);
-            const cString GroupName = cString::sprintf(" %s ", *Buffer);
+            const cString GroupName {cString::sprintf(" %s ", *Buffer)};
             MenuPixmap->DrawText(cPoint(Left + (m_MenuItemWidth / 10 * 2), Top), *GroupName, ColorFg, ColorBg, m_Font,
                                  0, 0, taCenter);
         } else {
@@ -930,7 +930,7 @@ bool cFlatDisplayMenu::SetItemTimer(const cTimer *Timer, int Index, bool Current
 
     const cChannel *Channel {Timer->Channel()};
     const int ChannelNumber {Channel->Number()};
-    cString Buffer = itoa(ChannelNumber);
+    cString Buffer {itoa(ChannelNumber)};
     const int Width {(ChannelNumber < 1000) ? FontCache.GetStringWidth(m_FontName, m_FontHeight, "000")
                                             : m_Font->Width(*Buffer)};  // Minimal width for channel number
 
@@ -974,7 +974,7 @@ bool cFlatDisplayMenu::SetItemTimer(const cTimer *Timer, int Index, bool Current
         name = WeekDayName(Timer->Day());
     } else {
         const time_t Day {Timer->Day()};
-        struct tm *tm_r = gmtime(&Day);  // NOLINT gmtime() is not thread-safe
+        struct tm *tm_r {gmtime(&Day)};  // NOLINT gmtime() is not thread-safe
         char buf[12];
         strftime(buf, sizeof(buf), "%Y%m%d", tm_r);
         day = buf;
@@ -1212,9 +1212,9 @@ bool cFlatDisplayMenu::SetItemEvent(const cEvent *Event, int Index, bool Current
                 const time_t total {Event->EndTime() - EventStartTime};
                 if (total >= 0) {
                     // Calculate progress bar
-                    const double duration = Event->Duration();
-                    const double progress =
-                        (duration > 0) ? std::clamp((now - EventStartTime) * 100.0 / duration, 0.0, 100.0) : 0.0;
+                    const double duration {static_cast<double>(Event->Duration())};
+                    const double progress {
+                        (duration > 0) ? std::clamp((now - EventStartTime) * 100.0 / duration, 0.0, 100.0) : 0.0};
 
                     int PBLeft {Left};
                     int PBTop {y + (m_ItemEventHeight - Config.MenuItemPadding) / 2 -
@@ -1255,7 +1255,7 @@ bool cFlatDisplayMenu::SetItemEvent(const cEvent *Event, int Index, bool Current
         cString Buffer {""};
         if (WithDate) {  // Draw day and date (Mon 01.)
             const time_t Day {Event->StartTime()};
-            struct tm *tm_r = gmtime(&Day);  // NOLINT gmtime() is not thread-safe
+            struct tm *tm_r {gmtime(&Day)};  // NOLINT gmtime() is not thread-safe
             char buf[3];
             snprintf(buf, sizeof(buf), "%2d", tm_r->tm_mday);
 
@@ -1310,8 +1310,8 @@ bool cFlatDisplayMenu::SetItemEvent(const cEvent *Event, int Index, bool Current
         Left += ImageHeight + m_MarginItem;
 
         // Draw title and short text
-        const cString Title = Event->Title();
-        const cString ShortText = (Event->ShortText()) ? Event->ShortText() : "";
+        const cString Title {Event->Title()};
+        const cString ShortText {Event->ShortText() ? Event->ShortText() : ""};
         if (MenuEventViewShort && Channel) {  // flatPlus short, flatPlus short + EPG
             if (Current) {
                 if (ShortText[0] != '\0') {
@@ -1419,7 +1419,7 @@ bool cFlatDisplayMenu::SetItemEvent(const cEvent *Event, int Index, bool Current
                     const std::string date {sep.substr(found - 14, 14)};
                     const int LineTop {Top + (m_FontHeight - m_LineWidth / 2) / 2};
                     MenuPixmap->DrawRectangle(cRect(0, LineTop, m_MenuItemWidth, m_LineWidth), ColorFg);
-                    const cString DateSpace = cString::sprintf(" %s ", date.c_str());
+                    const cString DateSpace {cString::sprintf(" %s ", date.c_str())};
                     MenuPixmap->DrawText(cPoint(LeftSecond + m_MenuWidth / 10 * 2, Top), *DateSpace, ColorFg, ColorBg,
                                          m_Font, 0, 0, taCenter);
                 } else {  // Date string not found
@@ -2439,8 +2439,8 @@ void cFlatDisplayMenu::AddActors(cComplexContent &ComplexContent, std::vector<sA
     int y {ContentTop};
     if (NumActors > 48) isyslog("flatPlus: First display of %d actor images will probably be slow!", NumActors);
 
-    for (std::size_t row {0}; row < PicLines; ++row) {
-        for (std::size_t col {0}; col < ActorsPerLine; ++col) {
+    for (int row {0}; row < PicLines; ++row) {
+        for (int col {0}; col < ActorsPerLine; ++col) {
             if (Actor == NumActors) break;
             img = ImgLoader.GetFile(*Actors[Actor].Path, ActorWidth, kIconMaxSize);
             if (img) {
@@ -2591,7 +2591,7 @@ void cFlatDisplayMenu::DrawRecordingInfo(const cRecording *Recording) {
         if (RecInfo->Aux()) InsertAuxInfos(RecInfo, RecAdditional, false);  // Insert aux infos without info line
     }  // if Config.RecordingAdditionalInfoShow
 
-    const int HeadIconLeft = DrawContentHeadFskGenre(Fsk, GenreIcons);
+    const int HeadIconLeft {DrawContentHeadFskGenre(Fsk, GenreIcons)};
 
 #ifdef DEBUGEPGTIME
     dsyslog("flatPlus: DrawRecordingInfo() Infotext time @ %ld ms", Timer.Elapsed());
@@ -2992,7 +2992,7 @@ cString cFlatDisplayMenu::GetIconName(const cString &element) const {
     std::string_view svElement {*element}, sv;
 
     // Check if the element matches any name in the cache
-    auto it = cache.find(svElement.data());
+    auto it {cache.find(svElement.data())};
     if (it != cache.end()) return *it->second;  // Return cached icon name including path
 
     cache.reserve(32);  // Reserve space for 32 entries to avoid rehashing
@@ -3055,20 +3055,20 @@ cString cFlatDisplayMenu::GetMenuIconName() const {
     static constexpr struct {
         eMenuCategory category;
         const char *icon;
-    } MenuIcons[] = {{mcMain, "menuIcons/" VDRLOGO},
-                     {mcSchedule, "menuIcons/Schedule"},
-                     {mcScheduleNow, "menuIcons/Schedule"},
-                     {mcScheduleNext, "menuIcons/Schedule"},
-                     {mcChannel, "menuIcons/Channels"},
-                     {mcTimer, "menuIcons/Timers"},
-                     {mcRecording, "menuIcons/Recordings"},
+    } MenuIcons[] {{mcMain, "menuIcons/" VDRLOGO},
+                   {mcSchedule, "menuIcons/Schedule"},
+                   {mcScheduleNow, "menuIcons/Schedule"},
+                   {mcScheduleNext, "menuIcons/Schedule"},
+                   {mcChannel, "menuIcons/Channels"},
+                   {mcTimer, "menuIcons/Timers"},
+                   {mcRecording, "menuIcons/Recordings"},
 #if APIVERSNUM >= 30012
-                     {mcRecordingDel, "menuIcons/DeletedRecordings"},
+                   {mcRecordingDel, "menuIcons/DeletedRecordings"},
 #endif
-                     {mcSetup, "menuIcons/Setup"},
-                     {mcCommand, "menuIcons/Commands"},
-                     {mcEvent, "extraIcons/Info"},
-                     {mcRecordingInfo, "extraIcons/PlayInfo"}};
+                   {mcSetup, "menuIcons/Setup"},
+                   {mcCommand, "menuIcons/Commands"},
+                   {mcEvent, "extraIcons/Info"},
+                   {mcRecordingInfo, "extraIcons/PlayInfo"}};
     // Use structured binding
     for (const auto &[category, icon] : MenuIcons) {
         if (category == m_MenuCategory) return cString(icon);
@@ -3216,7 +3216,7 @@ void cFlatDisplayMenu::UpdateTimerCounts(uint16_t &TimerActiveCount, uint16_t &T
 }
 
 bool cFlatDisplayMenu::IsRecordingOld(const cRecording *Recording, int Level) const {
-    int16_t value {-1};
+    int value {-1};
     if (Config.MenuItemRecordingUseOldFile) {
         const cString RecFolder {*GetRecordingName(Recording, Level)};
         value = Config.GetRecordingOldValue(*RecFolder);
@@ -3226,7 +3226,7 @@ bool cFlatDisplayMenu::IsRecordingOld(const cRecording *Recording, int Level) co
 
     const time_t LastRecTimeFromFolder {GetLastRecTimeFromFolder(Recording, Level)};
     const time_t now {time(0)};
-    const double days = (now - LastRecTimeFromFolder) * (1.0 / SECSINDAY);
+    const int days {static_cast<int>((now - LastRecTimeFromFolder) * (1.0 / SECSINDAY))};
     return days > value;
 }
 
@@ -3441,7 +3441,7 @@ void cFlatDisplayMenu::DrawMainMenuWidgets() {
 
     // Create a map that associates widget names with their drawing functions
     // Works as long all strings are different. Else we must use std::string
-    std::unordered_map<const char *, WidgetDrawFunction> WidgetDrawers = {
+    std::unordered_map<const char *, WidgetDrawFunction> WidgetDrawers {
         {"dvb_devices",
          [this](int left, int width, int top, int MenuPixmapViewPortHeight) {
              return DrawMainMenuWidgetDVBDevices(left, width, top, MenuPixmapViewPortHeight);
@@ -3484,10 +3484,10 @@ void cFlatDisplayMenu::DrawMainMenuWidgets() {
     int AddHeight {0}, ContentTop {0};
     // Process widgets
     for (const auto &PairWidget : widgets) {
-        std::string_view widget = PairWidget.second;
+        std::string_view widget {PairWidget.second};
 
         // Look up the widget drawer function
-        auto drawerIt = WidgetDrawers.find(widget.data());
+        auto drawerIt {WidgetDrawers.find(widget.data())};
         if (drawerIt != WidgetDrawers.end()) {
             // Call the drawer function and update ContentTop
             AddHeight = drawerIt->second(wLeft, wWidth, ContentTop, MenuPixmapViewPortHeight);
@@ -3568,7 +3568,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetDVBDevices(int wLeft, int wWidth, int Co
         LOCK_TIMERS_READ;  // Creates local const cTimers *Timers
         for (const cTimer *Timer {Timers->First()}; Timer; Timer = Timers->Next(Timer)) {
             if (Timer->HasFlags(tfRecording)) {
-                if (cRecordControl *RecordControl = cRecordControls::GetRecordControl(Timer)) {
+                if (cRecordControl *RecordControl {cRecordControls::GetRecordControl(Timer)}) {
                     const cDevice *RecDevice {RecordControl->Device()};
                     // Before setting the RecDevices array element, add bounds check
                     if (RecDevice && RecDevice->DeviceNumber() < NumDevices) {
@@ -3936,7 +3936,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetLastRecordings(int wLeft, int wWidth, in
         if (ContentTop + m_MarginItem > MenuPixmapViewPortHeight)
             break;  // Exit the loop if we've run out of display space
 
-        const auto &PairRec = Recs[i];
+        const auto &PairRec {Recs[i]};
 
         ContentWidget.AddText(
             *PairRec.second, false, cRect(m_MarginItem, ContentTop, wWidth - m_MarginItem2, m_FontSmlHeight),
@@ -4240,7 +4240,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetCommand(int wLeft, int wWidth, int Conte
 
     const char *s {nullptr};
     static const cString ItemFilename {cString::sprintf("%s/command_output/output", WIDGETOUTPUTPATH)};
-    FILE *f = fopen(*ItemFilename, "r");
+    FILE *f {fopen(*ItemFilename, "r")};
     if (f) {
         cReadLine ReadLine;
         while ((s = ReadLine.Read(f)) != nullptr) {
@@ -4288,7 +4288,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetWeather(int wLeft, int wWidth, int Conte
         WeatherCache.valid = true;
     }
 
-    const auto &wd = WeatherCache;  // Weather data reference
+    const auto &wd {WeatherCache};  // Weather data reference
 
     const cString TempToday {cString::sprintf("%s %s", *wd.Temp, *wd.TempTodaySign)};  // Read temperature
     const cString Title {cString::sprintf("%s - %s %s", tr("Weather"), *wd.Location, *TempToday)};

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -3511,7 +3511,7 @@ void cFlatDisplayMenu::DrawMainMenuWidgets() {
                            BorderMMWidget};
     DecorBorderDraw(ib);
 #ifdef DEBUGFUNCSCALL
-    if (Timer.Elapsed() > 1) dsyslog("   DrawMainMenuWidget() done in %ld ms", Timer.Elapsed());
+    if (Timer.Elapsed() > 0) dsyslog("   DrawMainMenuWidget() done in %ld ms", Timer.Elapsed());
 #endif
 }
 
@@ -3540,6 +3540,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetDVBDevices(int wLeft, int wWidth, int Co
                                                    int MenuPixmapViewPortHeight) {
 #ifdef DEBUGFUNCSCALL
     dsyslog("flatPlus: cFlatDisplayMenu::DrawMainMenuWidgetDVBDevices()");
+    cTimeMs Timer;  // Set Timer
 #endif
 
     if (ContentTop + m_FontHeight + m_LineMargin + m_FontSmlHeight > MenuPixmapViewPortHeight)
@@ -3661,6 +3662,9 @@ int cFlatDisplayMenu::DrawMainMenuWidgetDVBDevices(int wLeft, int wWidth, int Co
                               Theme.Color(clrMenuEventFontInfo), Theme.Color(clrMenuEventBg), m_FontSml);
         // ContentTop += m_FontSmlHeight;
     }
+#ifdef DEBUGFUNCSCALL
+    if (Timer.Elapsed() > 0) dsyslog("   DrawMainMenuWidgetDVBDevices() done in %ld ms", Timer.Elapsed());
+#endif
 
     return ContentWidget.ContentHeight(false);
 }
@@ -3669,6 +3673,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetActiveTimers(int wLeft, int wWidth, int 
                                                      int MenuPixmapViewPortHeight) {
 #ifdef DEBUGFUNCSCALL
     dsyslog("flatPlus: DrawMainMenuWidgetActiveTimers()");
+    cTimeMs Timer;  // Set Timer
 #endif
 
     if (ContentTop + m_FontHeight + m_LineMargin + m_FontSmlHeight > MenuPixmapViewPortHeight)
@@ -3870,6 +3875,9 @@ int cFlatDisplayMenu::DrawMainMenuWidgetActiveTimers(int wLeft, int wWidth, int 
             }
         }  // Config.MainMenuWidgetActiveTimerShowRemoteActive
     }
+#ifdef DEBUGFUNCSCALL
+    if (Timer.Elapsed() > 0) dsyslog("   DrawMainMenuWidgetActiveTimers() done in %ld ms", Timer.Elapsed());
+#endif
 
     return ContentWidget.ContentHeight(false);
 }
@@ -3886,6 +3894,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetLastRecordings(int wLeft, int wWidth, in
                                                        int MenuPixmapViewPortHeight) {
 #ifdef DEBUGFUNCSCALL
     dsyslog("DrawMainMenuWidgetLastRecordings(%d, %d, %d)", wLeft, wWidth, ContentTop);
+    cTimeMs Timer;  // Set Timer
 #endif
 
     if (ContentTop + m_FontHeight + m_LineMargin + m_FontSmlHeight > MenuPixmapViewPortHeight)
@@ -3933,6 +3942,10 @@ int cFlatDisplayMenu::DrawMainMenuWidgetLastRecordings(int wLeft, int wWidth, in
             Theme.Color(clrMenuEventFontInfo), Theme.Color(clrMenuEventBg), m_FontSml, wWidth - m_MarginItem2);
         ContentTop += m_FontSmlHeight;
     }
+#ifdef DEBUGFUNCSCALL
+    if (Timer.Elapsed() > 0) dsyslog("   DrawMainMenuWidgetLastRecordings() done in %ld ms", Timer.Elapsed());
+#endif
+
     return ContentWidget.ContentHeight(false);
 }
 
@@ -3940,6 +3953,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetTimerConflicts(int wLeft, int wWidth, in
                                                        int MenuPixmapViewPortHeight) {
 #ifdef DEBUGFUNCSCALL
     dsyslog("DrawMainMenuWidgetTimerConflicts(%d, %d, %d)", wLeft, wWidth, ContentTop);
+    cTimeMs Timer;  // Set Timer
 #endif
 
     if (ContentTop + m_FontHeight + m_LineMargin+ m_FontSmlHeight > MenuPixmapViewPortHeight)
@@ -3959,6 +3973,9 @@ int cFlatDisplayMenu::DrawMainMenuWidgetTimerConflicts(int wLeft, int wWidth, in
                               Theme.Color(clrMenuEventFontInfo), Theme.Color(clrMenuEventBg), m_FontSml,
                               wWidth - m_MarginItem2);
     }
+#ifdef DEBUGFUNCSCALL
+    if (Timer.Elapsed() > 0) dsyslog("   DrawMainMenuWidgetTimerConflicts() done in %ld ms", Timer.Elapsed());
+#endif
 
     return ContentWidget.ContentHeight(false);
 }
@@ -3967,6 +3984,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation(int wLeft, int wWidth,
                                                           int MenuPixmapViewPortHeight) {
 #ifdef DEBUGFUNCSCALL
     dsyslog("flatPlus: DrawMainMenuWidgetSystemInfomation() ContentTop: %d", ContentTop);
+    cTimeMs Timer;  // Set Timer
 #endif
 
     if (ContentTop + m_FontHeight + m_LineMargin + m_FontSmlHeight > MenuPixmapViewPortHeight)
@@ -4075,6 +4093,9 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemInformation(int wLeft, int wWidth,
             }
         }
     }
+#ifdef DEBUGFUNCSCALL
+    if (Timer.Elapsed() > 0) dsyslog("   DrawMainMenuWidgetSystemInfomation() done in %ld ms", Timer.Elapsed());
+#endif
 
     return ContentWidget.ContentHeight(false);
 }
@@ -4083,7 +4104,9 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemUpdates(int wLeft, int wWidth, int
                                                       int MenuPixmapViewPortHeight) {
 #ifdef DEBUGFUNCSCALL
     dsyslog("flatPlus: cFlatDisplayMenu::DrawMainMenuWidgetSystemUpdates()");
+    cTimeMs Timer;  // Set Timer
 #endif
+
     if (ContentTop + m_FontHeight + m_LineMargin + m_FontSmlHeight > MenuPixmapViewPortHeight)
         return -1;  // Not enough space to display anything meaningful
 
@@ -4112,6 +4135,9 @@ int cFlatDisplayMenu::DrawMainMenuWidgetSystemUpdates(int wLeft, int wWidth, int
             *str, false, cRect(wWidth / 2 + m_MarginItem, ContentTop, wWidth / 2 - m_MarginItem2, m_FontSmlHeight),
             Theme.Color(clrMenuEventFontInfo), Theme.Color(clrMenuEventBg), m_FontSml, wWidth - m_MarginItem2);
     }
+#ifdef DEBUGFUNCSCALL
+    if (Timer.Elapsed() > 0) dsyslog("   DrawMainMenuWidgetSystemUpdates() done in %ld ms", Timer.Elapsed());
+#endif
 
     return ContentWidget.ContentHeight(false);
 }
@@ -4120,6 +4146,7 @@ int cFlatDisplayMenu::DrawMainMenuWidgetTemperatures(int wLeft, int wWidth, int 
                                                      int MenuPixmapViewPortHeight) {
 #ifdef DEBUGFUNCSCALL
     dsyslog("flatPlus: cFlatDisplayMenu::DrawMainMenuWidgetTemperatures()");
+    cTimeMs Timer;  // Set Timer
 #endif
 
     if (ContentTop + m_FontHeight + m_LineMargin + m_FontSmlHeight > MenuPixmapViewPortHeight)
@@ -4183,11 +4210,19 @@ int cFlatDisplayMenu::DrawMainMenuWidgetTemperatures(int wLeft, int wWidth, int 
                                   wWidth - m_MarginItem2);
         }
     }
+#ifdef DEBUGFUNCSCALL
+    if (Timer.Elapsed() > 0) dsyslog("   DrawMainMenuWidgetTemperatures() done in %ld ms", Timer.Elapsed());
+#endif
 
     return ContentWidget.ContentHeight(false);
 }
 
 int cFlatDisplayMenu::DrawMainMenuWidgetCommand(int wLeft, int wWidth, int ContentTop, int MenuPixmapViewPortHeight) {
+#ifdef DEBUGFUNCSCALL
+    dsyslog("flatPlus: cFlatDisplayMenu::DrawMainMenuWidgetCommand()");
+    cTimeMs Timer;  // Set Timer
+#endif
+
     if (ContentTop + m_FontHeight + m_LineMargin + m_FontSmlHeight > MenuPixmapViewPortHeight)
         return -1;  // Not enough space to display anything meaningful
 
@@ -4221,12 +4256,17 @@ int cFlatDisplayMenu::DrawMainMenuWidgetCommand(int wLeft, int wWidth, int Conte
             Theme.Color(clrMenuEventFontInfo), Theme.Color(clrMenuEventBg), m_FontSml, wWidth - m_MarginItem2);
     }
 
+#ifdef DEBUGFUNCSCALL
+    if (Timer.Elapsed() > 0) dsyslog("   DrawMainMenuWidgetCommand() done in %ld ms", Timer.Elapsed());
+#endif
+
     return ContentWidget.ContentHeight(false);
 }
 
 int cFlatDisplayMenu::DrawMainMenuWidgetWeather(int wLeft, int wWidth, int ContentTop, int MenuPixmapViewPortHeight) {
 #ifdef DEBUGFUNCSCALL
     dsyslog("flatPlus: cFlatBaseRender::DrawMainMenuWidgetWeather()");
+    cTimeMs Timer;  // Set Timer
 #endif
 
     if (ContentTop + m_FontHeight + m_LineMargin + m_FontSmlHeight > MenuPixmapViewPortHeight)
@@ -4357,10 +4397,11 @@ int cFlatDisplayMenu::DrawMainMenuWidgetWeather(int wLeft, int wWidth, int Conte
         }  // for Config.MainMenuWidgetWeatherDays
     }
 
-    return ContentWidget.ContentHeight(false);
 #ifdef DEBUGFUNCSCALL
-    dsyslog("DrawMainMenuWidgetWeather() Done");
+    if (Timer.Elapsed() > 0) dsyslog("   DrawMainMenuWidgetWeather() done in %ld ms", Timer.Elapsed());
 #endif
+
+    return ContentWidget.ContentHeight(false);
 }
 
 void cFlatDisplayMenu::PreLoadImages() {

--- a/displaymenu.h
+++ b/displaymenu.h
@@ -164,7 +164,7 @@ class cFlatDisplayMenu : public cFlatBaseRender, public cSkinDisplayMenu {
     void DrawRecordingStateIcon(const cRecording *Recording, int Left, int Top, bool Current);
     void DrawRecordingFormatIcon(const cRecording *Recording, int Left, int Top);
     void DrawRecordingErrorIcon(const cRecording *Recording, int Left, int Top, bool Current);
-    int DrawRecordingIcon(const char *IconName, int Left, int Top, bool Current);           // NOLINT
+    int DrawRecordingIcon(const char *IconName, int Left, int Top, bool Current, bool Small = false);           // NOLINT
     int DrawContentHeadFskGenre(const cString &Fsk, std::vector<std::string> &GenreIcons);  // NOLINT
 
     void DrawMainMenuWidgets();

--- a/displayreplay.c
+++ b/displayreplay.c
@@ -772,7 +772,7 @@ void cFlatDisplayReplay::PreLoadImages() {
     }
 
     static constexpr uint32_t kCharCode {0x0030};  // U+0030 DIGIT ZERO
-    const int GlyphSize = FontCache.GetGlyphSize(Setup.FontOsd, kCharCode, Setup.FontOsdSize);  // Narrowing conversion
+    const int GlyphSize {FontCache.GetGlyphSize(Setup.FontOsd, kCharCode, Setup.FontOsdSize)};
     static constexpr const char *icons1[] {"recording_pos", "recording_total", "recording_cutted_extra",
                                            "recording_timeshift"};
     for (const auto &icon : icons1) {

--- a/displayreplay.c
+++ b/displayreplay.c
@@ -431,7 +431,7 @@ void cFlatDisplayReplay::UpdateInfo() {
     }
 
     if (marks && m_Recording->HasMarks()) {
-#if (APIVERSNUM >= 20608)
+#if APIVERSNUM >= 20608
         FramesAfterEdit = marks->GetFrameAfterEdit(NumFrames, NumFrames);
         if (FramesAfterEdit >= 0) CurrentFramesAfterEdit = marks->GetFrameAfterEdit(m_CurrentFrame, NumFrames);
 #else

--- a/displayreplay.c
+++ b/displayreplay.c
@@ -348,9 +348,9 @@ void cFlatDisplayReplay::UpdateInfo() {
     const int FontSecsHeight {FontCache.GetFontHeight(Setup.FontOsd, FontSecsSize)};  // Height of seconds font
     static constexpr uint32_t kCharCode {0x0030};                                     // U+0030 DIGIT ZERO
     // Cached glyph size
-    static int CachedGlyphSize = -1;
+    static int CachedGlyphSize {-1};
     static cString CachedFontOsd {""};
-    static int CachedFontOsdSize = -1;
+    static int CachedFontOsdSize {-1};
     if (strcmp(Setup.FontOsd, CachedFontOsd) != 0 || Setup.FontOsdSize != CachedFontOsdSize) {
         CachedFontOsd = Setup.FontOsd;
         CachedFontOsdSize = Setup.FontOsdSize;
@@ -453,7 +453,7 @@ void cFlatDisplayReplay::UpdateInfo() {
     img = ImgLoader.GetIcon("recording_total", kIconMaxSize, GlyphSize);
     const int ImgWidth {(img) ? img->Width() : 0};
     if (FramesAfterEdit > 0) {
-        const cString cutted = *IndexToHMSF(FramesAfterEdit, false, FramesPerSecond);
+        const cString cutted {IndexToHMSF(FramesAfterEdit, false, FramesPerSecond)};
         const int CuttedWidth {m_Font->Width(cutted)};  // Width of cutted length
         cImage *ImgCutted {ImgLoader.GetIcon("recording_cutted_extra", kIconMaxSize, GlyphSize)};
         const int ImgCuttedWidth {(ImgCutted) ? ImgCutted->Width() : 0};
@@ -595,8 +595,8 @@ void cFlatDisplayReplay::UpdateInfo() {
         } */
 
         const int Rest {NumFrames - m_CurrentFrame};
-        const cString TimeStr = (Rest >= 0) ? *TimeString(now + (Rest / FramesPerSecond)) : "??:??";  // HH:MM
-        cString EndTime = cString::sprintf("%s: %s", tr("ends at"), *TimeStr);
+        const cString TimeStr {(Rest >= 0) ? *TimeString(now + (Rest / FramesPerSecond)) : "??:??"};  // HH:MM
+        cString EndTime {cString::sprintf("%s: %s", tr("ends at"), *TimeStr)};
         const int EndTimeWidth {FontCache.GetStringWidth(
             m_FontName, m_FontHeight, cString::sprintf("%s: 00:00", tr("ends at")))};  // Width of 'ends at: HH:MM' text
         LabelPixmap->DrawText(cPoint(left, m_FontHeight), *EndTime, Theme.Color(clrReplayFont),
@@ -630,7 +630,7 @@ void cFlatDisplayReplay::UpdateInfo() {
         if (Config.TVScraperReplayInfoShowPoster) {
             GetScraperMediaTypeSize(MediaPath, MediaSize, nullptr, m_Recording);
             if (MediaPath[0] == '\0' && Config.TVScraperSearchLocalPosters) {  // Prio for tvscraper poster
-                const cString RecPath = m_Recording->FileName();
+                const cString RecPath {m_Recording->FileName()};
                 if (ImgLoader.SearchRecordingPoster(RecPath, MediaPath)) {
                     img = ImgLoader.GetFile(*MediaPath, m_TVSRect.Width(), m_TVSRect.Height());
                     if (img)

--- a/displaytracks.c
+++ b/displaytracks.c
@@ -63,12 +63,9 @@ void cFlatDisplayTracks::SetItem(const char *Text, int Index, bool Current) {
                      : std::make_pair(Theme.Color(clrTrackItemFont), Theme.Color(clrTrackItemBg));
 
     const cString TextWithSpace {cString::sprintf(" %s", Text)};
-    if (Index == -1)
-        TracksPixmap->DrawText(cPoint(0, y), TextWithSpace, ColorFg, ColorBg, m_Font, m_MaxItemWidth,
-                               m_ItemHeight - Config.MenuItemPadding - Config.decorBorderTrackSize * 2, taLeft);
-    else
-        TracksPixmap->DrawText(cPoint(0, y), TextWithSpace, ColorFg, ColorBg, m_Font, m_MaxItemWidth,
-                               m_ItemHeight - Config.MenuItemPadding - Config.decorBorderTrackSize * 2, taCenter);
+    TracksPixmap->DrawText(cPoint(0, y), TextWithSpace, ColorFg, ColorBg, m_Font, m_MaxItemWidth,
+                           m_ItemHeight - Config.MenuItemPadding - Config.decorBorderTrackSize * 2,
+                           (Index == -1) ? taLeft : taCenter);
 
     const int left {(m_OsdWidth - m_MaxItemWidth) / 2};
     const int top {m_OsdHeight - ItemsHeight - m_MarginItem + y};

--- a/displaytracks.c
+++ b/displaytracks.c
@@ -62,7 +62,7 @@ void cFlatDisplayTracks::SetItem(const char *Text, int Index, bool Current) {
         : Index >= 0 ? std::make_pair(Theme.Color(clrTrackItemSelableFont), Theme.Color(clrTrackItemSelableBg))
                      : std::make_pair(Theme.Color(clrTrackItemFont), Theme.Color(clrTrackItemBg));
 
-    const cString TextWithSpace = cString::sprintf(" %s", Text);
+    const cString TextWithSpace {cString::sprintf(" %s", Text)};
     if (Index == -1)
         TracksPixmap->DrawText(cPoint(0, y), TextWithSpace, ColorFg, ColorBg, m_Font, m_MaxItemWidth,
                                m_ItemHeight - Config.MenuItemPadding - Config.decorBorderTrackSize * 2, taLeft);

--- a/displayvolume.c
+++ b/displayvolume.c
@@ -41,8 +41,8 @@ void cFlatDisplayVolume::SetVolume(int Current, int Total, bool Mute) {
     PixmapClear(LabelPixmap);
     PixmapClear(MuteLogoPixmap);
 
-    const cString label = cString::sprintf("%s: %d", tr("Volume"), Current);
-    const cString MaxLabel = cString::sprintf("%s: %s", tr("Volume"), "000");  // Use '000' to get the max width
+    const cString label {cString::sprintf("%s: %d", tr("Volume"), Current)};
+    const cString MaxLabel {cString::sprintf("%s: %s", tr("Volume"), "000")};  // Use '000' to get the max width
     const int MaxLabelWidth {FontCache.GetStringWidth(m_FontName, m_FontHeight, *MaxLabel) + m_MarginItem};
     int left {(m_OsdWidth - MaxLabelWidth) / 2};
 

--- a/flat.c
+++ b/flat.c
@@ -283,7 +283,7 @@ void InsertMovieInfos(const cMovie &Movie, cString &MovieInfo) {  // NOLINT
     if (!Movie.releaseDate.empty()) oss << tr("release date: ") << Movie.releaseDate << '\n';
     if (Movie.popularity > 0)
         oss << tr("popularity: ") << std::fixed << std::setprecision(1) << Movie.popularity << '\n';
-    if (Movie.voteAverage > 0) oss << tr("vote average: ") << Movie.voteAverage * 10 << "%\n";  // 10 Points = 100%
+    if (Movie.voteAverage > 0) oss << tr("vote average: ") << Movie.voteAverage * 10 << " %\n";  // 10 Points = 100 %
     MovieInfo.Append(oss.str().c_str());
 }
 
@@ -374,7 +374,7 @@ cString GetRecordingSeenIcon(int FrameTotal, int FrameResume) {
     const double FrameSeen {static_cast<double>(FrameResume) / FrameTotal};  // 0.0...1.0
     const double SeenThreshold {Config.MenuItemRecordingSeenThreshold * 100.0};
     // dsyslog("flatPlus: Config.MenuItemRecordingSeenThreshold: %.2f", SeenThreshold);
-    if (FrameSeen >= SeenThreshold) return "recording_seen_10";  // 100%
+    if (FrameSeen >= SeenThreshold) return "recording_seen_10";  // 100 %
 
     const int idx {std::min(static_cast<int>(FrameSeen * 10.0 + 0.5), 10)};  // 0...10 rounded
     return cString::sprintf("recording_seen_%d", idx);
@@ -407,7 +407,7 @@ void SetMediaSize(const cSize &ContentSize, cSize &MediaSize, float MediaSizeUse
 
     static constexpr int kPosterAspectThreshold {1};              // Smaller than 1 = Poster
     static constexpr int kBannerAspectThreshold {4};              // Smaller than 4 = Portrait, bigger than 4 = Banner
-    static constexpr double kPosterHeightRatio {0.7};             // Max 70% of pixmap height
+    static constexpr double kPosterHeightRatio {0.7};             // Max 70 % of pixmap height
     static constexpr double kPortraitWidthRatio {1.0 / 3.0};      // Max 1/3 of pixmap width
     static constexpr double kBannerTargetRatio {758.0 / 1920.0};  // To get 758 width @ 1920
 
@@ -787,7 +787,7 @@ void JustifyLine(std::string &Line, const cFont *Font, const int LineMaxWidth) {
 
     static constexpr float kLineWidthThreshold {0.8f};         // Line width threshold for justifying
     const int16_t LineWidth = Font->Width(Line.c_str());       // Width in Pixel
-    if (LineWidth < (LineMaxWidth * kLineWidthThreshold)) return;  // Lines shorter than 80% looking bad when justified
+    if (LineWidth < (LineMaxWidth * kLineWidthThreshold)) return;  // Lines shorter than 80 % looking bad when justified
 
     // Count spaces in line
     const int LineSpaces = std::count_if(Line.begin(), Line.end(), [](char c) { return c == ' '; });

--- a/flat.c
+++ b/flat.c
@@ -619,7 +619,7 @@ void InsertCutLengthSize(const cRecording *Recording, cString &Text) {  // NOLIN
         HasMarks = Marks.Load(RecordingFileName, FramesPerSecond, IsPesRecording) && Marks.Count();
         index = std::make_unique<cIndexFile>(RecordingFileName, false, IsPesRecording);  // Assign unique ptr object
         if (index) {
-            off_t dummy;
+            off_t dummy {0};
             LastIndex = index->Last();
             index->Get(LastIndex, &MaxFileNum, &dummy);
         }

--- a/flat.c
+++ b/flat.c
@@ -786,7 +786,7 @@ void JustifyLine(std::string &Line, const cFont *Font, const int LineMaxWidth) {
 #endif
 
     static constexpr float kLineWidthThreshold {0.8f};         // Line width threshold for justifying
-    const int16_t LineWidth = Font->Width(Line.c_str());       // Width in Pixel
+    const int LineWidth {Font->Width(Line.c_str())};           // Width in Pixel
     if (LineWidth < (LineMaxWidth * kLineWidthThreshold)) return;  // Lines shorter than 80 % looking bad when justified
 
     // Count spaces in line
@@ -801,7 +801,7 @@ void JustifyLine(std::string &Line, const cFont *Font, const int LineMaxWidth) {
                                   FontCache.GetStringWidth(FontName, FontHeight, u8"\U0000200A")
                               ? " "
                               : u8"\U0000200A"};  // Use hair space if it is smaller than space
-    const int16_t FillCharWidth = FontCache.GetStringWidth(FontName, FontHeight, FillChar);  // Width in pixel
+    const int FillCharWidth {FontCache.GetStringWidth(FontName, FontHeight, FillChar)};  // Width in pixel
 
     if (LineSpaces == 0 || FillCharWidth == 0) {  // Avoid DIV/0 with lines without space
         // dsyslog("flatPlus: JustifyLine() Line can not be justified. LineSpaces: %d, FillCharWidth: %d", LineSpaces,
@@ -812,11 +812,11 @@ void JustifyLine(std::string &Line, const cFont *Font, const int LineMaxWidth) {
     if ((LineWidth + FillCharWidth) > LineMaxWidth)  // Check if at least one 'FillChar' fits in to the line
         return;
 
-    const int16_t NeedFillChar = (LineMaxWidth - LineWidth) / FillCharWidth;  // How many 'FillChar' we need?
-    const int16_t FillCharBlock = std::max(NeedFillChar / LineSpaces, 1);     // For inserting multiple 'FillChar'
+    const int NeedFillChar {(LineMaxWidth - LineWidth) / FillCharWidth};  // How many 'FillChar' we need?
+    const int FillCharBlock {std::max(NeedFillChar / LineSpaces, 1)};  // For inserting multiple 'FillChar'
     std::string FillChars {""};
     FillChars.reserve(FillCharBlock);
-    for (int16_t i {0}; i < FillCharBlock; ++i) {  // Create 'FillChars' block for inserting
+    for (int i {0}; i < FillCharBlock; ++i) {  // Create 'FillChars' block for inserting
         FillChars.append(FillChar);
     }
 
@@ -915,7 +915,7 @@ void cTextFloatingWrapper::Set(const char *Text, const cFont *Font, int WidthLow
     const std::size_t TextLen {strlen(Text)};
     if (TextLen == 0) return;  // Avoid processing empty text
     // Estimate number of lines. More conservative size estimation
-    const std::size_t EstimatedLines = (TextLen / 10) + UpperLines + 10;  // Add safety margin
+    const std::size_t EstimatedLines {(TextLen / 10) + UpperLines + 10};  // Add safety margin
     std::size_t Capacity {TextLen + EstimatedLines + 2};
 #ifdef DEBUGFUNCSCALL
     dsyslog("   TextLen: %ld, EstimatedLines: %ld, Capacity: %ld", TextLen, EstimatedLines, Capacity);
@@ -934,7 +934,7 @@ void cTextFloatingWrapper::Set(const char *Text, const cFont *Font, int WidthLow
     std::size_t CurLength {TextLen};  // Current length of the text
     char *Blank {nullptr}, *Delim {nullptr}, *NewText {nullptr};
     int16_t cw {0}, l {0}, sl {0}, w {0};
-    int16_t Width = (UpperLines > 0) ? WidthUpper : WidthLower;
+    int Width {(UpperLines > 0) ? WidthUpper : WidthLower};
     uint32_t sym {0};
     stripspace(m_Text);  // Strips trailing newlines
     for (char *p {m_Text}; *p;) {

--- a/flat.c
+++ b/flat.c
@@ -150,7 +150,7 @@ void GetScraperMedia(cString &MediaPath, cString &SeriesInfo, cString &MovieInfo
 
         if (series.banners.size() > 1) {  // Use random banner
             // Reuse RNG for less overhead during UI rendering.
-            static thread_local std::mt19937 generator{std::random_device{}()};
+            static thread_local std::mt19937 generator {std::random_device {}()};
 
             // Make sure all numbers have an equal chance.
             // Range is inclusive (so we need -1 for vector index)
@@ -165,8 +165,7 @@ void GetScraperMedia(cString &MediaPath, cString &SeriesInfo, cString &MovieInfo
             MediaPath = series.banners[0].path.c_str();
         }
         if ((Event && Config.TVScraperEPGInfoShowActors) || (Recording && Config.TVScraperRecInfoShowActors)) {
-            const std::size_t ActorsSize {series.actors.size()};
-            Actors.reserve(ActorsSize);  // Set capacity to size of actors
+            Actors.reserve(series.actors.size());  // Set capacity to size of actors
             for (const auto &actor : series.actors) {
                 if (LastModifiedTime(actor.actorThumb.path.c_str())) {
                     Actors.emplace_back(actor.name.c_str(), actor.role.c_str(), actor.actorThumb.path.c_str());
@@ -181,8 +180,7 @@ void GetScraperMedia(cString &MediaPath, cString &SeriesInfo, cString &MovieInfo
 
         MediaPath = movie.poster.path.c_str();
         if ((Event && Config.TVScraperEPGInfoShowActors) || (Recording && Config.TVScraperRecInfoShowActors)) {
-            const std::size_t ActorsSize {movie.actors.size()};
-            Actors.reserve(ActorsSize);  // Set capacity to size of actors
+            Actors.reserve(movie.actors.size());  // Set capacity to size of actors
             for (const auto &actor : movie.actors) {
                 if (LastModifiedTime(actor.actorThumb.path.c_str())) {
                     Actors.emplace_back(actor.name.c_str(), actor.role.c_str(), actor.actorThumb.path.c_str());
@@ -217,7 +215,7 @@ int GetScraperMediaTypeSize(cString &MediaPath, cSize &MediaSize, const cEvent *
 
         if (series.banners.size() > 1) {  // Use random banner
             // Reuse RNG for less overhead during UI rendering.
-            static thread_local std::mt19937 generator{std::random_device{}()};
+            static thread_local std::mt19937 generator {std::random_device {}()};
 
             // Make sure all numbers have an equal chance.
             // Range is inclusive (so we need -1 for vector index)
@@ -409,7 +407,7 @@ void SetMediaSize(const cSize &ContentSize, cSize &MediaSize, float MediaSizeUse
     static constexpr double kPortraitWidthRatio {1.0 / 3.0};      // Max 1/3 of pixmap width
     static constexpr double kBannerTargetRatio {758.0 / 1920.0};  // To get 758 width @ 1920
 
-    const uint16_t Aspect = MediaSize.Width() / MediaSize.Height();  // Aspect ratio as integer. Narrowing conversion
+    const int Aspect {MediaSize.Width() / MediaSize.Height()};  // Aspect ratio as integer. Narrowing conversion
     //* Set to default size and apply user settings
     //* Aspect of image is preserved in cImageLoader::GetFile()
     if (Aspect < kPosterAspectThreshold) {  //* Poster (For example 680x1000 = 0.68)
@@ -427,32 +425,25 @@ void SetMediaSize(const cSize &ContentSize, cSize &MediaSize, float MediaSizeUse
 void InsertComponents(const cComponents *Components, cString &Text, cString &Audio, cString &Subtitle,  // NOLINT
                       bool NewLine) {
     std::ostringstream ossText {""}, ossAudio {""}, ossSubtitle {""};
-    cString AudioType {""};
     const int NumComponents {Components->NumComponents()};
     for (int16_t i {0}; i < NumComponents; ++i) {
         const tComponent *p {Components->Component(i)};
         switch (p->stream) {
         case sc_video_MPEG2:
             if (NewLine) ossText << '\n';
-            if (p->description)
-                ossText << tr("Video") << ": " << p->description << " (MPEG2)";
-            else
-                ossText << tr("Video") << ": MPEG2";
+            (p->description) ? ossText << tr("Video") << ": " << p->description << " (MPEG2)"
+                             : ossText << tr("Video") << ": MPEG2";
             break;
         case sc_video_H264_AVC:
             if (NewLine) ossText << '\n';
-            if (p->description)
-                ossText << tr("Video") << ": " << p->description << " (H.264)";
-            else
-                ossText << tr("Video") << ": H.264";
+            (p->description) ? ossText << tr("Video") << ": " << p->description << " (H.264)"
+                             : ossText << tr("Video") << ": H.264";
             break;
         case sc_video_H265_HEVC:  // Might be not always correct because stream_content_ext (must be 0x0) is
                                   // not available in tComponent
             if (NewLine) ossText << '\n';
-            if (p->description)
-                ossText << tr("Video") << ": " << p->description << " (H.265)";
-            else
-                ossText << tr("Video") << ": H.265";
+            (p->description) ? ossText << tr("Video") << ": " << p->description << " (H.265)"
+                             : ossText << tr("Video") << ": H.265";
             break;
         case sc_audio_MP2:
         case sc_audio_AC3:
@@ -462,6 +453,7 @@ void InsertComponents(const cComponents *Components, cString &Text, cString &Aud
             if (p->description) {
                 ossAudio << p->description << " (" << p->language << ')';
             } else {
+                cString AudioType {""};
                 switch (p->stream) {
                 case sc_audio_MP2:
                     // Workaround for wrongfully used stream type X 02 05 for AC3
@@ -476,10 +468,8 @@ void InsertComponents(const cComponents *Components, cString &Text, cString &Aud
             break;
         case sc_subtitle:
             if (!ossSubtitle.str().empty()) ossSubtitle << ", ";
-            if (p->description)
-                ossSubtitle << p->description << " (" << p->language << ')';
-            else
-                ossSubtitle << p->language << " (" << tr("Subtitle") << ')';
+            (p->description) ? ossSubtitle << p->description << " (" << p->language << ')'
+                             : ossSubtitle << p->language << " (" << tr("Subtitle") << ')';
             break;
         }  // switch
     }  // for

--- a/flat.c
+++ b/flat.c
@@ -149,9 +149,8 @@ void GetScraperMedia(cString &MediaPath, cString &SeriesInfo, cString &MovieInfo
         if (!pScraper->Service("GetSeries", &series)) return;  // Check if service call was successful
 
         if (series.banners.size() > 1) {  // Use random banner
-            // Gets 'entropy' from device that generates random numbers itself
-            // to seed a mersenne twister (pseudo) random generator
-            std::mt19937 generator(std::random_device {}());
+            // Reuse RNG for less overhead during UI rendering.
+            static thread_local std::mt19937 generator{std::random_device{}()};
 
             // Make sure all numbers have an equal chance.
             // Range is inclusive (so we need -1 for vector index)
@@ -217,9 +216,8 @@ int GetScraperMediaTypeSize(cString &MediaPath, cSize &MediaSize, const cEvent *
         if (!pScraper->Service("GetSeries", &series)) return 0;  // Check if service call was successful
 
         if (series.banners.size() > 1) {  // Use random banner
-            // Gets 'entropy' from device that generates random numbers itself
-            // to seed a mersenne twister (pseudo) random generator
-            std::mt19937 generator(std::random_device {}());
+            // Reuse RNG for less overhead during UI rendering.
+            static thread_local std::mt19937 generator{std::random_device{}()};
 
             // Make sure all numbers have an equal chance.
             // Range is inclusive (so we need -1 for vector index)

--- a/flat.c
+++ b/flat.c
@@ -335,7 +335,7 @@ cString GetRecordingFormatIcon(const cRecording *Recording) {
     // Find radio and H.264/H.265 streams.
     //! RTL, SAT1 etc. do not send a video component :-(
     if (const auto *Components {Recording->Info()->Components()}) {
-        for (int16_t i {0}, n = Components->NumComponents(); i < n; ++i) {  // Not iterable
+        for (int i {0}, n {Components->NumComponents()}; i < n; ++i) {  // Not iterable
             switch (Components->Component(i)->stream) {
             case sc_video_MPEG2: return "sd";
             case sc_video_H264_AVC: return "hd";
@@ -424,26 +424,23 @@ void SetMediaSize(const cSize &ContentSize, cSize &MediaSize, float MediaSizeUse
 
 void InsertComponents(const cComponents *Components, cString &Text, cString &Audio, cString &Subtitle,  // NOLINT
                       bool NewLine) {
-    std::ostringstream ossText {""}, ossAudio {""}, ossSubtitle {""};
+    std::ostringstream ossVideo {""}, ossAudio {""}, ossSubtitle {""};
     const int NumComponents {Components->NumComponents()};
-    for (int16_t i {0}; i < NumComponents; ++i) {
+    for (int i {0}; i < NumComponents; ++i) {
         const tComponent *p {Components->Component(i)};
         switch (p->stream) {
         case sc_video_MPEG2:
-            if (NewLine) ossText << '\n';
-            (p->description) ? ossText << tr("Video") << ": " << p->description << " (MPEG2)"
-                             : ossText << tr("Video") << ": MPEG2";
+            (p->description) ? ossVideo << tr("Video") << ": " << p->description << " (MPEG2)"
+                             : ossVideo << tr("Video") << ": MPEG2";
             break;
         case sc_video_H264_AVC:
-            if (NewLine) ossText << '\n';
-            (p->description) ? ossText << tr("Video") << ": " << p->description << " (H.264)"
-                             : ossText << tr("Video") << ": H.264";
+            (p->description) ? ossVideo << tr("Video") << ": " << p->description << " (H.264)"
+                             : ossVideo << tr("Video") << ": H.264";
             break;
         case sc_video_H265_HEVC:  // Might be not always correct because stream_content_ext (must be 0x0) is
                                   // not available in tComponent
-            if (NewLine) ossText << '\n';
-            (p->description) ? ossText << tr("Video") << ": " << p->description << " (H.265)"
-                             : ossText << tr("Video") << ": H.265";
+            (p->description) ? ossVideo << tr("Video") << ": " << p->description << " (H.265)"
+                             : ossVideo << tr("Video") << ": H.265";
             break;
         case sc_audio_MP2:
         case sc_audio_AC3:
@@ -473,9 +470,16 @@ void InsertComponents(const cComponents *Components, cString &Text, cString &Aud
             break;
         }  // switch
     }  // for
-    Text.Append(ossText.str().c_str());
-    Audio.Append(ossAudio.str().c_str());
-    Subtitle.Append(ossSubtitle.str().c_str());
+
+    if (NewLine) Text.Append('\n');
+    Text.Append(ossVideo.str().c_str());
+
+    if (!ossAudio.str().empty()) Text.Append(cString::sprintf("\n%s: %s", tr("Audio"), ossAudio.str().c_str()));
+    // Audio.Append(ossAudio.str().c_str());
+
+    if (!ossSubtitle.str().empty())
+        Text.Append(cString::sprintf("\n%s: %s", tr("Subtitle"), ossSubtitle.str().c_str()));
+    // Subtitle.Append(ossSubtitle.str().c_str());
 }
 
 void InsertAuxInfos(const cRecordingInfo *RecInfo, cString &Text, bool InfoLine) {  // NOLINT

--- a/flat.h
+++ b/flat.h
@@ -26,7 +26,7 @@
 #include "./config.h"
 #include "./imagecache.h"
 
-struct sActor {
+struct sActor {  // Actor information structure (Name, Role and Path)
     cString Name {""};  // Actor name
     cString Role {""};  // Actor role
     cString Path {""};  // Actor image path

--- a/fontcache.c
+++ b/fontcache.c
@@ -263,7 +263,7 @@ int cFontCache::GetGlyphSize(const cString &Name, const FT_ULong CharCode, const
                 esyslog("flatPlus: GetGlyphSize() Error: Can't load glyph (Font = %s)", *FontFileName);
                 return 0;
             }
-            const int GlyphSize {(slot->metrics.height + 63) / 64};  // Round up to nearest integer
+            const int GlyphSize {static_cast<int>(slot->metrics.height + 63) / 64};  // Round up to nearest integer
 #ifdef DEBUGFONTCACHE
             dsyslog("   Calculated GlyphSize: %d", GlyphSize);
 #endif

--- a/fontcache.c
+++ b/fontcache.c
@@ -69,7 +69,7 @@ cFont* cFontCache::GetFont(const cString &Name, int Size) {
 
     // Font not found in cache, insert it
     InsertFont(Name, Size);
-    auto &lastFont = FontCache[m_InsertIndex > 0 ? m_InsertIndex - 1 : 0];
+    auto &lastFont {FontCache[m_InsertIndex > 0 ? m_InsertIndex - 1 : 0]};
     return lastFont.font;
 }
 
@@ -147,7 +147,7 @@ int cFontCache::GetStringWidth(const cString &Name, int Height, const cString &T
         if ((strcmp(*data.name, *Name) == 0) && data.height == Height) {
             if (data.font) {
                 const std::string TextStr {*Text};
-                auto it = data.StringWidthCache.find(TextStr);
+                auto it {data.StringWidthCache.find(TextStr)};
                 if (it != data.StringWidthCache.end()) {
                     return it->second;  // Return cached width
                 } else {
@@ -190,8 +190,8 @@ int cFontCache::GetFontAscender(const cString &FontName, int FontSize) {
                 return data.ascender;
             } else {
                 // Calculate and cache ascender value
-                GlyphMetricsCache &cache = glyphMetricsCache();
-                const auto face = cache.GetFace(*cFont::GetFontFileName(FontName));
+                GlyphMetricsCache &cache {glyphMetricsCache()};
+                const auto face {cache.GetFace(*cFont::GetFontFileName(FontName))};
                 if (!face) {
                     esyslog("flatPlus: cFontCache::GetFontAscender() FreeType error: Can't find face (Font = %s)",
                             *cFont::GetFontFileName(FontName));
@@ -233,7 +233,7 @@ int cFontCache::GetGlyphSize(const cString &Name, const FT_ULong CharCode, const
 
     for (auto &data : FontCache) {
         if ((strcmp(*data.name, *Name) == 0) && data.size == FontHeight) {
-            const auto it = data.GlyphSizeCache.find({*Name, CharCode, FontHeight});
+            const auto it {data.GlyphSizeCache.find({*Name, CharCode, FontHeight})};
             if (it != data.GlyphSizeCache.end()) {
 #ifdef DEBUGFONTCACHE
                 dsyslog("   Cache hit: GlyphSize=%d, Name=%s, CharCode=%lu, FontHeight=%d", it->second, *Name, CharCode,
@@ -243,13 +243,13 @@ int cFontCache::GetGlyphSize(const cString &Name, const FT_ULong CharCode, const
                 return it->second;
             }
 
-            GlyphMetricsCache &cache = glyphMetricsCache();
-            const cString FontFileName = cFont::GetFontFileName(*Name);
+            GlyphMetricsCache &cache {glyphMetricsCache()};
+            const cString FontFileName {cFont::GetFontFileName(*Name)};
             if (isempty(*FontFileName)) {
                 esyslog("flatPlus: GetGlyphSize() Error: Font file name is empty for font %s", *Name);
                 return 0;
             }
-            const auto face = cache.GetFace(*FontFileName);
+            const auto face {cache.GetFace(*FontFileName)};
             if (face == nullptr) {
                 esyslog("flatPlus: GetGlyphSize() Error: Can't find face (Font = %s)", *FontFileName);
                 return 0;
@@ -263,7 +263,7 @@ int cFontCache::GetGlyphSize(const cString &Name, const FT_ULong CharCode, const
                 esyslog("flatPlus: GetGlyphSize() Error: Can't load glyph (Font = %s)", *FontFileName);
                 return 0;
             }
-            const int GlyphSize = (slot->metrics.height + 63) / 64;  // Round up to nearest integer
+            const int GlyphSize {(slot->metrics.height + 63) / 64};  // Round up to nearest integer
 #ifdef DEBUGFONTCACHE
             dsyslog("   Calculated GlyphSize: %d", GlyphSize);
 #endif

--- a/fontcache.c
+++ b/fontcache.c
@@ -145,16 +145,20 @@ void cFontCache::InsertFont(const cString& Name, int Size) {
 int cFontCache::GetStringWidth(const cString &Name, int Height, const cString &Text) const {
     for (auto &data : FontCache) {
         if ((strcmp(*data.name, *Name) == 0) && data.height == Height) {
+            const std::string TextStr {*Text};
+            const auto it {data.StringWidthCache.find(TextStr)};
+            if (it != data.StringWidthCache.end())
+                return it->second;  // Return cached width
+
             if (data.font) {
-                const auto it {data.StringWidthCache.find(TextStr)};
-                if (it != data.StringWidthCache.end()) {
-                    return it->second;  // Return cached width
-                } else {
-                    const std::string TextStr {*Text};
-                    const int width {data.font->Width(*Text)};
-                    data.StringWidthCache[TextStr] = width;  // Cache the width
-                    return width;
-                }
+                const int width {data.font->Width(*Text)};
+#ifdef DEBUGFONTCACHE
+                dsyslog("flatPlus: cFontCache::GetStringWidth() Storing in cache: width=%d for font '%s', height=%d, "
+                        "text='%s'",
+                        width, *Name, Height, *Text);
+#endif
+                data.StringWidthCache[TextStr] = width;  // Store in cache for future use
+                return width;
             }
         }
     }

--- a/fontcache.c
+++ b/fontcache.c
@@ -9,7 +9,6 @@
 
 #include <map>
 #include <string>
-#include <string_view>
 
 #include "./fontcache.h"
 
@@ -52,18 +51,15 @@ void cFontCache::Clear() {
 }
 
 cFont* cFontCache::GetFont(const cString &Name, int Size) {
-    std::string_view svName {*Name};
-    if (svName.empty() || Size <= 0) {  // Invalid parameters
+    if (isempty(*Name) || Size <= 0) {  // Invalid parameters
         esyslog("flatPlus: cFontCache::GetFont() Invalid parameters: Name=%s, Size=%d", *Name, Size);
         return cFont::CreateFont("DummyFont", 16);  // Return dummy font
     }
 
-    std::string_view svDataName {""};
     for (const auto &data : FontCache) {
-        svDataName = *data.name;
-        if (svDataName.empty()) break;  // End of cache, insert new font
+        if (isempty(*data.name)) break;  // End of cache, insert new font
 
-        if (svDataName == svName && data.size == Size && data.font != nullptr) {
+        if ((strcmp(*data.name, *Name) == 0) && data.size == Size && data.font != nullptr) {
 #ifdef DEBUGFONTCACHE
             dsyslog("flatPlus: Found in FontCache: Name=%s, Size=%d", *Name, Size);
 #endif
@@ -88,7 +84,7 @@ cString cFontCache::GetFontName(const char *FileName) const {
 #endif
 
     for (const auto &data : FontCache) {
-        if (std::string_view {*data.FileName} == FileName) {
+        if (strcmp(*data.FileName, FileName) == 0) {
             return data.name;  // Return the font name
         }
     }
@@ -102,9 +98,8 @@ int cFontCache::GetFontHeight(const cString &Name, int Size) const {
     dsyslog("flatPlus: cFontCache::GetFontHeight() Name=%s, Size=%d", *Name, Size);
 #endif
 
-    std::string_view svName {*Name};
     for (const auto &data : FontCache) {
-        if (std::string_view {*data.name} == svName && data.size == Size) {
+        if ((strcmp(*data.name, *Name) == 0) && data.size == Size) {
             return data.height;
         }
     }
@@ -148,9 +143,8 @@ void cFontCache::InsertFont(const cString& Name, int Size) {
 }
 
 int cFontCache::GetStringWidth(const cString &Name, int Height, const cString &Text) const {
-    std::string_view svName {*Name};
     for (auto &data : FontCache) {
-        if (std::string_view {*data.name} == svName && data.height == Height) {
+        if ((strcmp(*data.name, *Name) == 0) && data.height == Height) {
             if (data.font) {
                 const std::string TextStr {*Text};
                 auto it = data.StringWidthCache.find(TextStr);
@@ -182,14 +176,15 @@ int cFontCache::GetCacheCount() const {
 int cFontCache::GetSize() const { return FontCache.size(); }
 
 int cFontCache::GetFontAscender(const cString &FontName, int FontSize) {
-    std::string_view svFontName {*FontName};
-    if (svFontName.empty() || FontSize <= 0) {
+    if (isempty(*FontName) || FontSize <= 0) {
         esyslog("flatPlus: cFontCache::GetFontAscender() Invalid parameters: FontName=%s, FontSize=%d", *FontName,
                 FontSize);
         return FontSize;
     }
+
+    // Check if the ascender value is already cached
     for (auto& data : FontCache) {
-        if (std::string_view {*data.name} == svFontName && data.size == FontSize) {
+        if ((strcmp(*data.name, *FontName) == 0) && data.size == FontSize) {
             if (data.ascender != 0) {
                 // Return cached ascender value
                 return data.ascender;
@@ -236,9 +231,8 @@ int cFontCache::GetGlyphSize(const cString &Name, const FT_ULong CharCode, const
     dsyslog("flatPlus: GetGlyphSize() Name=%s, CharCode=%lu, FontHeight=%d", *Name, CharCode, FontHeight);
 #endif
 
-    std::string_view svName {*Name};
     for (auto &data : FontCache) {
-        if (std::string_view {*data.name} == svName && data.size == FontHeight) {
+        if ((strcmp(*data.name, *Name) == 0) && data.size == FontHeight) {
             const auto it = data.GlyphSizeCache.find({*Name, CharCode, FontHeight});
             if (it != data.GlyphSizeCache.end()) {
 #ifdef DEBUGFONTCACHE

--- a/fontcache.c
+++ b/fontcache.c
@@ -135,11 +135,11 @@ void cFontCache::InsertFont(const cString& Name, int Size) {
     FontCache[m_InsertIndex].FileName = FontCache[m_InsertIndex].font->FontName();
     FontCache[m_InsertIndex].size = Size;
     FontCache[m_InsertIndex].height = FontCache[m_InsertIndex].font->Height();
-    #ifdef DEBUGFONTCACHE
-        dsyslog("   Font '%s' inserted at index %zu", *FontCache[m_InsertIndex].name, m_InsertIndex);
-        dsyslog("   Font file name: '%s'", *FontCache[m_InsertIndex].FileName);
-        dsyslog("   Font size: %d, height: %d", FontCache[m_InsertIndex].size, FontCache[m_InsertIndex].height);
-    #endif
+#ifdef DEBUGFONTCACHE
+    dsyslog("   Font '%s' inserted at index %zu", *FontCache[m_InsertIndex].name, m_InsertIndex);
+    dsyslog("   Font file name: '%s'", *FontCache[m_InsertIndex].FileName);
+    dsyslog("   Font size: %d, height: %d", FontCache[m_InsertIndex].size, FontCache[m_InsertIndex].height);
+#endif
 
     if (++m_InsertIndex >= kMaxFontCache) {
         isyslog("flatPlus: cFontCache::InsertFont() Cache overflow, increase kMaxFontCache (%zu)", kMaxFontCache);

--- a/fontcache.c
+++ b/fontcache.c
@@ -146,11 +146,11 @@ int cFontCache::GetStringWidth(const cString &Name, int Height, const cString &T
     for (auto &data : FontCache) {
         if ((strcmp(*data.name, *Name) == 0) && data.height == Height) {
             if (data.font) {
-                const std::string TextStr {*Text};
                 const auto it {data.StringWidthCache.find(TextStr)};
                 if (it != data.StringWidthCache.end()) {
                     return it->second;  // Return cached width
                 } else {
+                    const std::string TextStr {*Text};
                     const int width {data.font->Width(*Text)};
                     data.StringWidthCache[TextStr] = width;  // Cache the width
                     return width;

--- a/fontcache.c
+++ b/fontcache.c
@@ -103,7 +103,7 @@ int cFontCache::GetFontHeight(const cString &Name, int Size) const {
             return data.height;
         }
     }
-    dsyslog("flatPlus: cFontCache::GetFontHeight() Font not found in cache: Name=%s, Size=%d", *Name, Size);
+    esyslog("flatPlus: cFontCache::GetFontHeight() Font not found in cache: Name=%s, Size=%d", *Name, Size);
     return 0;  // Font not found in cache
 }
 
@@ -147,7 +147,7 @@ int cFontCache::GetStringWidth(const cString &Name, int Height, const cString &T
         if ((strcmp(*data.name, *Name) == 0) && data.height == Height) {
             if (data.font) {
                 const std::string TextStr {*Text};
-                auto it {data.StringWidthCache.find(TextStr)};
+                const auto it {data.StringWidthCache.find(TextStr)};
                 if (it != data.StringWidthCache.end()) {
                     return it->second;  // Return cached width
                 } else {
@@ -159,7 +159,7 @@ int cFontCache::GetStringWidth(const cString &Name, int Height, const cString &T
         }
     }
 
-    dsyslog("flatPlus: cFontCache::GetStringWidth() Font not found or invalid");
+    esyslog("flatPlus: cFontCache::GetStringWidth() Font '%s' with height '%d' not found or invalid", *Name, Height);
     return 0;  // Font not found or invalid
 }
 

--- a/fontcache.c
+++ b/fontcache.c
@@ -59,7 +59,7 @@ cFont* cFontCache::GetFont(const cString &Name, int Size) {
     for (const auto &data : FontCache) {
         if (isempty(*data.name)) break;  // End of cache, insert new font
 
-        if ((strcmp(*data.name, *Name) == 0) && data.size == Size && data.font != nullptr) {
+        if ((strcmp(*data.name, *Name) == 0) && data.size == Size && data.font) {
 #ifdef DEBUGFONTCACHE
             dsyslog("flatPlus: Found in FontCache: Name=%s, Size=%d", *Name, Size);
 #endif
@@ -113,7 +113,7 @@ void cFontCache::InsertFont(const cString& Name, int Size) {
 #endif
 
     if (isempty(*Name) || Size <= 0) return;  // Invalid parameters
-    if (FontCache[m_InsertIndex].font != nullptr) {  // If the slot is already used, delete it
+    if (FontCache[m_InsertIndex].font) {  // If the slot is already used, delete it
         dsyslog("flatPlus: cFontCache::InsertFont() Replacing existing font at index %zu", m_InsertIndex);
         delete FontCache[m_InsertIndex].font;
         FontCache[m_InsertIndex].font = nullptr;
@@ -254,7 +254,7 @@ int cFontCache::GetGlyphSize(const cString &Name, const FT_ULong CharCode, const
                 return 0;
             }
             const auto face {cache.GetFace(*FontFileName)};
-            if (face == nullptr) {
+            if (!face) {
                 esyslog("flatPlus: GetGlyphSize() Error: Can't find face (Font = %s)", *FontFileName);
                 return 0;
             }

--- a/fontcache.h
+++ b/fontcache.h
@@ -34,7 +34,7 @@ class GlyphMetricsCache {
 
     FT_Face GetFace(const std::string &FontFileName) {
         std::unique_lock lock(mutex_);
-        auto it = faces_.find(FontFileName);
+        const auto it = faces_.find(FontFileName);
         if (it != faces_.end())
             return it->second;
         FT_Face face {nullptr};

--- a/imagecache.c
+++ b/imagecache.c
@@ -58,7 +58,7 @@ void cImageCache::Clear() {
 }
 
 static std::string_view BaseNameFromCacheName(std::string_view full) {
-    const std::size_t lastSlash = full.find_last_of('/');
+    const std::size_t lastSlash {full.find_last_of('/')};
     return (lastSlash != std::string_view::npos) ? full.substr(lastSlash + 1) : full;
 }
 
@@ -66,12 +66,12 @@ cImage *cImageCache::FindImage(const cString &Name, int Width, int Height, bool 
     const ImageKey key {Name, static_cast<int16_t>(Width), static_cast<int16_t>(Height)};
 
     const auto &idx = IsIcon ? m_IconIndex : m_ImageIndex;
-    const auto it = idx.find(key);
+    const auto it {idx.find(key)};
     if (it != idx.end()) {
-        const std::size_t slot = it->second;
-        const auto &cache = IsIcon ? IconCache : ImageCache;
+        const std::size_t slot {it->second};
+        const auto &cache {IsIcon ? IconCache : ImageCache};
         if (slot < cache.size()) {
-            const ImageData &data = cache[slot];
+            const ImageData &data {cache[slot]};
             if (data.Image && data.Width == Width && data.Height == Height &&
                 std::strcmp(*data.Name, *Name) == 0) {
                 return data.Image.get();
@@ -80,7 +80,7 @@ cImage *cImageCache::FindImage(const cString &Name, int Width, int Height, bool 
     }
 
     // Fallback to linear search if not found in index (should not happen if index is maintained correctly)
-    const auto &cache = IsIcon ? IconCache : ImageCache;
+    const auto &cache {IsIcon ? IconCache : ImageCache};
     for (const auto &data : cache) {
         if (!data.Image) continue;
         if (data.Width != Width || data.Height != Height) continue;
@@ -108,8 +108,8 @@ void cImageCache::InsertImage(cImage *Image, const cString &Name, int Width, int
 
     if (IsIcon) {
         // Remove any previous mapping that points to the slot we are about to overwrite.
-        const std::size_t slot = m_InsertIconIndex;
-        for (auto it = m_IconIndex.begin(); it != m_IconIndex.end();) {
+        const std::size_t slot {m_InsertIconIndex};
+        for (auto it {m_IconIndex.begin()}; it != m_IconIndex.end();) {
             if (it->second == slot) it = m_IconIndex.erase(it);
             else
                 ++it;
@@ -121,8 +121,8 @@ void cImageCache::InsertImage(cImage *Image, const cString &Name, int Width, int
         const ImageKey key {Name, static_cast<int16_t>(Width), static_cast<int16_t>(Height)};
         m_IconIndex[key] = slot;
     } else {
-        const std::size_t slot = m_InsertIndex;
-        for (auto it = m_ImageIndex.begin(); it != m_ImageIndex.end();) {
+        const std::size_t slot {m_InsertIndex};
+        for (auto it {m_ImageIndex.begin()}; it != m_ImageIndex.end();) {
             if (it->second == slot) it = m_ImageIndex.erase(it);
             else
                 ++it;
@@ -158,11 +158,11 @@ bool cImageCache::RemoveFromCache(const cString &Name) {
     bool removedAny {false};
 
     for (std::size_t slot {0}; slot < ImageCache.size(); ++slot) {
-        auto &data = ImageCache[slot];
+        auto &data {ImageCache[slot]};
         if (!data.Image) continue;
 
         std::string_view fullName {*data.Name};
-        const std::string_view baseName = BaseNameFromCacheName(fullName);
+        const std::string_view baseName {BaseNameFromCacheName(fullName)};
         if (baseName != svName) continue;
 
         const ImageKey key {data.Name, data.Width, data.Height};

--- a/imagecache.c
+++ b/imagecache.c
@@ -110,9 +110,8 @@ void cImageCache::InsertImage(cImage *Image, const cString &Name, int Width, int
         // Remove any previous mapping that points to the slot we are about to overwrite.
         const std::size_t slot {m_InsertIconIndex};
         for (auto it {m_IconIndex.begin()}; it != m_IconIndex.end();) {
-            if (it->second == slot) it = m_IconIndex.erase(it);
-            else
-                ++it;
+            (it->second == slot) ? it = m_IconIndex.erase(it)
+                                 : ++it;
         }
 
         InsertIntoCache(IconCache.data(), m_InsertIconIndex, kMaxIconCache, m_InsertIconIndexBase, Image, Name,
@@ -123,9 +122,8 @@ void cImageCache::InsertImage(cImage *Image, const cString &Name, int Width, int
     } else {
         const std::size_t slot {m_InsertIndex};
         for (auto it {m_ImageIndex.begin()}; it != m_ImageIndex.end();) {
-            if (it->second == slot) it = m_ImageIndex.erase(it);
-            else
-                ++it;
+            (it->second == slot) ? it = m_ImageIndex.erase(it)
+                                 : ++it;
         }
 
         InsertIntoCache(ImageCache.data(), m_InsertIndex, kMaxImageCache, m_InsertIndexBase, Image, Name, Width,
@@ -202,6 +200,6 @@ void cImageCache::PreLoadImage() {
     m_InsertIndexBase = GetCacheCount();
     m_InsertIconIndexBase = GetIconCacheCount();
 
-    dsyslog("flatPlus: Imagecache pre load images and icons time: %ld ms", Timer.Elapsed());
     dsyslog("flatPlus: Imagecache pre loaded %ld images and %ld icons", m_InsertIndexBase, m_InsertIconIndexBase);
+    dsyslog("flatPlus: Imagecache pre load images and icons time: %ld ms", Timer.Elapsed());
 }

--- a/imagecache.c
+++ b/imagecache.c
@@ -15,11 +15,11 @@
 #include "./displaytracks.h"
 #include "./displayvolume.h"
 
-cImageCache::cImageCache() :
-    ImageCache(kMaxImageCache),  // Initialize vector with fixed size
-    IconCache(kMaxIconCache) {}
+cImageCache::cImageCache()
+    : ImageCache(kMaxImageCache),  // Initialize vector with fixed size
+      IconCache(kMaxIconCache) {}
 
-cImageCache::~cImageCache() {}  // std::unique_ptr handles memory deallocation automatically
+cImageCache::~cImageCache() = default;
 
 void cImageCache::Create() {
     // Reset Image and Icon caches to default empty state
@@ -50,65 +50,96 @@ void cImageCache::Clear() {
         data.Height = -1;
     }
 
+    m_ImageIndex.clear();
+    m_IconIndex.clear();
+
     m_InsertIndex = 0;
     m_InsertIconIndex = 0;
 }
 
-bool cImageCache::RemoveFromCache(const cString &Name) {
-    std::string_view svBaseFileName {""}, svDataName{""};
-    std::string_view svName {*Name};
-
-    for (auto &data : ImageCache) {
-        // Check if the ImageData entry is valid (not marked as empty)
-        svDataName = *data.Name;  // Get the name from the cache entry
-        if (data.Image == nullptr && svDataName.empty()) {
-            // This assumes that an empty name and null image means the end of valid entries
-            // or an explicitly empty slot. If "" is a valid name, this logic needs adjustment.
-            break;
-        }
-
-        // Find the last '/' and extract the base filename
-        const std::size_t LastSlashPos = svDataName.find_last_of('/');
-        if (LastSlashPos != std::string_view::npos) {
-            svBaseFileName = svDataName.substr(LastSlashPos + 1);
-        } else {
-            svBaseFileName = svDataName;  // No slash, so the whole name is the base filename
-        }
-
-        if (svBaseFileName == svName) {
-            dsyslog("flatPlus: RemoveFromCache: %s", *data.Name);
-            data.Image.reset();  // This deletes the cImage object and sets Image to nullptr
-            data.Name = "-Empty!-";  // Mark as empty because "" is for end of cache
-            data.Width = -1;
-            data.Height = -1;
-            return true;
-        }
-    }
-    return false;
+static std::string_view BaseNameFromCacheName(std::string_view full) {
+    const std::size_t lastSlash = full.find_last_of('/');
+    return (lastSlash != std::string_view::npos) ? full.substr(lastSlash + 1) : full;
 }
 
-cImage* cImageCache::GetImage(const cString &Name, int Width, int Height, bool IsIcon) const {
-    std::string_view svDataName {""};
-    std::string_view svName {*Name};
-    const auto &cache = IsIcon ? IconCache : ImageCache;
+cImage *cImageCache::FindImage(const cString &Name, int Width, int Height, bool IsIcon) const {
+    const ImageKey key {Name, static_cast<int16_t>(Width), static_cast<int16_t>(Height)};
 
-    for (const auto &data : cache) {
-        svDataName = *data.Name;  // Get the name from the cache entry
-        // Check if the ImageData entry is valid (not marked as empty)
-        if (data.Image == nullptr && svDataName.empty()) {
-            break;  // No more valid images in cache
-        }
-        if (svDataName == svName && data.Width == Width && data.Height == Height) {
-            return data.Image.get();  // Return the cached image if found
+    const auto &idx = IsIcon ? m_IconIndex : m_ImageIndex;
+    const auto it = idx.find(key);
+    if (it != idx.end()) {
+        const std::size_t slot = it->second;
+        const auto &cache = IsIcon ? IconCache : ImageCache;
+        if (slot < cache.size()) {
+            const ImageData &data = cache[slot];
+            if (data.Image && data.Width == Width && data.Height == Height &&
+                std::strcmp(*data.Name, *Name) == 0) {
+                return data.Image.get();
+            }
         }
     }
+
+    // Fallback to linear search if not found in index (should not happen if index is maintained correctly)
+    const auto &cache = IsIcon ? IconCache : ImageCache;
+    for (const auto &data : cache) {
+        if (!data.Image) continue;
+        if (data.Width != Width || data.Height != Height) continue;
+        if (std::strcmp(*data.Name, *Name) != 0) continue;
+        return data.Image.get();
+    }
+
     return nullptr;
 }
 
+cImage *cImageCache::GetImage(const cString &Name, int Width, int Height, bool IsIcon) const {
+    const cImage *img {FindImage(Name, Width, Height, IsIcon)};
+    if (img) return const_cast<cImage *>(img);
+
+    return nullptr;
+}
+
+void cImageCache::InsertImage(cImage *Image, const cString &Name, int Width, int Height, bool IsIcon) {
+    if (!Image) return;
+
+    if (FindImage(Name, Width, Height, IsIcon)) {  // Image already in cache
+        delete Image;
+        return;
+    }
+
+    if (IsIcon) {
+        // Remove any previous mapping that points to the slot we are about to overwrite.
+        const std::size_t slot = m_InsertIconIndex;
+        for (auto it = m_IconIndex.begin(); it != m_IconIndex.end();) {
+            if (it->second == slot) it = m_IconIndex.erase(it);
+            else
+                ++it;
+        }
+
+        InsertIntoCache(IconCache.data(), m_InsertIconIndex, kMaxIconCache, m_InsertIconIndexBase, Image, Name,
+                         Width, Height);
+
+        const ImageKey key {Name, static_cast<int16_t>(Width), static_cast<int16_t>(Height)};
+        m_IconIndex[key] = slot;
+    } else {
+        const std::size_t slot = m_InsertIndex;
+        for (auto it = m_ImageIndex.begin(); it != m_ImageIndex.end();) {
+            if (it->second == slot) it = m_ImageIndex.erase(it);
+            else
+                ++it;
+        }
+
+        InsertIntoCache(ImageCache.data(), m_InsertIndex, kMaxImageCache, m_InsertIndexBase, Image, Name, Width,
+                         Height);
+
+        const ImageKey key {Name, static_cast<int16_t>(Width), static_cast<int16_t>(Height)};
+        m_ImageIndex[key] = slot;
+    }
+}
+
 void cImageCache::InsertIntoCache(ImageData *Cache, std::size_t &InsertIndex, const std::size_t MaxSize,
-                                  std::size_t BaseIndex, cImage *Image, const cString &Name, int Width, int Height) {
-    // std::unique_ptr will automatically delete the old image if one exists when a new one is assigned
-    Cache[InsertIndex].Image = std::unique_ptr<cImage>(Image);  // Store image in cache
+                                   std::size_t BaseIndex, cImage *Image, const cString &Name, int Width,
+                                   int Height) {
+    Cache[InsertIndex].Image = std::unique_ptr<cImage>(Image);
     Cache[InsertIndex].Name = Name;
     Cache[InsertIndex].Width = Width;
     Cache[InsertIndex].Height = Height;
@@ -120,22 +151,40 @@ void cImageCache::InsertIntoCache(ImageData *Cache, std::size_t &InsertIndex, co
     }
 }
 
-void cImageCache::InsertImage(cImage *Image, const cString &Name, int Width, int Height, bool IsIcon) {
-    // dsyslog("flatPlus: Imagecache insert image %s Width %d Height %d", Name.c_str(), Width, Height);
-    if (IsIcon) {  // Insert into icon cache
-        InsertIntoCache(IconCache.data(), m_InsertIconIndex, kMaxIconCache, m_InsertIconIndexBase, Image, Name, Width,
-                        Height);
-    } else {  // Insert into image cache
-        InsertIntoCache(ImageCache.data(), m_InsertIndex, kMaxImageCache, m_InsertIndexBase, Image, Name, Width,
-                        Height);
+bool cImageCache::RemoveFromCache(const cString &Name) {
+    // Preserve old behavior: remove entries by base filename (ignoring path)
+    const std::string_view svName {*Name};
+
+    bool removedAny {false};
+
+    for (std::size_t slot {0}; slot < ImageCache.size(); ++slot) {
+        auto &data = ImageCache[slot];
+        if (!data.Image) continue;
+
+        std::string_view fullName {*data.Name};
+        const std::string_view baseName = BaseNameFromCacheName(fullName);
+        if (baseName != svName) continue;
+
+        const ImageKey key {data.Name, data.Width, data.Height};
+        m_ImageIndex.erase(key);
+
+        dsyslog("flatPlus: RemoveFromCache: %s", *data.Name);
+        data.Image.reset();
+        data.Name = "";
+        data.Width = -1;
+        data.Height = -1;
+
+        removedAny = true;
     }
+
+    return removedAny;
 }
 
 // Preload images and icons
 // This function is called at startup to load images and icons into the cache
 // to speed up the display of the menu and other components.
 void cImageCache::PreLoadImage() {
-    cTimeMs Timer;  // Start timer
+    cTimeMs Timer;
 
     cFlatDisplayChannel DisplayChannel(false);
     // Called first. Also used to determine if 'logo_background' should be loaded from logo path or theme path
@@ -152,6 +201,7 @@ void cImageCache::PreLoadImage() {
 
     m_InsertIndexBase = GetCacheCount();
     m_InsertIconIndexBase = GetIconCacheCount();
+
     dsyslog("flatPlus: Imagecache pre load images and icons time: %ld ms", Timer.Elapsed());
     dsyslog("flatPlus: Imagecache pre loaded %ld images and %ld icons", m_InsertIndexBase, m_InsertIconIndexBase);
 }

--- a/imagecache.h
+++ b/imagecache.h
@@ -10,7 +10,9 @@
 #include <vdr/osd.h>
 #include <vdr/skins.h>
 
+#include <cstring>
 #include <memory>  // For std::unique_ptr
+#include <unordered_map>
 #include <vector>  // For std::vector
 
 static constexpr std::size_t kMaxImageCache {1024};  // Image cache including two times 'kLogoPreCache'
@@ -36,11 +38,11 @@ class cImageCache {
     bool RemoveFromCache(const cString &Name);
 
     int GetCacheCount() const {
-      return m_InsertIndex + 1;
+      return m_InsertIndex;
     }
 
     int GetIconCacheCount() const {
-      return m_InsertIconIndex + 1;
+      return m_InsertIconIndex;
     }
 
     cImage *GetImage(const cString &Name, int Width, int Height, bool IsIcon = false) const;
@@ -48,9 +50,33 @@ class cImageCache {
 
     void PreLoadImage();
 
+    struct ImageKey {
+        cString Name;
+        int16_t Width {0};
+        int16_t Height {0};
+
+        bool operator==(const ImageKey &other) const {
+            return Width == other.Width && Height == other.Height && std::strcmp(*Name, *other.Name) == 0;
+        }
+    };
+
+    struct ImageKeyHash {
+        std::size_t operator()(const ImageKey &k) const noexcept {
+            const std::string_view sv {*k.Name};
+            const std::size_t h1 {std::hash<std::string_view>{}(sv)};
+            const std::size_t h2 {std::hash<int16_t>{}(k.Width)};
+            const std::size_t h3 {std::hash<int16_t>{}(k.Height)};
+            return ((h1 ^ (h2 << 1)) ^ (h3 << 1));
+        }
+    };
+
  private:
     std::vector<ImageData> ImageCache;
     std::vector<ImageData> IconCache;
+
+    // O(1) lookup indexes for (Name, Width, Height)->slot
+    std::unordered_map<ImageKey, std::size_t, ImageKeyHash> m_ImageIndex;
+    std::unordered_map<ImageKey, std::size_t, ImageKeyHash> m_IconIndex;
 
     std::size_t m_InsertIndex {0};      // Imagecache index
     std::size_t m_InsertIndexBase {0};  // Imagecache after first fill at start
@@ -58,6 +84,7 @@ class cImageCache {
     std::size_t m_InsertIconIndex {0};      // Iconcache index
     std::size_t m_InsertIconIndexBase {0};  // Icon cache after first fill at start
 
+    cImage *FindImage(const cString &Name, int Width, int Height, bool IsIcon) const;
     void InsertIntoCache(ImageData *Cache, std::size_t &InsertIndex, const std::size_t MaxSize, std::size_t BaseIndex,  // NOLINT
                          cImage *Image, const cString &Name, int Width, int Height);
 };

--- a/imageloader.c
+++ b/imageloader.c
@@ -44,7 +44,7 @@ cImage* cImageLoader::GetLogo(const char *logo, int width, int height) {
 #endif
 
     // Plain logo without converting to lower including '/'
-    cString File = cString::sprintf("%s/%s.%s", *Config.LogoPath, logo, *m_LogoExtension);
+    cString File {cString::sprintf("%s/%s.%s", *Config.LogoPath, logo, *m_LogoExtension)};
     std::string LogoLower {""};
     bool success {false};
     cImage *img {nullptr};
@@ -110,7 +110,7 @@ cImage* cImageLoader::GetLogo(const char *logo, int width, int height) {
 cImage* cImageLoader::GetIcon(const char *cIcon, int width, int height) {
     if (width < 0 || height < 0 || isempty(cIcon)) return nullptr;
 
-    cString File = cString::sprintf("%s/%s/%s.%s", *Config.IconPath, Setup.OSDTheme, cIcon, *m_LogoExtension);
+    cString File {cString::sprintf("%s/%s/%s.%s", *Config.IconPath, Setup.OSDTheme, cIcon, *m_LogoExtension)};
 
 #ifdef DEBUGIMAGELOADTIME
     dsyslog("flatPlus: cImageLoader::GetIcon() '%s'", *File);
@@ -180,7 +180,7 @@ cImage* cImageLoader::GetIcon(const char *cIcon, int width, int height) {
 cImage* cImageLoader::GetFile(const char *cFile, int width, int height) {
     if (width < 0 || height < 0 || isempty(cFile)) return nullptr;
 
-    const cString File = cFile;
+    const cString File {cFile};
 
 #ifdef DEBUGIMAGELOADTIME
     dsyslog("flatPlus: cImageLoader::GetFile() '%s'", *File);

--- a/imagemagickwrapper.c
+++ b/imagemagickwrapper.c
@@ -155,7 +155,7 @@ cImage cImageMagickWrapper::CreateImageCopy() {
 }
 
 bool cImageMagickWrapper::LoadImage(const char *fullpath) {
-    if ((fullpath == nullptr) || (strlen(fullpath) < 5))
+    if (!fullpath || (strlen(fullpath) < 5))
         return false;
 
     // Check if file exists

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: vdr-skinflatplus 1.1.8\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2026-03-06 09:03+0100\n"
+"POT-Creation-Date: 2026-07-22 18:09+0000\n"
 "PO-Revision-Date: 2025-02-27 10:09+0100\n"
 "Last-Translator: Martin Schirrmacher\n"
 "Language-Team: Martin Schirrmacher\n"
@@ -29,6 +29,9 @@ msgstr "Uhr"
 
 msgid "Unknown"
 msgstr "Unbekannt"
+
+msgid "No EPG info available."
+msgstr "Keine EPG-Info verfügbar."
 
 msgid "FSK"
 msgstr ""
@@ -625,6 +628,21 @@ msgstr "Zeige Event Startzeit links"
 
 msgid "Show signal quality"
 msgstr "Zeige Signalqualität"
+
+msgid "Zapcockpit: Key right opens channellist"
+msgstr "Zapcockpit: Taste rechts öffnet Kanalliste"
+
+msgid "Zapcockpit: Relative list width"
+msgstr "Zapcockpit: Relative Listenbreite"
+
+msgid "Zapcockpit: Relative list font size"
+msgstr "Zapcockpit: Relative Schriftgröße der Listen"
+
+msgid "Zapcockpit: List fade-in time (ms)"
+msgstr "Zapcockpit: Einblendzeit der Listen (ms)"
+
+msgid "Zapcockpit: List shift-in time (ms)"
+msgstr "Zapcockpit: Einschiebezeit der Listen (ms)"
 
 msgid "Show weather widget"
 msgstr "Zeige Wetter Widget"

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -1040,3 +1040,21 @@ msgstr "Uso comandi dei widget: posizione"
 
 #~ msgid "dvbapi plugin non installed"
 #~ msgstr "dvbapi plugin non installato"
+
+msgid "No EPG info available."
+msgstr "Nessuna info EPG disponibile."
+
+msgid "Zapcockpit: Key right opens channellist"
+msgstr "Zapcockpit: tasto destro apre la lista canali"
+
+msgid "Zapcockpit: Relative list width"
+msgstr "Zapcockpit: larghezza relativa lista"
+
+msgid "Zapcockpit: Relative list font size"
+msgstr "Zapcockpit: dimensione fonte relativa lista"
+
+msgid "Zapcockpit: List fade-in time (ms)"
+msgstr "Zapcockpit: tempo di dissolvenza lista (ms)"
+
+msgid "Zapcockpit: List shift-in time (ms)"
+msgstr "Zapcockpit: tempo di scorrimento lista (ms)"

--- a/po/pl_PL.po
+++ b/po/pl_PL.po
@@ -1035,3 +1035,21 @@ msgstr "Aktywny?"
 
 msgid "Widget custom commands: position"
 msgstr "Pozycja"
+
+msgid "No EPG info available."
+msgstr "Brak dostępnych informacji EPG."
+
+msgid "Zapcockpit: Key right opens channellist"
+msgstr "Zapcockpit: klawisz w prawo otwiera listę kanałów"
+
+msgid "Zapcockpit: Relative list width"
+msgstr "Zapcockpit: względna szerokość listy"
+
+msgid "Zapcockpit: Relative list font size"
+msgstr "Zapcockpit: względny rozmiar czcionki listy"
+
+msgid "Zapcockpit: List fade-in time (ms)"
+msgstr "Zapcockpit: czas pojawiania się listy (ms)"
+
+msgid "Zapcockpit: List shift-in time (ms)"
+msgstr "Zapcockpit: czas wsuwania listy (ms)"

--- a/setup.c
+++ b/setup.c
@@ -182,13 +182,13 @@ void cFlatSetup::Setup() {
 }
 
 eOSState cFlatSetup::ProcessKey(eKeys Key) {
-    bool hadSubMenu = HasSubMenu();
-    eOSState state = cMenuSetupPage::ProcessKey(Key);
+    bool hadSubMenu {HasSubMenu()};
+    eOSState state {cMenuSetupPage::ProcessKey(Key)};
     if (hadSubMenu && Key == kOk)
         Store();
     if (!hadSubMenu && (state == osUnknown || Key == kOk)) {
         if ((Key == kOk && !hadSubMenu)) {
-            const char* ItemText = Get(Current())->Text();
+            const char* ItemText {Get(Current())->Text()};
             if (strcmp(ItemText, tr("General settings")) == 0)
                 state = AddSubMenu(new cFlatSetupGeneral(&SetupConfig));
             if (strcmp(ItemText, tr("Channelinfo settings")) == 0)
@@ -390,10 +390,10 @@ void cFlatSetup::Store() {
 }
 
 void cFlatSetupGeneral::LoadConfigFile() {
-    cString Filename =
-        cString::sprintf("%s/configs/%s", cPlugin::ConfigDirectory(PLUGIN_NAME_I18N), ConfigFiles[ConfigFileSelection]);
+    cString Filename {cString::sprintf("%s/configs/%s", cPlugin::ConfigDirectory(PLUGIN_NAME_I18N),
+                                       ConfigFiles[ConfigFileSelection])};
 
-    FILE *f = fopen(Filename, "r");
+    FILE *f {fopen(Filename, "r")};
     if (f) {
         char *s {nullptr}, *p {nullptr}, *n {nullptr}, *v {nullptr};
         cReadLine ReadLine;
@@ -408,7 +408,7 @@ void cFlatSetupGeneral::LoadConfigFile() {
                     *v++ = 0;
                     n = stripspace(skipspace(n));
                     v = stripspace(skipspace(v));
-                    bool success = SetupParse(n, v);
+                    bool success {SetupParse(n, v)};
                     if (!success)
                         dsyslog("flatPlus: Failed to load config: %s with value: %s", n, v);
                 }
@@ -419,7 +419,7 @@ void cFlatSetupGeneral::LoadConfigFile() {
         dsyslog("flatPlus: Failed to load config: file <%s> not found", *Filename);
         return;
     }
-    cString msg = cString::sprintf("%s %s %s", tr("configfile"), ConfigFiles[ConfigFileSelection], tr("loaded"));
+    cString msg {cString::sprintf("%s %s %s", tr("configfile"), ConfigFiles[ConfigFileSelection], tr("loaded"))};
     Skins.Message(mtInfo, msg);
 }
 
@@ -604,13 +604,13 @@ bool cFlatSetupGeneral::SetupParse(const char *Name, const char *Value) {
 }
 
 void cFlatSetupGeneral::SaveCurrentSettings() {
-    time_t t = time(0);
+    time_t t {time(0)};
     struct tm tm_r;
     localtime_r(&t, &tm_r);
     char time[32];
     strftime(time, sizeof(time)-1, "%d.%m.%Y_%H:%M", &tm_r);
-    cString File = time;
-    cString Filename = cString::sprintf("%s/configs/%s", PLUGINRESOURCEPATH, *File);
+    cString File {time};
+    cString Filename {cString::sprintf("%s/configs/%s", PLUGINRESOURCEPATH, *File)};
 
     // if file exist remove it
     if (access(Filename, F_OK) != -1)
@@ -790,7 +790,7 @@ void cFlatSetupGeneral::SaveCurrentSettings() {
     Config.Store("TVScraperSearchLocalPosters", SetupConfig->TVScraperSearchLocalPosters, *Filename);
     Config.Store("WeatherFontSize", dtoa(Config.WeatherFontSize), *Filename);
 
-    cString msg = cString::sprintf("%s %s", tr("saved settings in file:"), *File);
+    cString msg {cString::sprintf("%s %s", tr("saved settings in file:"), *File)};
     Skins.Message(mtInfo, msg);
 }
 //------------------------------------------------------------------------------------------------------------------
@@ -840,7 +840,7 @@ void cFlatSetupGeneral::Setup() {
         Add(new cMenuEditStraItem(tr("Press ok to load config file"), &ConfigFileSelection, ConfigFiles.Size(),
                                   &ConfigFiles[0]));
 
-    cString saveSettings = cString::sprintf("%s:\t%s", tr("Save current settings"), tr("press ok to save current settings"));
+    cString saveSettings {cString::sprintf("%s:\t%s", tr("Save current settings"), tr("press ok to save current settings"))};
     Add(new cOsdItem(saveSettings, osUnknown, true));
 
     Add(new cMenuEditBoolItem(tr("Show empty color-buttons"), &SetupConfig->ButtonsShowEmpty));
@@ -866,19 +866,19 @@ void cFlatSetupGeneral::Setup() {
         Add(new cMenuEditIntItem(tr("Scroller delay (in ms)"), &SetupConfig->ScrollerDelay, 15, 100));  // 15 ms ... 100 ms
         Add(new cMenuEditStraItem(tr("Scroller type"), &SetupConfig->ScrollerType, ScrollerTypes.Size(), &ScrollerTypes[0]));
     } else {
-        cString step = cString::sprintf("%s:\t%d", tr("Scroller step (in pixel)"), SetupConfig->ScrollerStep);
+        cString step {cString::sprintf("%s:\t%d", tr("Scroller step (in pixel)"), SetupConfig->ScrollerStep)};
         Add(new cOsdItem(step, osUnknown, false));
-        cString delay = cString::sprintf("%s:\t%d", tr("Scroller delay (in ms)"), SetupConfig->ScrollerDelay);
+        cString delay {cString::sprintf("%s:\t%d", tr("Scroller delay (in ms)"), SetupConfig->ScrollerDelay)};
         Add(new cOsdItem(delay, osUnknown, false));
-        cString type = cString::sprintf("%s:\t%s", tr("Scroller type"), ScrollerTypes[SetupConfig->ScrollerType]);
+        cString type {cString::sprintf("%s:\t%s", tr("Scroller type"), ScrollerTypes[SetupConfig->ScrollerType])};
         Add(new cOsdItem(type, osUnknown, false));
     }
 
     Add(new cMenuEditBoolItem(tr("TopBar border by decor-file?"), &SetupConfig->decorBorderTopBarByTheme));
     if (SetupConfig->decorBorderTopBarByTheme) {
-        cString type = cString::sprintf("%s:\t%s", tr("TopBar border type"), Bordertypes[SetupConfig->decorBorderTopBarTypeTheme]);
+        cString type {cString::sprintf("%s:\t%s", tr("TopBar border type"), Bordertypes[SetupConfig->decorBorderTopBarTypeTheme])};
         Add(new cOsdItem(type, osUnknown, false));
-        cString size = cString::sprintf("%s:\t%d", tr("TopBar border size"), SetupConfig->decorBorderTopBarSizeTheme);
+        cString size {cString::sprintf("%s:\t%d", tr("TopBar border size"), SetupConfig->decorBorderTopBarSizeTheme)};
         Add(new cOsdItem(size, osUnknown, false));
     } else {
         Add(new cMenuEditStraItem(tr("TopBar border type"), &SetupConfig->decorBorderTopBarTypeUser, Bordertypes.Size(), &Bordertypes[0]));
@@ -887,9 +887,9 @@ void cFlatSetupGeneral::Setup() {
 
     Add(new cMenuEditBoolItem(tr("Message border by decor-file?"), &SetupConfig->decorBorderMessageByTheme));
     if (SetupConfig->decorBorderMessageByTheme) {
-        cString type = cString::sprintf("%s:\t%s", tr("Message border type"), Bordertypes[SetupConfig->decorBorderMessageTypeTheme]);
+        cString type {cString::sprintf("%s:\t%s", tr("Message border type"), Bordertypes[SetupConfig->decorBorderMessageTypeTheme])};
         Add(new cOsdItem(type, osUnknown, false));
-        cString size = cString::sprintf("%s:\t%d", tr("Message border size"), SetupConfig->decorBorderMessageSizeTheme);
+        cString size {cString::sprintf("%s:\t%d", tr("Message border size"), SetupConfig->decorBorderMessageSizeTheme)};
         Add(new cOsdItem(size, osUnknown, false));
     } else {
         Add(new cMenuEditStraItem(tr("Message border type"), &SetupConfig->decorBorderMessageTypeUser, Bordertypes.Size(), &Bordertypes[0]));
@@ -898,22 +898,22 @@ void cFlatSetupGeneral::Setup() {
 
     Add(new cMenuEditBoolItem(tr("Button border by decor-file?"), &SetupConfig->decorBorderButtonByTheme));
     if (SetupConfig->decorBorderButtonByTheme) {
-        cString type = cString::sprintf("%s:\t%s", tr("Button border type"), Bordertypes[SetupConfig->decorBorderButtonTypeTheme]);
+        cString type {cString::sprintf("%s:\t%s", tr("Button border type"), Bordertypes[SetupConfig->decorBorderButtonTypeTheme])};
         Add(new cOsdItem(type, osUnknown, false));
-        cString size = cString::sprintf("%s:\t%d", tr("Button border size"), SetupConfig->decorBorderButtonSizeTheme);
+        cString size {cString::sprintf("%s:\t%d", tr("Button border size"), SetupConfig->decorBorderButtonSizeTheme)};
         Add(new cOsdItem(size, osUnknown, false));
     } else {
         Add(new cMenuEditStraItem(tr("Button border type"), &SetupConfig->decorBorderButtonTypeUser, Bordertypes.Size(), &Bordertypes[0]));
         Add(new cMenuEditIntItem(tr("Button border size"), &SetupConfig->decorBorderButtonSizeUser));
     }
 
-    cString ImageCache = cString::sprintf("%s:\t%d / %ld", tr("Imagecache entries"), ImgCache.GetCacheCount(), kMaxImageCache);
+    cString ImageCache {cString::sprintf("%s:\t%d / %ld", tr("Imagecache entries"), ImgCache.GetCacheCount(), kMaxImageCache)};
     Add(new cOsdItem(ImageCache, osUnknown, true));
-    cString IconCache = cString::sprintf("%s:\t%d / %ld", tr("Iconcache entries"), ImgCache.GetIconCacheCount(), kMaxIconCache);
+    cString IconCache {cString::sprintf("%s:\t%d / %ld", tr("Iconcache entries"), ImgCache.GetIconCacheCount(), kMaxIconCache)};
     Add(new cOsdItem(IconCache, osUnknown, true));
 
-    cString FontCacheNum =
-        cString::sprintf("%s:\t%d / %d", tr("Fontcache entries"), FontCache.GetCacheCount(), FontCache.GetSize());
+    cString FontCacheNum {
+        cString::sprintf("%s:\t%d / %d", tr("Fontcache entries"), FontCache.GetCacheCount(), FontCache.GetSize())};
     Add(new cOsdItem(FontCacheNum, osUnknown, true));
 
     if (ItemLastSel >= 0) {
@@ -925,12 +925,12 @@ void cFlatSetupGeneral::Setup() {
 }
 
 eOSState cFlatSetupGeneral::ProcessKey(eKeys Key) {
-    eOSState state = cOsdMenu::ProcessKey(Key);
+    eOSState state {cOsdMenu::ProcessKey(Key)};
     if (state == osUnknown) {
         switch (Key) {
             case kOk:
             {
-                const char* ItemText = Get(Current())->Text();
+                const char* ItemText {Get(Current())->Text()};
                 if (strstr(ItemText, tr("Save current settings")) != nullptr) {
                     SaveCurrentSettings();
                     return osUnknown;
@@ -946,7 +946,7 @@ eOSState cFlatSetupGeneral::ProcessKey(eKeys Key) {
         }
     }
     if (Key == kLeft || Key == kRight) {
-        const char* ItemText = Get(Current())->Text();
+        const char* ItemText {Get(Current())->Text()};
         if (strstr(ItemText, tr("TopBar border by decor-file?")) != nullptr ||
             strstr(ItemText, tr("Message border by decor-file?")) != nullptr ||
             strstr(ItemText, tr("Use Textscroller?")) != nullptr ||
@@ -988,9 +988,9 @@ void cFlatSetupChannelInfo::Setup() {
 
     Add(new cMenuEditBoolItem(tr("Channelinfo border by decor-file?"), &SetupConfig->decorBorderChannelByTheme));
     if (SetupConfig->decorBorderChannelByTheme) {
-        cString type = cString::sprintf("%s:\t%s", tr("Channelinfo border type"), Bordertypes[SetupConfig->decorBorderChannelTypeTheme]);
+        cString type {cString::sprintf("%s:\t%s", tr("Channelinfo border type"), Bordertypes[SetupConfig->decorBorderChannelTypeTheme])};
         Add(new cOsdItem(type, osUnknown, false));
-        cString size = cString::sprintf("%s:\t%d", tr("Channelinfo border size"), SetupConfig->decorBorderChannelSizeTheme);
+        cString size {cString::sprintf("%s:\t%d", tr("Channelinfo border size"), SetupConfig->decorBorderChannelSizeTheme)};
         Add(new cOsdItem(size, osUnknown, false));
     } else {
         Add(new cMenuEditStraItem(tr("Channelinfo border type"), &SetupConfig->decorBorderChannelTypeUser, Bordertypes.Size(), &Bordertypes[0]));
@@ -999,9 +999,9 @@ void cFlatSetupChannelInfo::Setup() {
 
     Add(new cMenuEditBoolItem(tr("Channelinfo EPG border by decor-file?"), &SetupConfig->decorBorderChannelEPGByTheme));
     if (SetupConfig->decorBorderChannelEPGByTheme) {
-        cString type = cString::sprintf("%s:\t%s", tr("Channelinfo EPG border type"), Bordertypes[SetupConfig->decorBorderChannelEPGTypeTheme]);
+        cString type {cString::sprintf("%s:\t%s", tr("Channelinfo EPG border type"), Bordertypes[SetupConfig->decorBorderChannelEPGTypeTheme])};
         Add(new cOsdItem(type, osUnknown, false));
-        cString size = cString::sprintf("%s:\t%d", tr("Channelinfo EPG border size"), SetupConfig->decorBorderChannelEPGSizeTheme);
+        cString size {cString::sprintf("%s:\t%d", tr("Channelinfo EPG border size"), SetupConfig->decorBorderChannelEPGSizeTheme)};
         Add(new cOsdItem(size, osUnknown, false));
     } else {
         Add(new cMenuEditStraItem(tr("Channelinfo EPG border type"), &SetupConfig->decorBorderChannelEPGTypeUser, Bordertypes.Size(), &Bordertypes[0]));
@@ -1010,9 +1010,9 @@ void cFlatSetupChannelInfo::Setup() {
 
     Add(new cMenuEditBoolItem(tr("Channelinfo progress by decor-file?"), &SetupConfig->decorProgressChannelByTheme));
     if (SetupConfig->decorProgressChannelByTheme) {
-        cString type = cString::sprintf("%s:\t%s", tr("Channelinfo progress type"), Progresstypes[SetupConfig->decorProgressChannelTypeTheme]);
+        cString type {cString::sprintf("%s:\t%s", tr("Channelinfo progress type"), Progresstypes[SetupConfig->decorProgressChannelTypeTheme])};
         Add(new cOsdItem(type, osUnknown, false));
-        cString size = cString::sprintf("%s:\t%d", tr("Channelinfo progress size"), SetupConfig->decorProgressChannelSizeTheme);
+        cString size {cString::sprintf("%s:\t%d", tr("Channelinfo progress size"), SetupConfig->decorProgressChannelSizeTheme)};
         Add(new cOsdItem(size, osUnknown, false));
     } else {
         Add(new cMenuEditStraItem(tr("Channelinfo progress type"), &SetupConfig->decorProgressChannelTypeUser, Progresstypes.Size(), &Progresstypes[0]));
@@ -1021,9 +1021,9 @@ void cFlatSetupChannelInfo::Setup() {
 
     Add(new cMenuEditBoolItem(tr("Signalquality progress by decor-file?"), &SetupConfig->decorProgressSignalByTheme));
     if (SetupConfig->decorProgressSignalByTheme) {
-        cString type = cString::sprintf("%s:\t%s", tr("Signalquality progress type"), Progresstypes[SetupConfig->decorProgressSignalTypeTheme]);
+        cString type {cString::sprintf("%s:\t%s", tr("Signalquality progress type"), Progresstypes[SetupConfig->decorProgressSignalTypeTheme])};
         Add(new cOsdItem(type, osUnknown, false));
-        cString size = cString::sprintf("%s:\t%d", tr("Signalquality progress size"), SetupConfig->decorProgressSignalSizeTheme);
+        cString size {cString::sprintf("%s:\t%d", tr("Signalquality progress size"), SetupConfig->decorProgressSignalSizeTheme)};
         Add(new cOsdItem(size, osUnknown, false));
     } else {
         Add(new cMenuEditStraItem(tr("Signalquality progress type"), &SetupConfig->decorProgressSignalTypeUser, Progresstypes.Size(), &Progresstypes[0]));
@@ -1039,7 +1039,7 @@ void cFlatSetupChannelInfo::Setup() {
 }
 
 eOSState cFlatSetupChannelInfo::ProcessKey(eKeys Key) {
-    eOSState state = cOsdMenu::ProcessKey(Key);
+    eOSState state {cOsdMenu::ProcessKey(Key)};
     if (state == osUnknown) {
         switch (Key) {
             case kOk:
@@ -1049,7 +1049,7 @@ eOSState cFlatSetupChannelInfo::ProcessKey(eKeys Key) {
         }
     }
     if (Key == kLeft || Key == kRight) {
-        const char* ItemText = Get(Current())->Text();
+        const char* ItemText {Get(Current())->Text()};
         if (strstr(ItemText, tr("Channelinfo border by decor-file?")) != nullptr ||
             strstr(ItemText, tr("Channelinfo EPG border by decor-file?")) != nullptr ||
             strstr(ItemText, tr("Channelinfo progress by decor-file?")) != nullptr ||
@@ -1098,9 +1098,9 @@ void cFlatSetupMenu::Setup() {
 
     Add(new cMenuEditBoolItem(tr("Scrollbar by decor-file?"), &SetupConfig->decorScrollBarByTheme));
     if (SetupConfig->decorScrollBarByTheme) {
-        cString type = cString::sprintf("%s:\t%s", tr("Scrollbar type"), ScrollBarTypes[SetupConfig->decorScrollBarTypeTheme]);
+        cString type {cString::sprintf("%s:\t%s", tr("Scrollbar type"), ScrollBarTypes[SetupConfig->decorScrollBarTypeTheme])};
         Add(new cOsdItem(type, osUnknown, false));
-        cString size = cString::sprintf("%s:\t%d", tr("Scrollbar size"), SetupConfig->decorScrollBarSizeTheme);
+        cString size {cString::sprintf("%s:\t%d", tr("Scrollbar size"), SetupConfig->decorScrollBarSizeTheme)};
         Add(new cOsdItem(size, osUnknown, false));
     } else {
         Add(new cMenuEditStraItem(tr("Scrollbar type"), &SetupConfig->decorScrollBarTypeUser, ScrollBarTypes.Size(), &ScrollBarTypes[0]));
@@ -1109,9 +1109,9 @@ void cFlatSetupMenu::Setup() {
 
     Add(new cMenuEditBoolItem(tr("Menuitem border by decor-file?"), &SetupConfig->decorBorderMenuItemByTheme));
     if (SetupConfig->decorBorderMenuItemByTheme) {
-        cString type = cString::sprintf("%s:\t%s", tr("Menuitem border type"), Bordertypes[SetupConfig->decorBorderMenuItemTypeTheme]);
+        cString type {cString::sprintf("%s:\t%s", tr("Menuitem border type"), Bordertypes[SetupConfig->decorBorderMenuItemTypeTheme])};
         Add(new cOsdItem(type, osUnknown, false));
-        cString size = cString::sprintf("%s:\t%d", tr("Menuitem border size"), SetupConfig->decorBorderMenuItemSizeTheme);
+        cString size {cString::sprintf("%s:\t%d", tr("Menuitem border size"), SetupConfig->decorBorderMenuItemSizeTheme)};
         Add(new cOsdItem(size, osUnknown, false));
     } else {
         Add(new cMenuEditStraItem(tr("Menuitem border type"), &SetupConfig->decorBorderMenuItemTypeUser, Bordertypes.Size(), &Bordertypes[0]));
@@ -1120,9 +1120,9 @@ void cFlatSetupMenu::Setup() {
 
     Add(new cMenuEditBoolItem(tr("Menucont. border by decor-file?"), &SetupConfig->decorBorderMenuContentByTheme));
     if (SetupConfig->decorBorderMenuContentByTheme) {
-        cString type = cString::sprintf("%s:\t%s", tr("Menucont. border type"), Bordertypes[SetupConfig->decorBorderMenuContentTypeTheme]);
+        cString type {cString::sprintf("%s:\t%s", tr("Menucont. border type"), Bordertypes[SetupConfig->decorBorderMenuContentTypeTheme])};
         Add(new cOsdItem(type, osUnknown, false));
-        cString size = cString::sprintf("%s:\t%d", tr("Menucont. border size"), SetupConfig->decorBorderMenuContentSizeTheme);
+        cString size {cString::sprintf("%s:\t%d", tr("Menucont. border size"), SetupConfig->decorBorderMenuContentSizeTheme)};
         Add(new cOsdItem(size, osUnknown, false));
     } else {
         Add(new cMenuEditStraItem(tr("Menucont. border type"), &SetupConfig->decorBorderMenuContentTypeUser, Bordertypes.Size(), &Bordertypes[0]));
@@ -1131,9 +1131,9 @@ void cFlatSetupMenu::Setup() {
 
     Add(new cMenuEditBoolItem(tr("Menucont. head border by decor-file?"), &SetupConfig->decorBorderMenuContentHeadByTheme));
     if (SetupConfig->decorBorderMenuContentHeadByTheme) {
-        cString type = cString::sprintf("%s:\t%s", tr("Menucont. head border type"), Bordertypes[SetupConfig->decorBorderMenuContentHeadTypeTheme]);
+        cString type {cString::sprintf("%s:\t%s", tr("Menucont. head border type"), Bordertypes[SetupConfig->decorBorderMenuContentHeadTypeTheme])};
         Add(new cOsdItem(type, osUnknown, false));
-        cString size = cString::sprintf("%s:\t%d", tr("Menucont. head border size"), SetupConfig->decorBorderMenuContentHeadSizeTheme);
+        cString size {cString::sprintf("%s:\t%d", tr("Menucont. head border size"), SetupConfig->decorBorderMenuContentHeadSizeTheme)};
         Add(new cOsdItem(size, osUnknown, false));
     } else {
         Add(new cMenuEditStraItem(tr("Menucont. head border type"), &SetupConfig->decorBorderMenuContentHeadTypeUser, Bordertypes.Size(), &Bordertypes[0]));
@@ -1142,9 +1142,9 @@ void cFlatSetupMenu::Setup() {
 
     Add(new cMenuEditBoolItem(tr("Menuitem progress by decor-file?"), &SetupConfig->decorProgressMenuItemByTheme));
     if (SetupConfig->decorProgressMenuItemByTheme) {
-        cString type = cString::sprintf("%s:\t%s", tr("Menuitem progress type"), Progresstypes[SetupConfig->decorProgressMenuItemTypeTheme]);
+        cString type {cString::sprintf("%s:\t%s", tr("Menuitem progress type"), Progresstypes[SetupConfig->decorProgressMenuItemTypeTheme])};
         Add(new cOsdItem(type, osUnknown, false));
-        cString size = cString::sprintf("%s:\t%d", tr("Menuitem progress size"), SetupConfig->decorProgressMenuItemSizeTheme);
+        cString size {cString::sprintf("%s:\t%d", tr("Menuitem progress size"), SetupConfig->decorProgressMenuItemSizeTheme)};
         Add(new cOsdItem(size, osUnknown, false));
     } else {
         Add(new cMenuEditStraItem(tr("Menuitem progress type"), &SetupConfig->decorProgressMenuItemTypeUser, Progresstypes.Size(), &Progresstypes[0]));
@@ -1160,7 +1160,7 @@ void cFlatSetupMenu::Setup() {
 }
 
 eOSState cFlatSetupMenu::ProcessKey(eKeys Key) {
-    eOSState state = cOsdMenu::ProcessKey(Key);
+    eOSState state {cOsdMenu::ProcessKey(Key)};
     if (state == osUnknown) {
         switch (Key) {
             case kOk:
@@ -1170,7 +1170,7 @@ eOSState cFlatSetupMenu::ProcessKey(eKeys Key) {
         }
     }
     if (Key == kLeft || Key == kRight) {
-        const char* ItemText = Get(Current())->Text();
+        const char* ItemText {Get(Current())->Text()};
         if (strstr(ItemText, tr("Menuitem border by decor-file?")) != nullptr ||
             strstr(ItemText, tr("Menucont. border by decor-file?")) != nullptr ||
             strstr(ItemText, tr("Menucont. head border by decor-file?")) != nullptr ||
@@ -1211,16 +1211,16 @@ void cFlatSetupReplay::Setup() {
         Add(new cMenuEditIntItem(tr("Dimm on pause delay"), &SetupConfig->RecordingDimmOnPauseDelay));
         Add(new cMenuEditIntItem(tr("Dimm on pause opaque"), &SetupConfig->RecordingDimmOnPauseOpaque));
     } else {
-        cString type = cString::sprintf("%s:\t%d", tr("Dimm on pause delay"), SetupConfig->RecordingDimmOnPauseDelay);
+        cString type {cString::sprintf("%s:\t%d", tr("Dimm on pause delay"), SetupConfig->RecordingDimmOnPauseDelay)};
         Add(new cOsdItem(type, osUnknown, false));
-        cString size = cString::sprintf("%s:\t%d", tr("Dimm on pause opaque"), SetupConfig->RecordingDimmOnPauseOpaque);
+        cString size {cString::sprintf("%s:\t%d", tr("Dimm on pause opaque"), SetupConfig->RecordingDimmOnPauseOpaque)};
         Add(new cOsdItem(size, osUnknown, false));
     }
     Add(new cMenuEditBoolItem(tr("Replay border by decor-file?"), &SetupConfig->decorBorderReplayByTheme));
     if (SetupConfig->decorBorderReplayByTheme) {
-        cString type = cString::sprintf("%s:\t%s", tr("Replay border type"), Bordertypes[SetupConfig->decorBorderReplayTypeTheme]);
+        cString type {cString::sprintf("%s:\t%s", tr("Replay border type"), Bordertypes[SetupConfig->decorBorderReplayTypeTheme])};
         Add(new cOsdItem(type, osUnknown, false));
-        cString size = cString::sprintf("%s:\t%d", tr("Replay border size"), SetupConfig->decorBorderReplaySizeTheme);
+        cString size {cString::sprintf("%s:\t%d", tr("Replay border size"), SetupConfig->decorBorderReplaySizeTheme)};
         Add(new cOsdItem(size, osUnknown, false));
     } else {
         Add(new cMenuEditStraItem(tr("Replay border type"), &SetupConfig->decorBorderReplayTypeUser, Bordertypes.Size(), &Bordertypes[0]));
@@ -1229,7 +1229,7 @@ void cFlatSetupReplay::Setup() {
 
     Add(new cMenuEditBoolItem(tr("Replay progress by decor-file?"), &SetupConfig->decorProgressReplayByTheme));
     if (SetupConfig->decorProgressReplayByTheme) {
-        cString size = cString::sprintf("%s:\t%d", tr("Replay progress size"), SetupConfig->decorProgressReplaySizeTheme);
+        cString size {cString::sprintf("%s:\t%d", tr("Replay progress size"), SetupConfig->decorProgressReplaySizeTheme)};
         Add(new cOsdItem(size, osUnknown, false));
     } else {
         Add(new cMenuEditIntItem(tr("Replay progress size"), &SetupConfig->decorProgressReplaySizeUser));
@@ -1244,7 +1244,7 @@ void cFlatSetupReplay::Setup() {
 }
 
 eOSState cFlatSetupReplay::ProcessKey(eKeys Key) {
-    eOSState state = cOsdMenu::ProcessKey(Key);
+    eOSState state {cOsdMenu::ProcessKey(Key)};
     if (state == osUnknown) {
         switch (Key) {
             case kOk:
@@ -1254,7 +1254,7 @@ eOSState cFlatSetupReplay::ProcessKey(eKeys Key) {
         }
     }
     if (Key == kLeft || Key == kRight) {
-        const char* ItemText = Get(Current())->Text();
+        const char* ItemText {Get(Current())->Text()};
         if (strstr(ItemText, tr("Replay border by decor-file?")) != nullptr ||
             strstr(ItemText, tr("Replay progress by decor-file?")) != nullptr ||
             strstr(ItemText, tr("Dimm on pause?")) != nullptr) {
@@ -1275,9 +1275,9 @@ void cFlatSetupVolume::Setup() {
 
     Add(new cMenuEditBoolItem(tr("Volume border by decor-file?"), &SetupConfig->decorBorderVolumeByTheme));
     if (SetupConfig->decorBorderVolumeByTheme) {
-        cString type = cString::sprintf("%s:\t%s", tr("Volume border type"), Bordertypes[SetupConfig->decorBorderVolumeTypeTheme]);
+        cString type {cString::sprintf("%s:\t%s", tr("Volume border type"), Bordertypes[SetupConfig->decorBorderVolumeTypeTheme])};
         Add(new cOsdItem(type, osUnknown, false));
-        cString size = cString::sprintf("%s:\t%d", tr("Volume border size"), SetupConfig->decorBorderVolumeSizeTheme);
+        cString size {cString::sprintf("%s:\t%d", tr("Volume border size"), SetupConfig->decorBorderVolumeSizeTheme)};
         Add(new cOsdItem(size, osUnknown, false));
     } else {
         Add(new cMenuEditStraItem(tr("Volume border type"), &SetupConfig->decorBorderVolumeTypeUser, Bordertypes.Size(), &Bordertypes[0]));
@@ -1286,9 +1286,9 @@ void cFlatSetupVolume::Setup() {
 
     Add(new cMenuEditBoolItem(tr("Volume progress by decor-file?"), &SetupConfig->decorProgressVolumeByTheme));
     if (SetupConfig->decorProgressVolumeByTheme) {
-        cString type = cString::sprintf("%s:\t%s", tr("Volume progress type"), Progresstypes[SetupConfig->decorProgressVolumeTypeTheme]);
+        cString type {cString::sprintf("%s:\t%s", tr("Volume progress type"), Progresstypes[SetupConfig->decorProgressVolumeTypeTheme])};
         Add(new cOsdItem(type, osUnknown, false));
-        cString size = cString::sprintf("%s:\t%d", tr("Volume progress size"), SetupConfig->decorProgressVolumeSizeTheme);
+        cString size {cString::sprintf("%s:\t%d", tr("Volume progress size"), SetupConfig->decorProgressVolumeSizeTheme)};
         Add(new cOsdItem(size, osUnknown, false));
     } else {
         Add(new cMenuEditStraItem(tr("Volume progress type"), &SetupConfig->decorProgressVolumeTypeUser, Progresstypes.Size(), &Progresstypes[0]));
@@ -1304,7 +1304,7 @@ void cFlatSetupVolume::Setup() {
 }
 
 eOSState cFlatSetupVolume::ProcessKey(eKeys Key) {
-    eOSState state = cOsdMenu::ProcessKey(Key);
+    eOSState state {cOsdMenu::ProcessKey(Key)};
     if (state == osUnknown) {
         switch (Key) {
             case kOk:
@@ -1314,7 +1314,7 @@ eOSState cFlatSetupVolume::ProcessKey(eKeys Key) {
         }
     }
     if (Key == kLeft || Key == kRight) {
-        const char* ItemText = Get(Current())->Text();
+        const char* ItemText {Get(Current())->Text()};
         if (strstr(ItemText, tr("Volume border by decor-file?")) != nullptr ||
             strstr(ItemText, tr("Volume progress by decor-file?")) != nullptr) {
             ItemLastSel = Current();
@@ -1334,9 +1334,9 @@ void cFlatSetupTracks::Setup() {
 
     Add(new cMenuEditBoolItem(tr("Tracks border by decor-file?"), &SetupConfig->decorBorderTrackByTheme));
     if (SetupConfig->decorBorderTrackByTheme) {
-        cString type = cString::sprintf("%s:\t%s", tr("Tracks border type"), Bordertypes[SetupConfig->decorBorderTrackTypeTheme]);
+        cString type {cString::sprintf("%s:\t%s", tr("Tracks border type"), Bordertypes[SetupConfig->decorBorderTrackTypeTheme])};
         Add(new cOsdItem(type, osUnknown, false));
-        cString size = cString::sprintf("%s:\t%d", tr("Tracks border size"), SetupConfig->decorBorderTrackSizeTheme);
+        cString size {cString::sprintf("%s:\t%d", tr("Tracks border size"), SetupConfig->decorBorderTrackSizeTheme)};
         Add(new cOsdItem(size, osUnknown, false));
     } else {
         Add(new cMenuEditStraItem(tr("Tracks border type"), &SetupConfig->decorBorderTrackTypeUser, Bordertypes.Size(), &Bordertypes[0]));
@@ -1352,7 +1352,7 @@ void cFlatSetupTracks::Setup() {
 }
 
 eOSState cFlatSetupTracks::ProcessKey(eKeys Key) {
-    eOSState state = cOsdMenu::ProcessKey(Key);
+    eOSState state {cOsdMenu::ProcessKey(Key)};
     if (state == osUnknown) {
         switch (Key) {
             case kOk:
@@ -1362,7 +1362,7 @@ eOSState cFlatSetupTracks::ProcessKey(eKeys Key) {
         }
     }
     if (Key == kLeft || Key == kRight) {
-        const char* ItemText = Get(Current())->Text();
+        const char* ItemText {Get(Current())->Text()};
         if (strstr(ItemText, tr("Tracks border by decor-file?")) != nullptr) {
             ItemLastSel = Current();
             Setup();
@@ -1389,8 +1389,8 @@ void cFlatSetupTVScraper::Setup() {
         Add(new cMenuEditPrcItem(tr("Replay/channelinfo poster opacity"), &SetupConfig->TVScraperPosterOpacity, 0.001,
                                  0.01, 2));
     } else {
-        cString opacity =
-            cString::sprintf("%s:\t%.2f", tr("Replay/channelinfo poster opacity"), SetupConfig->TVScraperPosterOpacity);
+        cString opacity {cString::sprintf("%s:\t%.2f", tr("Replay/channelinfo poster opacity"),
+                                          SetupConfig->TVScraperPosterOpacity)};
         Add(new cOsdItem(opacity, osUnknown, false));
     }
     Add(new cMenuEditBoolItem(tr("EPG info show poster?"), &SetupConfig->TVScraperEPGInfoShowPoster));
@@ -1400,8 +1400,8 @@ void cFlatSetupTVScraper::Setup() {
         Add(new cMenuEditStraItem(tr("search local posters"), &SetupConfig->TVScraperSearchLocalPosters,
                                   SearchLocalPosters.Size(), &SearchLocalPosters[0]));
     } else {
-        cString search = cString::sprintf("%s:\t%s", tr("search local posters"),
-                                          SearchLocalPosters[SetupConfig->TVScraperSearchLocalPosters]);
+        cString search {cString::sprintf("%s:\t%s", tr("search local posters"),
+                                          SearchLocalPosters[SetupConfig->TVScraperSearchLocalPosters])};
         Add(new cOsdItem(search, osUnknown, false));
     }
     Add(new cMenuEditBoolItem(tr("recording info show actors?"), &SetupConfig->TVScraperRecInfoShowActors));
@@ -1409,7 +1409,7 @@ void cFlatSetupTVScraper::Setup() {
         Add(new cMenuEditIntItem(tr("Max. actors to show?"), &SetupConfig->TVScraperShowMaxActors, -1, 999,
                                  trVDR("no")));
     } else {
-        cString max = cString::sprintf("%s:\t%d", tr("Max. actors to show?"), SetupConfig->TVScraperShowMaxActors);
+        cString max {cString::sprintf("%s:\t%d", tr("Max. actors to show?"), SetupConfig->TVScraperShowMaxActors)};
         Add(new cOsdItem(max, osUnknown, false));
     }
 
@@ -1422,7 +1422,7 @@ void cFlatSetupTVScraper::Setup() {
 }
 
 eOSState cFlatSetupTVScraper::ProcessKey(eKeys Key) {
-    eOSState state = cOsdMenu::ProcessKey(Key);
+    eOSState state {cOsdMenu::ProcessKey(Key)};
     if (state == osUnknown) {
         switch (Key) {
             case kOk:
@@ -1432,7 +1432,7 @@ eOSState cFlatSetupTVScraper::ProcessKey(eKeys Key) {
         }
     }
     if (Key == kLeft || Key == kRight) {
-        const char* ItemText = Get(Current())->Text();
+        const char* ItemText {Get(Current())->Text()};
         if (strstr(ItemText, tr("Channelinfo show poster?")) != nullptr ||
             strstr(ItemText, tr("Replayinfo show poster?")) != nullptr ||
             strstr(ItemText, tr("EPG info show poster?")) != nullptr ||
@@ -1537,7 +1537,7 @@ void cFlatSetupMMWidget::Setup() {
 }
 
 eOSState cFlatSetupMMWidget::ProcessKey(eKeys Key) {
-    eOSState state = cOsdMenu::ProcessKey(Key);
+    eOSState state {cOsdMenu::ProcessKey(Key)};
     if (state == osUnknown) {
         switch (Key) {
             case kOk:
@@ -1547,7 +1547,7 @@ eOSState cFlatSetupMMWidget::ProcessKey(eKeys Key) {
         }
     }
     if (Key == kLeft || Key == kRight) {
-        const char* ItemText = Get(Current())->Text();
+        const char* ItemText {Get(Current())->Text()};
         if (strstr(ItemText, tr("Enable main menu widgets")) != nullptr ||
             strstr(ItemText, tr("Widget weather: enable")) != nullptr ||
             strstr(ItemText, tr("Widget DVB devices: enable")) != nullptr ||

--- a/setup.c
+++ b/setup.c
@@ -276,6 +276,11 @@ void cFlatSetup::Store() {
     SetupStore("ChannelSimpleAspectFormat", Config.ChannelSimpleAspectFormat);
     SetupStore("ChannelTimeLeft", Config.ChannelTimeLeft);
     SetupStore("ChannelWeatherShow", Config.ChannelWeatherShow);
+    SetupStore("ChannelZapcockpitKeyRightOpensList", Config.ChannelZapcockpitKeyRightOpensList);
+    SetupStore("ChannelZapcockpitListWidth", Config.ChannelZapcockpitListWidth);
+    SetupStore("ChannelZapcockpitFontSize", Config.ChannelZapcockpitFontSize);
+    SetupStore("ChannelZapcockpitFadeTime", Config.ChannelZapcockpitFadeTime);
+    SetupStore("ChannelZapcockpitShiftTime", Config.ChannelZapcockpitShiftTime);
     SetupStore("DecorIndex", Config.DecorIndex);
     SetupStore("DiskUsageFree", Config.DiskUsageFree);
     SetupStore("DiskUsageShort", Config.DiskUsageShort);
@@ -488,6 +493,11 @@ bool cFlatSetupGeneral::SetupParse(const char *Name, const char *Value) {
     else if (strcmp(Name, "ChannelSimpleAspectFormat") == 0)            SetupConfig->ChannelSimpleAspectFormat = atoi(Value);
     else if (strcmp(Name, "ChannelTimeLeft") == 0)                      SetupConfig->ChannelTimeLeft = atoi(Value);
     else if (strcmp(Name, "ChannelWeatherShow") == 0)                   SetupConfig->ChannelWeatherShow = atoi(Value);
+    else if (strcmp(Name, "ChannelZapcockpitKeyRightOpensList") == 0)   SetupConfig->ChannelZapcockpitKeyRightOpensList = atoi(Value);
+    else if (strcmp(Name, "ChannelZapcockpitListWidth") == 0)           SetupConfig->ChannelZapcockpitListWidth = atoi(Value);
+    else if (strcmp(Name, "ChannelZapcockpitFontSize") == 0)            SetupConfig->ChannelZapcockpitFontSize = atoi(Value);
+    else if (strcmp(Name, "ChannelZapcockpitFadeTime") == 0)            SetupConfig->ChannelZapcockpitFadeTime = atoi(Value);
+    else if (strcmp(Name, "ChannelZapcockpitShiftTime") == 0)           SetupConfig->ChannelZapcockpitShiftTime = atoi(Value);
     else if (strcmp(Name, "DecorIndex") == 0)                           SetupConfig->DecorIndex = atoi(Value);
     else if (strcmp(Name, "DiskUsageFree") == 0)                        SetupConfig->DiskUsageFree = atoi(Value);
     else if (strcmp(Name, "DiskUsageShort") == 0)                       SetupConfig->DiskUsageShort = atoi(Value);
@@ -680,6 +690,11 @@ void cFlatSetupGeneral::SaveCurrentSettings() {
     Config.Store("ChannelSimpleAspectFormat", SetupConfig->ChannelSimpleAspectFormat, *Filename);
     Config.Store("ChannelTimeLeft", SetupConfig->ChannelTimeLeft, *Filename);
     Config.Store("ChannelWeatherShow", SetupConfig->ChannelWeatherShow, *Filename);
+    Config.Store("ChannelZapcockpitKeyRightOpensList", SetupConfig->ChannelZapcockpitKeyRightOpensList, *Filename);
+    Config.Store("ChannelZapcockpitListWidth", SetupConfig->ChannelZapcockpitListWidth, *Filename);
+    Config.Store("ChannelZapcockpitFontSize", SetupConfig->ChannelZapcockpitFontSize, *Filename);
+    Config.Store("ChannelZapcockpitFadeTime", SetupConfig->ChannelZapcockpitFadeTime, *Filename);
+    Config.Store("ChannelZapcockpitShiftTime", SetupConfig->ChannelZapcockpitShiftTime, *Filename);
     Config.Store("DecorIndex", SetupConfig->DecorIndex, *Filename);
     Config.Store("DiskUsageFree", SetupConfig->DiskUsageFree, *Filename);
     Config.Store("DiskUsageShort", SetupConfig->DiskUsageShort, *Filename);
@@ -971,6 +986,18 @@ void cFlatSetupChannelInfo::Setup() {
     Add(new cMenuEditBoolItem(tr("Show Channelinfo icons"), &SetupConfig->ChannelIconsShow));
     Add(new cMenuEditBoolItem(tr("Show event start time left"), &SetupConfig->ChannelShowStartTime));
     Add(new cMenuEditBoolItem(tr("Show signal quality"), &SetupConfig->SignalQualityShow));
+#ifdef USE_ZAPCOCKPIT
+    Add(new cMenuEditBoolItem(tr("Zapcockpit: Key right opens channellist"),
+                              &SetupConfig->ChannelZapcockpitKeyRightOpensList));
+    Add(new cMenuEditIntItem(tr("Zapcockpit: Relative list width"),
+                             &SetupConfig->ChannelZapcockpitListWidth, 20, 40));
+    Add(new cMenuEditIntItem(tr("Zapcockpit: Relative list font size"),
+                             &SetupConfig->ChannelZapcockpitFontSize, 60, 100));
+    Add(new cMenuEditIntItem(tr("Zapcockpit: List fade-in time (ms)"),
+                             &SetupConfig->ChannelZapcockpitFadeTime, 0, 1000));
+    Add(new cMenuEditIntItem(tr("Zapcockpit: List shift-in time (ms)"),
+                             &SetupConfig->ChannelZapcockpitShiftTime, 0, 1000));
+#endif
     Add(new cMenuEditBoolItem(tr("Show weather widget"), &SetupConfig->ChannelWeatherShow));
     Add(new cMenuEditPrcItem(tr("Weather widget font size"), &SetupConfig->WeatherFontSize, 0.01, 0.2, 1));
     Add(new cMenuEditBoolItem(tr("Colors for signal quality"), &SetupConfig->SignalQualityUseColors));

--- a/skinflatplus.c
+++ b/skinflatplus.c
@@ -19,8 +19,8 @@
 #include "./setup.h"
 #include "./imageloader.h"
 
-static const char *VERSION        = "1.2.10";
-static const char *DESCRIPTION    = "Skin flatPlus";
+static const char *VERSION     {"1.2.10"};
+static const char *DESCRIPTION {"Skin flatPlus"};
 
 class cPluginFlat : public cPlugin {
  public:
@@ -61,7 +61,7 @@ const char *cPluginFlat::CommandLineHelp() {
 
 bool cPluginFlat::ProcessArgs(int argc, char *argv[]) {
     // Implement command line argument processing here if applicable.
-    static const struct option long_options[] = {
+    static const struct option long_options[] {
         { "logopath", required_argument, NULL, 'l' },
         { NULL }
     };
@@ -149,7 +149,7 @@ bool cPluginFlat::Service(const char *Id, void *Data) {
 }
 
 const char **cPluginFlat::SVDRPHelpPages() {
-    static const char *HelpPages[] = {
+    static const char *HelpPages[] {
         "RLFC\n"
         "    Remove Logo From Cache.\n"
         "    Specify logo filename with extension, but without path",

--- a/skinflatplus.c
+++ b/skinflatplus.c
@@ -19,7 +19,7 @@
 #include "./setup.h"
 #include "./imageloader.h"
 
-static const char *VERSION     {"1.2.10"};
+static const char *VERSION     {"1.3.0"};
 static const char *DESCRIPTION {"Skin flatPlus"};
 
 class cPluginFlat : public cPlugin {

--- a/textscroller.h
+++ b/textscroller.h
@@ -34,6 +34,11 @@ class cTextScroll {
     void UpdateViewPortWidth(int w);
     void Reset();
 
+    // Hide/show the scroller pixmap (used by the zapcockpit list views)
+    void SetVisible(bool Visible) {
+        if (Pixmap) Pixmap->SetLayer(Visible ? m_Layer : -1);
+    }
+
     void SetText(const char *text, const cRect &position, tColor colorFg, tColor colorBg,
                  cFont *font, tColor ColorExtraTextFg = 0);
     void DoStep();
@@ -72,6 +77,12 @@ class cTextScrollers : public cThread {
                      cFont *font, tColor ColorExtraTextFg = 0);
     void UpdateViewPortWidth(int w);
     bool isActive() { return Active(); }
+
+    // Hide/show all scroller pixmaps (used by the zapcockpit list views)
+    void SetVisible(bool Visible) {
+        for (cTextScroll *Scroller : Scrollers)
+            Scroller->SetVisible(Visible);
+    }
 
  private:
     std::vector<cTextScroll *> Scrollers;  // NOLINT

--- a/widgets/system_information/system_information.g2v
+++ b/widgets/system_information/system_information.g2v
@@ -121,18 +121,18 @@ if [[ "$SHOW_MEM_USAGE" == "1" ]] ; then
   MU=$((MEMUSED * 1000 / MEMTOTAL[1]))
   [[ $MU -lt 10 ]] && MU="0${MU}"
   MU_DEC="${MU: -1}" ; MEM_USAGE="${MU:0: -1},${MU_DEC}"
-  echo "${MEM_USAGE}%" > "${OUTPUTFLDR}/${MEM_USAGE_POS}_mem_usage"
+  echo "${MEM_USAGE} %" > "${OUTPUTFLDR}/${MEM_USAGE_POS}_mem_usage"
 fi
 
 if [[ "$SHOW_SWAP_USAGE" == "1" ]] ; then
   if [[ ${SWAPTOTAL[1]} -eq ${SWAPFREE[1]} ]] ; then
-    echo "0,0%" > "${OUTPUTFLDR}/${SWAP_USAGE_POS}_swap_usage"
+    echo "0,0 %" > "${OUTPUTFLDR}/${SWAP_USAGE_POS}_swap_usage"
   else
     SWPUSED=$((SWAPTOTAL[1] - SWAPFREE[1]))
     SU=$((SWPUSED * 1000 / SWAPFREE[1]))
     [[ $SU -lt 10 ]] && SU="0${SU}"
     SU_DEC="${SU: -1}" ; SWAP_USAGE="${SU:0: -1},${SU_DEC}"
-    echo "${SWAP_USAGE}%" > "${OUTPUTFLDR}/${SWAP_USAGE_POS}_swap_usage"
+    echo "${SWAP_USAGE} %" > "${OUTPUTFLDR}/${SWAP_USAGE_POS}_swap_usage"
   fi
 fi
 
@@ -140,14 +140,14 @@ if [[ "$SHOW_ROOT_USAGE" == "1" ]] ; then
   mapfile -t < <(df -Ph /)    # Ausgabe von df in Array (Zwei Zeilen)
   IFS=' ' read -r -a ROOTUSAGE <<< "${MAPFILE[1]}"  # 2. Zeile in Array
   # Beispiel 2. Zeile: tmpfs  128M  30M  99M  23%  /root
-  echo "${ROOTUSAGE[4]}" > "${OUTPUTFLDR}/${ROOT_USAGE_POS}_root_usage"
+  echo "${ROOTUSAGE[4]/'%'/' %'}" > "${OUTPUTFLDR}/${ROOT_USAGE_POS}_root_usage"
 fi
 
 if [[ "$SHOW_VIDEO_USAGE" == "1" && -d "$VIDEO_MOUNT" ]] ; then
   mapfile -t < <(df -Ph "$VIDEO_MOUNT")    # Ausgabe von df in Array (Zwei Zeilen)
   IFS=' ' read -r -a VIDEOUSAGE <<< "${MAPFILE[1]}"  # 2. Zeile in Array
   # Beispiel 2. Zeile: tmpfs  128M  30M  99M  23%  /root
-  echo "${VIDEOUSAGE[4]}" > "${OUTPUTFLDR}/${VIDEO_USAGE_POS}_video_usage"
+  echo "${VIDEOUSAGE[4]/'%'/' %'}" > "${OUTPUTFLDR}/${VIDEO_USAGE_POS}_video_usage"
 fi
 
 if [[ "$SHOW_VDR_CPU_USAGE" == "1" || "$SHOW_VDR_MEM_USAGE" == "1" ]] ; then
@@ -157,13 +157,13 @@ fi
 if [[ "$SHOW_VDR_CPU_USAGE" == "1" ]] ; then
   IFS=' ' read -r -a CPUTMP <<< "${MAPFILE[0]}"
   CPU_USAGE=${CPUTMP[0]/./,}  # 24.2 -> 24,2
-  echo "${CPU_USAGE//[[:space:]]/}%" > "${OUTPUTFLDR}/${VDR_CPU_USAGE_POS}_vdr_cpu_usage"
+  echo "${CPU_USAGE//[[:space:]]/} %" > "${OUTPUTFLDR}/${VDR_CPU_USAGE_POS}_vdr_cpu_usage"
 fi
 
 if [[ "$SHOW_VDR_MEM_USAGE" == "1" ]] ; then
   IFS=' ' read -r -a MEMTMP <<< "${MAPFILE[0]}"
   VDR_MEM_USAGE=${MEMTMP[1]/./,}  # 24.2 -> 24,2
-  echo "${VDR_MEM_USAGE//[[:space:]]/}%" > "${OUTPUTFLDR}/${VDR_MEM_USAGE_POS}_vdr_mem_usage"
+  echo "${VDR_MEM_USAGE//[[:space:]]/} %" > "${OUTPUTFLDR}/${VDR_MEM_USAGE_POS}_vdr_mem_usage"
 fi
 
 if [[ "$SHOW_TEMPERATURES" == "1" ]] ; then

--- a/widgets/system_information/system_information.ubuntu
+++ b/widgets/system_information/system_information.ubuntu
@@ -104,7 +104,7 @@ if [ $SHOW_MEM_USAGE = 1 ]; then
   MEM_USAGE=$((${BUF[2]} * 1000 / ${MEM[1]}))
   [ $MEM_USAGE -lt 10 ] && MEM_USAGE="0${MEM_USAGE}"
   MEM_DEC=${MEM_USAGE: -1}
-  echo "${MEM_USAGE:0: -1},${MEM_DEC}%" > ${OUTPUTFLDR}/${MEM_USAGE_POS}_mem_usage
+  echo "${MEM_USAGE:0: -1},${MEM_DEC} %" > ${OUTPUTFLDR}/${MEM_USAGE_POS}_mem_usage
 fi
 
 if [ $SHOW_SWAP_USAGE = 1 ]; then
@@ -115,9 +115,9 @@ if [ $SHOW_SWAP_USAGE = 1 ]; then
       SWP=$((${SWAP[2]} * 1000 / ${SWAP[1]}))
       [ $SWP -lt 10 ] && SWP="0${SWP}"
       SWP_DEC=${SWP: -1} ; SWP=${SWP:0: -1},${SWP_DEC}
-      echo "${SWP}%" > ${OUTPUTFLDR}/${SWAP_USAGE_POS}_swap_usage
+      echo "${SWP} %" > ${OUTPUTFLDR}/${SWAP_USAGE_POS}_swap_usage
     else
-      echo "0,0%" > ${OUTPUTFLDR}/${SWAP_USAGE_POS}_swap_usage
+      echo "0,0 %" > ${OUTPUTFLDR}/${SWAP_USAGE_POS}_swap_usage
     fi
   fi
 fi
@@ -135,7 +135,7 @@ if [ $SHOW_VDR_CPU_USAGE = 1 ]; then
   if [ $? = 0 ]; then
     mapfile -t < <(ps -p ${vdr_pid} -o %cpu) # Ausgabe von ps in Array (Zwei Zeilen)
     CPU_USAGE=${MAPFILE[1]/./,}              # 24.2 -> 24,2
-    echo "${CPU_USAGE}%" > ${OUTPUTFLDR}/${VDR_CPU_USAGE_POS}_vdr_cpu_usage
+    echo "${CPU_USAGE} %" > ${OUTPUTFLDR}/${VDR_CPU_USAGE_POS}_vdr_cpu_usage
   fi
 fi
 
@@ -144,7 +144,7 @@ if [ $SHOW_VDR_MEM_USAGE = 1 ]; then
   if [ $? = 0 ]; then
     mapfile -t < <(ps -p ${vdr_pid} -o %mem) # Ausgabe von ps in Array (Zwei Zeilen)
     VDR_MEM_USAGE=${MAPFILE[1]/./,}          # 24.2 -> 24,2
-    echo "${VDR_MEM_USAGE}%" > ${OUTPUTFLDR}/${VDR_MEM_USAGE_POS}_vdr_mem_usage
+    echo "${VDR_MEM_USAGE} %" > ${OUTPUTFLDR}/${VDR_MEM_USAGE_POS}_vdr_mem_usage
   fi
 fi
 

--- a/widgets/temperatures/temperatures.default
+++ b/widgets/temperatures/temperatures.default
@@ -25,4 +25,4 @@ sensors -A acpitz-virtual-0 | grep "temp1" | awk '{print $2}' | tr -d "+" > ${OU
 # nvidia gpu temp
 # nvidia-settings must be run as the user of the x server
 GPU="$(nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader)"
-echo "${GPU}°C" > ${OUTPUTFLDR}/gpu
+echo "${GPU} °C" > ${OUTPUTFLDR}/gpu

--- a/widgets/temperatures/temperatures.g2v
+++ b/widgets/temperatures/temperatures.g2v
@@ -28,22 +28,22 @@ done
 
 # cpu temp
 #CPUTEMP=($(sensors -A | grep "CPU Temperature"))  # no need for grep
-CPUTEMP[2]="${CPUTEMP[2]/+}"                       # +36.0°C -> 36.0°C
-#echo "${CPUTEMP[2]/./,}" > "${OUTPUTFLDR}/cpu"    # 36,0°C
-echo "${CPUTEMP[2]%.*}°C" > "${OUTPUTFLDR}/cpu"    # 36°C
+CPUTEMP[2]="${CPUTEMP[2]/+}"                       # +36.0 °C -> 36.0 °C
+#echo "${CPUTEMP[2]/./,}" > "${OUTPUTFLDR}/cpu"    # 36,0 °C
+echo "${CPUTEMP[2]%.*} °C" > "${OUTPUTFLDR}/cpu"    # 36 °C
 
 # pc case temp
 #sensors -A acpitz-virtual-0 | grep "temp1" | awk '{print $2}' | tr -d "+" > "${OUTPUTFLDR}/pccase"
 
 # motherboard temp
-MBTEMP[2]="${MBTEMP[2]/+}"                              # +36.0°C -> 36.0°C
-#echo "${MBTEMP[2]/./,}" > "${OUTPUTFLDR}/motherboard"  # 36,0°C
-echo "${MBTEMP[2]%.*}°C" > "${OUTPUTFLDR}/motherboard"  # 36°C
+MBTEMP[2]="${MBTEMP[2]/+}"                              # +36.0 °C -> 36.0 °C
+#echo "${MBTEMP[2]/./,}" > "${OUTPUTFLDR}/motherboard"  # 36,0 °C
+echo "${MBTEMP[2]%.*} °C" > "${OUTPUTFLDR}/motherboard"  # 36 °C
 
 # nvidia gpu temp
 # nvidia-settings must be run as the user of the x server
 #GPU=$(nvidia-settings -c :0 -t -query GPUCoreTemp | head -n 1)   # slow
 #GPU=$(nvidia-smi -q -d TEMPERATURE | grep -Pow "[[:digit:]]+(?=\sC)" | head -n1) # faster
 GPU="$(/opt/bin/nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader)"    # fastest
-echo "${GPU}°C" > "${OUTPUTFLDR}/gpu"
+echo "${GPU} °C" > "${OUTPUTFLDR}/gpu"
 

--- a/widgets/weather/update_weather.sh
+++ b/widgets/weather/update_weather.sh
@@ -35,9 +35,9 @@ f_log(){
 
 f_write_temp(){  # Temperaturwert aufbereiten und schreiben ($1 Temperatur, $2 Ausgabedatei)
   local data="$1" file="$2"
-  printf -v data '%.1f' "$data"                  # Temperatur mit einer Nachkommastelle
-  [[ -n "$DEC" ]] && data="${data/./"$DEC"}"     # . durch , ersetzen
-  printf '%s' "${data}${DEGREE_SIGN}" > "$file"  # Daten schreiben (13,1°C)
+  printf -v data '%.1f' "$data"                   # Temperatur mit einer Nachkommastelle
+  [[ -n "$DEC" ]] && data="${data/./"$DEC"}"      # . durch , ersetzen
+  printf '%s' "${data} ${DEGREE_SIGN}" > "$file"  # Daten schreiben (13,1 °C)
 }
 
 f_get_weather(){
@@ -89,7 +89,9 @@ f_get_weather(){
 
 ### Start ###
 # Datenverzeichnis erstellen
-[[ ! -d "$DATA_DIR" ]] && { mkdir --parents "$DATA_DIR" || exit 1 ;}
+if [[ ! -d "$DATA_DIR" ]] ; then
+  mkdir --parents "$DATA_DIR" || { f_log "Error: Could not create directory $DATA_DIR!" ; exit 1 ;}
+fi
 
 rm "${DATA_DIR}/weather.*" &>/dev/null  # Alte Daten löschen
 

--- a/widgets/weather/update_weather.sh
+++ b/widgets/weather/update_weather.sh
@@ -95,6 +95,11 @@ fi
 
 rm "${DATA_DIR}/weather.*" &>/dev/null  # Alte Daten löschen
 
+# Benötigte Tools prüfen
+for tool in curl jq ; do
+  command -v "$tool" &>/dev/null || { f_log "Error: $tool is not installed!" ; RC=1 ;}
+done
+
 # Konfiguration laden und prüfen
 [[ -e "$CONF" ]] && { source "$CONF" || exit 1 ;}
 for var in API_KEY FORECAST_DAYS _LANG LOCATION UNITS ; do

--- a/widgets/weather/update_weather_owm_free.sh
+++ b/widgets/weather/update_weather_owm_free.sh
@@ -37,9 +37,9 @@ f_log(){
 
 f_write_temp(){  # Temperaturwert aufbereiten und schreiben ($1 Temperatur, $2 Ausgabedatei)
   local data="$1" file="$2"
-  printf -v data '%.1f' "$data"                  # Temperatur mit einer Nachkommastelle
-  [[ -n "$DEC" ]] && data="${data/./"$DEC"}"     # . durch , ersetzen
-  printf '%s' "${data}${DEGREE_SIGN}" > "$file"  # Daten schreiben (13,1°C)
+  printf -v data '%.1f' "$data"                   # Temperatur mit einer Nachkommastelle
+  [[ -n "$DEC" ]] && data="${data/./"$DEC"}"      # . durch , ersetzen
+  printf '%s' "${data} ${DEGREE_SIGN}" > "$file"  # Daten schreiben (13,1 °C)
 }
 
 f_get_weather(){


### PR DESCRIPTION
2026-07-23: Version 1.3.0
- [add] Zapcockpit support (extended channel display) like in skindesigner:
        channellist, grouplist with separate group channel list, channel hints
        while entering a channel number and detailed EPG info (2nd 'Ok').
        Requires a VDR patched with the zapcockpit patch (USE_ZAPCOCKPIT in
        vdr/skins.h) and 'Zapcockpit: enabled' in the VDR miscellaneous setup.
        The lists slide in from the side of the pressed key (key 'left'
        opens its list at the right edge) and while a list is shown all
        other OSD elements (top bar, channel info) are hidden.
        The channellist items show the channel logo and three text lines:
        Remaining time, title of the running event and the following event.
        The lists use the full OSD height; too long texts are cut off and
        end with '...' like in skindesigner. The channel logos in the lists
        are drawn on the 'logo_background' image like in the channel info
        display at the bottom (alpha blended in software, so semi transparent
        images do not punch through to the live picture).
        Builds unchanged against an unpatched VDR.
        New setup options: 'Zapcockpit: Key right opens channellist',
        relative list width, relative list font size, list fade-in time and
        list shift-in time (ms, 0 = off) for animated showing of the lists.
        Thanks to heifisch @ VDR-Portal
- [update] Add spacing before percent and degree symbols
- [update] Improve image cache by replacing linear search with hash-based lookup
- [update] Clarify disk usage time units by adding 'h' to hour values in top bar
- [update] Replace hyphens (U+002D) with en dashes (U+2013) in time range formatting
- [update] Add prerequisite tool validation before execution in 'update_weather.sh'
- [update] Optimice ReadAndExtractData() for faster access
- [update] Some internal optimizations