### PR TITLE
Found while running flatPlus 1.3.0 on VDR 2.8.2 with a DRM/VAAPI output plugin that changes OSD size at runtime and replays media files.

### DIFF
--- a/displaychannel.c
+++ b/displaychannel.c
@@ -1296,7 +1296,7 @@ void cFlatDisplayChannel::PreLoadImages() {
     int ImageBgHeight {height};
 
     // Load 'logo_background' and determine if logo was found in channel logo path
-    cImage *img {ImgLoader.GetLogo("logo_background", ImageBgWidth, ImageBgHeight)};
+    cImage *img {ImgLoader.GetLogo("logo_background", ImageBgWidth, ImageBgHeight, true)};  // Miss is expected
     if (img) {
         g_LogoBgOverwrite = true;  // Used for GetLogoBg()
     } else {

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -1198,6 +1198,7 @@ void cFlatDisplayChannel::DvbapiInfoDraw() {
         dsyslog("flatPlus: DVBApi plugin %s", pDVBApi ? "found and loaded" : "not found");
     }
     if (!pDVBApi) return;
+    if (!m_CurChannel) return;  // Not set yet when an OSD size change re-created this object
 
     sDVBAPIEcmInfo ecmInfo {.sid = static_cast<uint16_t>(m_CurChannel->Sid()), .ecmtime = 0, .hops = -1};
 

--- a/displayreplay.c
+++ b/displayreplay.c
@@ -419,18 +419,18 @@ void cFlatDisplayReplay::UpdateInfo() {
         // left += TimeShiftWidth + m_MarginItem;
     }
 
-    // Check if m_Recording is null and return if so
-    if (!m_Recording) return;
+    // Without a recording (media player replay) only the total length can be drawn
+    if (!m_Recording && isempty(*m_Total)) return;
 
     int FramesAfterEdit {-1};
     int CurrentFramesAfterEdit {-1};
-    const int NumFrames {m_Recording->NumFrames()};  // Total frames in recording
-    if (NumFrames <= 0) {
+    const int NumFrames {m_Recording ? m_Recording->NumFrames() : 0};  // Total frames in recording
+    if (m_Recording && NumFrames <= 0) {
         esyslog("flatPlus: cFlatDisplayReplay::UpdateInfo() Invalid NumFrames: %d", NumFrames);
         return;
     }
 
-    if (marks && m_Recording->HasMarks()) {
+    if (m_Recording && marks && m_Recording->HasMarks()) {
 #if APIVERSNUM >= 20608
         FramesAfterEdit = marks->GetFrameAfterEdit(NumFrames, NumFrames);
         if (FramesAfterEdit >= 0) CurrentFramesAfterEdit = marks->GetFrameAfterEdit(m_CurrentFrame, NumFrames);
@@ -440,8 +440,8 @@ void cFlatDisplayReplay::UpdateInfo() {
 #endif
     }
 
-    const double FramesPerSecond {m_Recording->FramesPerSecond()};
-    if (FramesPerSecond <= 0.0) {  // Avoid DIV/0
+    const double FramesPerSecond {m_Recording ? m_Recording->FramesPerSecond() : 0.0};
+    if (m_Recording && FramesPerSecond <= 0.0) {  // Avoid DIV/0
         esyslog("flatPlus: cFlatDisplayReplay::UpdateInfo() Invalid FramesPerSecond: %.2f", FramesPerSecond);
         return;
     }
@@ -579,6 +579,8 @@ void cFlatDisplayReplay::UpdateInfo() {
                                   m_Font, TotalWidth, m_FontHeight);
         }
     }  // HasMarks
+
+    if (!m_Recording) return;  // End time and poster need the recording
 
     //* Draw end time of recording with symbol for cutted end time (2. line)
     const time_t now {time(0)};  // Fix 'jumping' end times - Update once per minute or 'm_Current' changed

--- a/displayreplay.c
+++ b/displayreplay.c
@@ -322,15 +322,15 @@ void cFlatDisplayReplay::SetCurrent(const char *Current) {
 #endif
     if (m_ModeOnly) return;
 
-    m_Current = Current;
+    m_Current = Current ? Current : "";  // Never store a nullptr, it is dereferenced unchecked below
     UpdateInfo();
 }
 
 void cFlatDisplayReplay::SetTotal(const char *Total) {
     if (m_ModeOnly) return;
 
-    m_Total = Total;
-    if (m_Current[0] != '\0')  // Do not call 'UpdateInfo()' when 'm_Current' is not set
+    m_Total = Total ? Total : "";
+    if (!isempty(*m_Current))  // Do not call 'UpdateInfo()' when 'm_Current' is not set
         UpdateInfo();
 }
 

--- a/imagecache.c
+++ b/imagecache.c
@@ -184,18 +184,12 @@ bool cImageCache::RemoveFromCache(const cString &Name) {
 void cImageCache::PreLoadImage() {
     cTimeMs Timer;
 
-    cFlatDisplayChannel DisplayChannel(false);
+    // Only one OSD may be open at a time, so scope each object to close its OSD before the next one
     // Called first. Also used to determine if 'logo_background' should be loaded from logo path or theme path
-    DisplayChannel.PreLoadImages();
-
-    cFlatDisplayMenu Display_Menu;
-    Display_Menu.PreLoadImages();
-
-    cFlatDisplayReplay DisplayReplay(false);
-    DisplayReplay.PreLoadImages();
-
-    cFlatDisplayVolume DisplayVolume;
-    DisplayVolume.PreLoadImages();
+    { cFlatDisplayChannel DisplayChannel(false); DisplayChannel.PreLoadImages(); }
+    { cFlatDisplayMenu Display_Menu; Display_Menu.PreLoadImages(); }
+    { cFlatDisplayReplay DisplayReplay(false); DisplayReplay.PreLoadImages(); }
+    { cFlatDisplayVolume DisplayVolume; DisplayVolume.PreLoadImages(); }
 
     m_InsertIndexBase = GetCacheCount();
     m_InsertIconIndexBase = GetIconCacheCount();

--- a/imageloader.c
+++ b/imageloader.c
@@ -35,7 +35,7 @@ cImageLoader::~cImageLoader() {}
  * @param height The desired height of the logo.
  * @return The loaded and scaled logo, or nullptr if the logo could not be loaded.
  */
-cImage* cImageLoader::GetLogo(const char *logo, int width, int height) {
+cImage* cImageLoader::GetLogo(const char *logo, int width, int height, bool Quiet) {
     if (width < 0 || height < 0 || isempty(logo)) return nullptr;
 
 #ifdef DEBUGIMAGELOADTIME
@@ -70,7 +70,7 @@ cImage* cImageLoader::GetLogo(const char *logo, int width, int height) {
 
         success = LoadImage(*File);  // Try to load image from disk
         if (!success) {              // Image not found on disk
-            if (i == 2)              // Third try and not found
+            if (i == 2 && !Quiet)    // Third try and not found
                 isyslog("flatPlus: cImageLoader::GetLogo() %s/%s.%s could not be loaded", *Config.LogoPath, logo,
                         *m_LogoExtension);
             continue;

--- a/imageloader.h
+++ b/imageloader.h
@@ -29,7 +29,7 @@ class cImageLoader : public cImageMagickWrapper {
     cImageLoader();
     ~cImageLoader();
 
-    cImage* GetLogo(const char *logo, int width, int height);
+    cImage* GetLogo(const char *logo, int width, int height, bool Quiet = false);  // 'Quiet': Do not log a miss
     cImage* GetIcon(const char *cIcon, int width, int height);
     cImage* GetFile(const char *cFile, int width, int height);
     cImage* GetLogoBg(int Width, int Height);  // Load 'logo_background'


### PR DESCRIPTION
* displaychannel: DvbapiInfoDraw() dereferenced m_CurChannel unguarded.
  cDisplayChannel::ProcessKey() re-creates the skin object on an OSD size
  change and then falls through to Flush() without SetChannel() — crash.
* imagecache: PreLoadImage() kept four cFlatDisplay* objects alive at once;
  each opens an OSD, so VDR logged "attempt to open OSD while it is already
  open" three times per start and theme change.
* displayreplay: the total length was never drawn when replaying something
  that is not a cRecording, although SetTotal() had stored it.
* displayreplay: SetCurrent()/SetTotal() stored a nullptr unchecked.
* imageloader: the deliberate 'logo_background' probe was reported as a
  missing logo on every start.
