### PR TITLE
Version 1.3.1

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -9,7 +9,9 @@
                 "/usr/include/**",
                 "/usr/local/include/**"
             ],
-            "defines": [],
+            "defines": [
+                "USE_ZAPCOCKPIT"
+            ],
             "cStandard": "c11",
             "cppStandard": "c++17",
             "intelliSenseMode": "linux-gcc-x64",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -92,9 +92,11 @@
     "javascript.inlayHints.enumMemberValues.enabled": true,
     "C_Cpp.default.defines": [
         "PLUGIN_NAME_I18N=skinflatplus",
-        "USE_ZAPCOCKPIT=1"
+        "USE_ZAPCOCKPIT"
     ],
     "editor.dropIntoEditor.preferences": [
 
-    ]
+    ],
+    "C_Cpp.default.enableConfigurationSquiggles": true,
+    "C_Cpp.default.compilerPath": ""
 }

--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,7 @@
 VDR Plugin 'skin flatPlus' Revision History
 -------------------------------------------
 2026-xx-xx: Version 1.3.1
+- [fix] Add missing include in imagecache.h
 - [update] Remove extra space in some date and time strings.
 - [update] Changes in Zapcockpit:
              - Use Dynamic LineWidth and LineMargin in channel information.
@@ -8,8 +9,22 @@ VDR Plugin 'skin flatPlus' Revision History
              - Hide EPG image and weather widget in zapcockpit channel info display.
              - Justify description in zapcockpit if it is set for event and recording info.
              - Reuse event data (Present/Following) from SetEvents() in wide channel info.
-             - Use own CTextFloatingWrapper for channel info description wrapping.
+             - Use own cTextFloatingWrapper for channel info description wrapping.
              - Add a outer margin (Same as for EPG image) to wide channel info display.
+             - ZapAlphaOver now exits earlier for fully opaque or fully transparent cases.
+             - Refactor ZapBlendImage:
+                 Use the underlying pixel buffer via Data() instead of repeated GetPixel/SetPixel.
+                 Compute the visible clip rectangle once before the loops.
+                 Avoid per-pixel bounds checks in the hot loop.
+             - Refactor ZapShortenText:
+                 Added an early guard for MaxWidth <= 0.
+                 If the ellipsis itself does not fit, return an empty string instead of
+                 attempting a meaningless truncation.
+                 For the final result, return a clean ellipsis-only string when the input
+                 becomes empty after trimming.
+             - Improve ZapRunShowAnimation by using 'ViewPort' and PixmapSetAlpha().
+- [update] Refactor imagescaler.c: Changing the hot loop to direct component arithmetic so
+             it avoids the temporary-object style work in the inner path.
 - [update] Some internal optimizations.
 
 2026-07-23: Version 1.3.0

--- a/HISTORY
+++ b/HISTORY
@@ -4,27 +4,29 @@ VDR Plugin 'skin flatPlus' Revision History
 - [fix] Add missing include in imagecache.h
 - [update] Remove extra space in some date and time strings.
 - [update] Changes in Zapcockpit:
-             - Use Dynamic LineWidth and LineMargin in channel information.
-             - Use medium font for wide display of channel info.
-             - Hide EPG image and weather widget in zapcockpit channel info display.
-             - Justify description in zapcockpit if it is set for event and recording info.
-             - Reuse event data (Present/Following) from SetEvents() in wide channel info.
-             - Use own cTextFloatingWrapper for channel info description wrapping.
-             - Add a outer margin (Same as for EPG image) to wide channel info display.
-             - ZapAlphaOver now exits earlier for fully opaque or fully transparent cases.
-             - Refactor ZapBlendImage:
-                 Use the underlying pixel buffer via Data() instead of repeated GetPixel/SetPixel.
-                 Compute the visible clip rectangle once before the loops.
-                 Avoid per-pixel bounds checks in the hot loop.
-             - Refactor ZapShortenText:
-                 Added an early guard for MaxWidth <= 0.
-                 If the ellipsis itself does not fit, return an empty string instead of
-                 attempting a meaningless truncation.
-                 For the final result, return a clean ellipsis-only string when the input
-                 becomes empty after trimming.
-             - Improve ZapRunShowAnimation by using 'ViewPort' and PixmapSetAlpha().
+           - Use Dynamic LineWidth and LineMargin in channel information.
+           - Use medium font for wide display of channel info.
+           - Use a bigger font for the channel number and name in the channel info.
+           - Disable the channel number and name at the bottom of the channel info in wide display.
+           - Hide EPG image and weather widget in zapcockpit channel info display.
+           - Justify description in zapcockpit if it is set for event and recording info.
+           - Reuse event data (Present/Following) from SetEvents() in wide channel info.
+           - Use own cTextFloatingWrapper for channel info description wrapping.
+           - Add a outer margin (Same as for EPG image) to wide channel info display.
+           - ZapAlphaOver now exits earlier for fully opaque or fully transparent cases.
+           - Refactor ZapBlendImage:
+              Use the underlying pixel buffer via Data() instead of repeated GetPixel/SetPixel.
+              Compute the visible clip rectangle once before the loops.
+              Avoid per-pixel bounds checks in the hot loop.
+           - Refactor ZapShortenText:
+              Added an early guard for MaxWidth <= 0.
+              If the ellipsis itself does not fit, return an empty string instead of
+              attempting a meaningless truncation.
+              For the final result, return a clean ellipsis-only string when the input
+              becomes empty after trimming.
+           - Improve ZapRunShowAnimation by using 'ViewPort' and PixmapSetAlpha().
 - [update] Refactor imagescaler.c: Changing the hot loop to direct component arithmetic so
-             it avoids the temporary-object style work in the inner path.
+           it avoids the temporary-object style work in the inner path.
 - [update] Some internal optimizations.
 
 2026-07-23: Version 1.3.0

--- a/HISTORY
+++ b/HISTORY
@@ -1,5 +1,17 @@
 VDR Plugin 'skin flatPlus' Revision History
 -------------------------------------------
+2026-xx-xx: Version 1.3.1
+- [update] Remove extra space in some date and time strings.
+- [update] Changes in Zapcockpit:
+             - Use Dynamic LineWidth and LineMargin in channel information.
+             - Use medium font for wide display of channel info.
+             - Hide EPG image and weather widget in zapcockpit channel info display.
+             - Justify description in zapcockpit if it is set for event and recording info.
+             - Reuse event data (Present/Following) from SetEvents() in wide channel info.
+             - Use own CTextFloatingWrapper for channel info description wrapping.
+             - Add a outer margin (Same as for EPG image) to wide channel info display.
+- [update] Some internal optimizations.
+
 2026-07-23: Version 1.3.0
 - [add] Zapcockpit support (extended channel display) like in skindesigner:
         channellist, grouplist with separate group channel list, channel hints

--- a/HISTORY
+++ b/HISTORY
@@ -1,7 +1,13 @@
 VDR Plugin 'skin flatPlus' Revision History
 -------------------------------------------
-2026-xx-xx: Version 1.3.1
+2026-08-02: Version 1.3.1
 - [fix] Add missing include in imagecache.h
+- [fix] Thanks to zork @ VDR-Portal for fixing:
+        - imageloader: Do not report the expected 'logo_background' miss.
+        - displayreplay: Never store a nullptr in 'm_Current' or 'm_Total'.
+                         Show total length when replaying without a cRecording.
+        - imagecache: Open only one OSD at a time while pre-loading.
+        - displaychannel: Guard against null m_CurChannel in DvbapiInfoDraw()
 - [update] Remove extra space in some date and time strings.
 - [update] Changes in Zapcockpit:
            - Use Dynamic LineWidth and LineMargin in channel information.

--- a/baserender.c
+++ b/baserender.c
@@ -32,6 +32,7 @@
 
 #include "./flat.h"
 #include "./fontcache.h"
+#include "baserender.h"
 
 // Global flag to indicate if logo was found in channel logo path
 bool g_LogoBgOverwrite {false};
@@ -1408,6 +1409,17 @@ void cFlatBaseRender::DecorBorderClearByFrom(int From) {
 void cFlatBaseRender::DecorBorderRedrawAll() {
     for (const auto &ib : Borders) {
         DecorBorderDraw(ib, false);
+    }
+}
+
+// Draw an specific border by its From value. This is useful when you want to redraw a specific border without redrawing
+// all of them. Only use for unique From values, as this function will only redraw the first matching border it finds.
+void cFlatBaseRender::DecorBorderRedrawByFrom(int From) {
+    for (const auto &ib : Borders) {
+        if (ib.From == From) {
+            DecorBorderDraw(ib, false);
+            break;  // We break after finding the first match.
+        }
     }
 }
 

--- a/baserender.h
+++ b/baserender.h
@@ -29,7 +29,8 @@ enum eBorder {
     BorderContent,
     BorderTVSPoster,
     BorderSetRecording,
-    BorderMMWidget
+    BorderMMWidget,
+    BorderChannelInfo
 };
 
 // Decorated border (Left, Top, Width, Height, Size, Type, ColorFg, ColorBg, From)

--- a/baserender.h
+++ b/baserender.h
@@ -138,6 +138,7 @@ class cFlatBaseRender {
     void DecorBorderClear(const cRect &Rect, int Size);
     void DecorBorderClearAll() const;
     void DecorBorderRedrawAll();
+    void DecorBorderRedrawByFrom(int From);  // Redraw first decorated border that have the given "From" value
     void DecorBorderClearByFrom(int From);
 
     cString ReadAndExtractData(const cString &FilePath) const;  // Read file and return its content as cString

--- a/baserender.h
+++ b/baserender.h
@@ -30,7 +30,7 @@ enum eBorder {
     BorderTVSPoster,
     BorderSetRecording,
     BorderMMWidget,
-    BorderChannelInfo
+    BorderChannelInfoBottom
 };
 
 // Decorated border (Left, Top, Width, Height, Size, Type, ColorFg, ColorBg, From)

--- a/complexcontent.c
+++ b/complexcontent.c
@@ -147,7 +147,7 @@ void cComplexContent::AddImageWithFloatedText(cImage *image, int imageAlignment,
     //         FloatLines, NumLines, TextWidthLeft, TextWidthFull);
 
     std::string Line {""};
-    Line.reserve(128);
+    Line.reserve(256);
     cRect FloatedTextPos {TextPos};
     const int Top {TextPos.Top()};  // Cache TextPos.Top() outside the loop
     for (int i {0}; i < NumLines; ++i) {  // Add text line by line

--- a/complexcontent.c
+++ b/complexcontent.c
@@ -141,20 +141,20 @@ void cComplexContent::AddImageWithFloatedText(cImage *image, int imageAlignment,
 
     cTextFloatingWrapper WrapperFloat;  // Modified cTextWrapper lent from skin ElchiHD
     WrapperFloat.Set(Text, Font, TextWidthFull, FloatLines, TextWidthLeft);  //* Set() strips trailing newlines!
-    const int Lines {WrapperFloat.Lines()};
+    const int NumLines {WrapperFloat.Lines()};
 
     // dsyslog("flatPlus: AddImageWithFloatedText:\nFloatLines %d, Lines %d, TextWithLeft %d, TextWidthFull %d",
-    //         FloatLines, Lines, TextWidthLeft, TextWidthFull);
+    //         FloatLines, NumLines, TextWidthLeft, TextWidthFull);
 
     std::string Line {""};
     Line.reserve(128);
     cRect FloatedTextPos {TextPos};
     const int Top {TextPos.Top()};  // Cache TextPos.Top() outside the loop
-    for (int i {0}; i < Lines; ++i) {  // Add text line by line
+    for (int i {0}; i < NumLines; ++i) {  // Add text line by line
         FloatedTextPos.SetTop(Top + (i * m_ScrollSize));
         Line = WrapperFloat.GetLine(i);
         // Last line is not justified
-        if (Config.MenuEventRecordingViewJustify == 1 && i < (Lines - 1))
+        if (Config.MenuEventRecordingViewJustify == 1 && i < (NumLines - 1))
             JustifyLine(Line, Font, (i < FloatLines) ? TextWidthLeft : TextWidthFull);
 
         AddText(Line.c_str(), false, FloatedTextPos, ColorFg, ColorBg, Font, TextWidthFull, TextHeight, TextAlignment);
@@ -257,7 +257,7 @@ bool cComplexContent::Scroll(bool Up, bool Page) {
             return false;
         }
     } else {
-        const int MaxScroll = -(TotalHeight - ScreenHeight);
+        const int MaxScroll {-(TotalHeight - ScreenHeight)};  // Maximum scroll position (negative value)
         if (Page) {  // Page down
             NewY = std::max(CurrentHeight - ScreenHeight, MaxScroll);
         } else {  // Line down

--- a/complexcontent.h
+++ b/complexcontent.h
@@ -49,7 +49,7 @@ class cSimpleContent {
         cTextFloatingWrapper Wrapper;
         Wrapper.Set(*m_Text, m_Font, PositionWidth);
         std::string Line;
-        Line.reserve(128);
+        Line.reserve(256);
         const int Lines {Wrapper.Lines()};
         const int FontHeight {m_Font->Height()};
 

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -1296,7 +1296,7 @@ void cFlatDisplayChannel::PreLoadImages() {
     int ImageBgHeight {height};
 
     // Load 'logo_background' and determine if logo was found in channel logo path
-    cImage *img {ImgLoader.GetLogo("logo_background", ImageBgWidth, ImageBgHeight)};
+    cImage *img {ImgLoader.GetLogo("logo_background", ImageBgWidth, ImageBgHeight, true)};  // Miss is expected
     if (img) {
         g_LogoBgOverwrite = true;  // Used for GetLogoBg()
     } else {

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -522,33 +522,35 @@ void cFlatDisplayChannel::SetEvents(const cEvent *Present, const cEvent *Followi
 
     if (Config.ChannelIconsShow && m_CurChannel) ChannelIconsDraw(m_CurChannel, true);
 
-    cString MediaPath {""};
-    cSize MediaSize {0, 0};  // Width, Height
-    if (Config.TVScraperChanInfoShowPoster) GetScraperMediaTypeSize(MediaPath, MediaSize, Present);
+    if (Config.TVScraperChanInfoShowPoster) {
+        cString MediaPath {""};
+        cSize MediaSize {0, 0};  // Width, Height
+        GetScraperMediaTypeSize(MediaPath, MediaSize, Present);
 
-    PixmapClear(ChanEpgImagesPixmap);
-    DecorBorderClearByFrom(BorderTVSPoster);
-    if (MediaPath[0] != '\0') {
-        SetMediaSize(m_TVSRect.Size(), MediaSize,
-        Config.TVScraperChanInfoPosterSize * 100);  // Set size and apply user setting
-        cImage *img {ImgLoader.GetFile(*MediaPath, MediaSize.Width(), MediaSize.Height())};
-        if (img) {
-            PixmapSetAlpha(ChanEpgImagesPixmap, 255 * Config.TVScraperPosterOpacity * 100);  // Set transparency
-            ChanEpgImagesPixmap->DrawImage(cPoint(0, 0), *img);
+        PixmapClear(ChanEpgImagesPixmap);
+        DecorBorderClearByFrom(BorderTVSPoster);
+        if (MediaPath[0] != '\0') {
+            SetMediaSize(m_TVSRect.Size(), MediaSize,
+            Config.TVScraperChanInfoPosterSize * 100);  // Set size and apply user setting
+            cImage *img {ImgLoader.GetFile(*MediaPath, MediaSize.Width(), MediaSize.Height())};
+            if (img) {
+                PixmapSetAlpha(ChanEpgImagesPixmap, 255 * Config.TVScraperPosterOpacity * 100);  // Set transparency
+                ChanEpgImagesPixmap->DrawImage(cPoint(0, 0), *img);
 
-            const sDecorBorder ib {m_MarginEPGImage + Config.decorBorderChannelEPGSize,
-                                   m_TopBarHeight + Config.decorBorderTopBarSize * 2 + m_MarginEPGImage +
-                                       Config.decorBorderChannelEPGSize,
-                                   img->Width(),
-                                   img->Height(),
-                                   Config.decorBorderChannelEPGSize,
-                                   Config.decorBorderChannelEPGType,
-                                   Config.decorBorderChannelEPGFg,
-                                   Config.decorBorderChannelEPGBg,
-                                   BorderTVSPoster};
-            DecorBorderDraw(ib);
+                const sDecorBorder ib {m_MarginEPGImage + Config.decorBorderChannelEPGSize,
+                                    m_TopBarHeight + Config.decorBorderTopBarSize * 2 + m_MarginEPGImage +
+                                        Config.decorBorderChannelEPGSize,
+                                    img->Width(),
+                                    img->Height(),
+                                    Config.decorBorderChannelEPGSize,
+                                    Config.decorBorderChannelEPGType,
+                                    Config.decorBorderChannelEPGFg,
+                                    Config.decorBorderChannelEPGBg,
+                                    BorderTVSPoster};
+                DecorBorderDraw(ib);
+            }
         }
-    }
+    }  // if (Config.TVScraperChanInfoShowPoster)
 }
 
 void cFlatDisplayChannel::SetMessage(eMessageType Type, const char *Text) {

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -708,13 +708,13 @@ void cFlatDisplayChannel::ZapRunShowAnimation() {
     const int TotalTime {std::max(ShiftTime, FadeTime)};
     if (TotalTime <= 0 || (!Pixmaps[0] && !Pixmaps[1])) return;
 
-    static constexpr int FrameTime {10};  // Duration of one animation step in ms
-    for (int t {FrameTime}; t < TotalTime; t += FrameTime) {
+    static constexpr int kFrameTime {10};  // Duration of one animation step in ms
+    for (int t {kFrameTime}; t < TotalTime; t += kFrameTime) {
         for (cPixmap *Pixmap : Pixmaps) {
             if (!Pixmap || Pixmap->Layer() < 0) continue;
             if (ShiftTime > 0) {  // Slide the content in from the anchored edge
                 const double Progress {std::min(1.0, static_cast<double>(t) / ShiftTime)};
-                const int Offset = static_cast<int>((1.0 - Progress) * Pixmap->ViewPort().Width());
+                const int Offset {static_cast<int>((1.0 - Progress) * Pixmap->ViewPort().Width())};
                 const bool LeftAnchored {Pixmap->ViewPort().X() < m_OsdWidth / 2};
                 Pixmap->SetDrawPortPoint(cPoint(LeftAnchored ? -Offset : Offset, 0));
             }
@@ -972,9 +972,9 @@ void cFlatDisplayChannel::SetChannelInfo(const cChannel *Channel) {
                             Theme.Color(clrChannelFontTitle),
                             Theme.Color(clrChannelBg), m_Font, MaxTextWidth);
     top += m_FontHeight;
-    ZapInfoPixmap->DrawRectangle(cRect(m_MarginItem2, top + m_MarginItem / 2, MaxTextWidth, 3),
+    ZapInfoPixmap->DrawRectangle(cRect(m_MarginItem2, top + m_MarginItem / 2, MaxTextWidth, m_LineHeight),
                                  Theme.Color(clrChannelFontTitle));
-    top += m_MarginItem2 + 3;
+    top += m_MarginItem2 + m_LineMargin;
 
     const cEvent *Present {nullptr}, *Following {nullptr};
     {
@@ -1029,9 +1029,9 @@ void cFlatDisplayChannel::SetChannelInfo(const cChannel *Channel) {
     }
 
     if (Following) {  // Following event in the reserved line at the bottom
-        const cString Next = cString::sprintf("%s  %s%s%s", *Following->GetTimeString(), Following->Title(),
+        const cString Next {cString::sprintf("%s  %s%s%s", *Following->GetTimeString(), Following->Title(),
                                               isempty(Following->ShortText()) ? "" : " - ",
-                                              isempty(Following->ShortText()) ? "" : Following->ShortText());
+                                              isempty(Following->ShortText()) ? "" : Following->ShortText())};
         ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, Height - m_FontSmlHeight),
                                 *ZapShortenText(*Next, m_FontSml, MaxTextWidth),
                                 Theme.Color(clrChannelFontEpgFollow), Theme.Color(clrChannelBg), m_FontSml,

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -558,11 +558,12 @@ void cFlatDisplayChannel::SetMessage(eMessageType Type, const char *Text) {
 // composition of the separate logo pixmap layers)
 static tColor ZapAlphaOver(tColor Fg, tColor Bg) {
     const int Af {static_cast<int>((Fg >> 24) & 0xFF)};
-    if (Af == 255) return Fg;
-    if (Af == 0) return Bg;
+    if (Af >= 255) return Fg;
+    if (Af <= 0) return Bg;
     const int Ab {static_cast<int>((Bg >> 24) & 0xFF)};
+    if (Ab <= 0) return Fg;
     const int A {Af + Ab * (255 - Af) / 255};
-    if (A == 0) return clrTransparent;
+    if (A <= 0) return clrTransparent;
     const auto Channel = [&](int Shift) -> int {
         const int Cf {static_cast<int>((Fg >> Shift) & 0xFF)};
         const int Cb {static_cast<int>((Bg >> Shift) & 0xFF)};
@@ -579,15 +580,25 @@ static void ZapBlendImage(cImage &Composed, const cImage *Image, int Left, int T
 #endif
 
     if (!Image) return;
-    const int Width {Image->Width()}, Height {Image->Height()};
-    for (int y {0}; y < Height; ++y) {
-        const int cy {Top + y};
-        if (cy < 0 || cy >= Composed.Height()) continue;
-        for (int x {0}; x < Width; ++x) {
-            const int cx {Left + x};
-            if (cx < 0 || cx >= Composed.Width()) continue;
-            const cPoint Src {x, y}, Dst {cx, cy};
-            Composed.SetPixel(Dst, ZapAlphaOver(Image->GetPixel(Src), Composed.GetPixel(Dst)));
+    const int ComposedWidth {Composed.Width()};
+    const int ComposedHeight {Composed.Height()};
+    const int ImageWidth {Image->Width()};
+    const int ImageHeight {Image->Height()};
+    const int StartX {std::max(0, -Left)};
+    const int StartY {std::max(0, -Top)};
+    const int EndX {std::min(ImageWidth, ComposedWidth - Left)};
+    const int EndY {std::min(ImageHeight, ComposedHeight - Top)};
+    if (StartX >= EndX || StartY >= EndY) return;
+
+    const tColor *ImageData {Image->Data()};
+    tColor *ComposedData {const_cast<tColor *>(Composed.Data())};
+    for (int y {StartY}; y < EndY; ++y) {
+        const int SrcIndexY {y * ImageWidth};
+        const int DstIndexY {(Top + y) * ComposedWidth};
+        for (int x {StartX}; x < EndX; ++x) {
+            const int SrcIndex {SrcIndexY + x};
+            const int DstIndex {DstIndexY + Left + x};
+            ComposedData[DstIndex] = ZapAlphaOver(ImageData[SrcIndex], ComposedData[DstIndex]);
         }
     }
 #ifdef DEBUGIMAGELOADTIME

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -744,7 +744,7 @@ void cFlatDisplayChannel::ZapShowBaseElements() {
 
 // Fade-in/shift-in animation for newly shown list panels, executed in Flush() after the panel content has been drawn
 // (like fadetimezapcockpit/shifttimezapcockpit in skindesigner themes). The lists slide in from the edge they are
-// anchored to. Runs blocking for at most one second
+// anchored to. Runs blocking for at most one second.
 void cFlatDisplayChannel::ZapRunShowAnimation() {
     m_ZapAnimPending = false;
     cPixmap *Pixmaps[2] {m_ZapAnimPixmap1, m_ZapAnimPixmap2};
@@ -759,24 +759,26 @@ void cFlatDisplayChannel::ZapRunShowAnimation() {
     for (int t {kFrameTime}; t < TotalTime; t += kFrameTime) {
         for (cPixmap *Pixmap : Pixmaps) {
             if (!Pixmap || Pixmap->Layer() < 0) continue;
+            const cRect ViewPort {Pixmap->ViewPort()};
             if (ShiftTime > 0) {  // Slide the content in from the anchored edge
                 const double Progress {std::min(1.0, static_cast<double>(t) / ShiftTime)};
-                const int Offset {static_cast<int>((1.0 - Progress) * Pixmap->ViewPort().Width())};
-                const bool LeftAnchored {Pixmap->ViewPort().X() < m_OsdWidth / 2};
+                const int Offset {static_cast<int>((1.0 - Progress) * ViewPort.Width())};
+                const bool LeftAnchored {ViewPort.X() < m_OsdWidth / 2};
                 Pixmap->SetDrawPortPoint(cPoint(LeftAnchored ? -Offset : Offset, 0));
             }
             if (FadeTime > 0) {  // Fade the content in
                 const double Progress {std::min(1.0, static_cast<double>(t) / FadeTime)};
-                Pixmap->SetAlpha(static_cast<int>(ALPHA_OPAQUE * Progress));
+                PixmapSetAlpha(Pixmap, static_cast<int>(ALPHA_OPAQUE * Progress));
             }
         }
         m_Osd->Flush();
         cCondWait::SleepMs(kFrameTime);
     }
+
     for (cPixmap *Pixmap : Pixmaps) {  // Ensure the final state
         if (Pixmap) {
             Pixmap->SetDrawPortPoint(cPoint(0, 0));
-            Pixmap->SetAlpha(ALPHA_OPAQUE);
+            PixmapSetAlpha(Pixmap, ALPHA_OPAQUE);
         }
     }
 }

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -1198,6 +1198,7 @@ void cFlatDisplayChannel::DvbapiInfoDraw() {
         dsyslog("flatPlus: DVBApi plugin %s", pDVBApi ? "found and loaded" : "not found");
     }
     if (!pDVBApi) return;
+    if (!m_CurChannel) return;  // Not set yet when an OSD size change re-created this object
 
     sDVBAPIEcmInfo ecmInfo {.sid = static_cast<uint16_t>(m_CurChannel->Sid()), .ecmtime = 0, .hops = -1};
 

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -39,11 +39,11 @@ cFlatDisplayChannel::cFlatDisplayChannel(bool WithInfo) {
         m_HeightBottom += m_FontSmlHeight + m_MarginItem;
 
     int height {m_HeightBottom};
-    const cRect ChanInfoViewPort {Config.decorBorderChannelSize,
-                                  Config.decorBorderChannelSize + m_ChannelHeight - height, m_ChannelWidth,
-                                  m_HeightBottom};
-    ChanInfoBottomPixmap = CreatePixmap(m_Osd, "ChanInfoBottomPixmap", 1, ChanInfoViewPort);
-    ChanIconsPixmap = CreatePixmap(m_Osd, "ChanIconsPixmap", 2, ChanInfoViewPort);
+    const cRect ChanInfoBottomViewPort {Config.decorBorderChannelSize,
+                                        Config.decorBorderChannelSize + m_ChannelHeight - height, m_ChannelWidth,
+                                        m_HeightBottom};
+    ChanInfoBottomPixmap = CreatePixmap(m_Osd, "ChanInfoBottomPixmap", 1, ChanInfoBottomViewPort);
+    ChanIconsPixmap = CreatePixmap(m_Osd, "ChanIconsPixmap", 2, ChanInfoBottomViewPort);
 
     // Pixmap for channel logo and background (4:3 aspect ratio, scaled to height of m_HeightImageLogo)
     const cRect ChanLogoViewPort {Config.decorBorderChannelSize,
@@ -158,10 +158,21 @@ cFlatDisplayChannel::cFlatDisplayChannel(bool WithInfo) {
         m_ZapInfoRectGroup.Set(Lx3, 0, std::max(0, ZapRight - Lx3), ZapFullHeight);
         m_ZapHintsRect.Set(Rx1, ZapTop, m_ZapColWidth, ZapHeight);
     }
+    // The area between top bar and the channel info display at the bottom without the ChanInfoTopPixmap area
     // m_ZapInfoWideRect.Set(ZapLeft, ZapTop, ZapRight - ZapLeft, ZapHeight);
-    // Use m_TVSRect for the EPG info panel, because it is already calculated to fit the area between top bar and
-    // channel info display at the bottom
-    m_ZapInfoWideRect = m_TVSRect;
+    m_ZapInfoWideRect.Set(ZapLeft + m_MarginEPGImage, ZapTop + m_MarginEPGImage,
+                          ZapRight - ZapLeft - m_MarginEPGImage * 2, ZapHeight + HeightTop - m_MarginEPGImage * 2);
+
+    // DecorBorder for the channel info display at the bottom without the ChanInfoTopPixmap area (Channel name)
+    m_ZapChanInfoBottomDecorBorder = {
+        Config.decorBorderChannelSize,
+        ChanInfoTopViewPort.Y() + HeightTop,
+        m_ChannelWidth,
+        m_HeightBottom + Config.decorProgressChannelSize + m_MarginItem2,
+        Config.decorBorderChannelSize,
+        Config.decorBorderChannelType,
+        Config.decorBorderChannelFg,
+        Config.decorBorderChannelBg};
 #endif
 
     // Decor border depending on setting 'ChannelShowNameWithShadow'
@@ -174,7 +185,7 @@ cFlatDisplayChannel::cFlatDisplayChannel(bool WithInfo) {
                            Config.decorBorderChannelType,
                            Config.decorBorderChannelFg,
                            Config.decorBorderChannelBg,
-                           BorderChannelInfo};
+                           BorderChannelInfoBottom};
     DecorBorderDraw(ib);
 #ifdef DEBUGFUNCSCALL
     dsyslog("   cFlatDisplayChannel() done, elapsed time %ld ms", Timer.Elapsed());
@@ -611,12 +622,13 @@ static void ZapBlendImage(cImage &Composed, const cImage *Image, int Left, int T
 static cString ZapShortenText(const char *Text, const cFont *Font, int MaxWidth) {
     if (!Text || !*Text || MaxWidth <= 0) return "";
 
+    int CurrentWidth {Font->Width(Text)};
+    if (CurrentWidth <= MaxWidth) return Text;
+
     const int EllipsisWidth {Font->Width("...")};
     if (EllipsisWidth >= MaxWidth) return "";
 
     std::string Shortened {Text};
-    int CurrentWidth {Font->Width(Shortened.c_str())};
-
     while (!Shortened.empty() && CurrentWidth + EllipsisWidth > MaxWidth) {
         std::size_t i {Shortened.size()};  // Remove the last UTF-8 character.
         do {
@@ -713,19 +725,33 @@ void cFlatDisplayChannel::ZapHideBaseElements() {
     WeatherWidget.SetVisible(false);
 }
 
-// Hide the weather widget and the ChanEpgImagesPixmap when the zapcockipt channel info is shown, because the weather
-// widget and the poster image of the selected channel would overlap the zapcockpit info pixmap. The original pixmap
-// layers are stored for restoring in ZapShowBaseElements()
-void cFlatDisplayChannel::ZapHideEpgImages() {
+// Hide the weather widget, ChanEpgImagesPixmap and the channel name when the zapcockipt channel info is shown, because
+// they would overlap the zapcockpit info pixmap. The original pixmap. Layers are stored for restoring in
+// ZapShowBaseElements()
+void cFlatDisplayChannel::ZapHideInfoElements() {
     if (m_ZapEpgImagesHidden) return;
     m_ZapEpgImagesHidden = true;
 
-    if (ChanEpgImagesPixmap && ChanEpgImagesPixmap->Layer() >= 0) {
-        m_ZapHiddenPixmaps.emplace_back(ChanEpgImagesPixmap, ChanEpgImagesPixmap->Layer());
-        ChanEpgImagesPixmap->SetLayer(-1);
-        // Remove the border around the poster image, because it would overlap the zapcockpit info pixmap
-        DecorBorderClearByFrom(BorderTVSPoster);
+    cPixmap *InfoElementPixmaps[] {ChanEpgImagesPixmap, ChanInfoTopPixmap};
+    m_ZapHiddenPixmaps.clear();
+    m_ZapHiddenPixmaps.reserve(sizeof(InfoElementPixmaps) / sizeof(InfoElementPixmaps[0]));
+    for (cPixmap *Pixmap : InfoElementPixmaps) {
+        if (Pixmap && Pixmap->Layer() >= 0) {
+            m_ZapHiddenPixmaps.emplace_back(Pixmap, Pixmap->Layer());
+            Pixmap->SetLayer(-1);
+        }
     }
+
+    // Remove the border around the poster image, because it would overlap the zapcockpit info pixmap
+    DecorBorderClearByFrom(BorderTVSPoster);
+
+    // If channel name is drawn without shadow, redraw the border for the bottom pixmap
+    if (!Config.ChannelShowNameWithShadow) {
+        DecorBorderClearByFrom(BorderChannelInfoBottom);  // Remove the Border
+        // Draw the border for the remaining bottom pixmap
+        DecorBorderDraw(m_ZapChanInfoBottomDecorBorder, false);
+    }
+
     WeatherWidget.SetVisible(false);
 }
 
@@ -801,8 +827,8 @@ void cFlatDisplayChannel::SetViewType(eDisplaychannelView ViewType) {
     case dcChannelInfo:  // Info pixmap is (re)created in SetChannelInfo()
         ZapHideLists();
         ZapShowBaseElements();
-        ZapHideEpgImages();  // Hide the weather widget and the poster image of the selected channel, because they would
-                             // overlap the info pixmap
+        ZapHideInfoElements();  // Hide the weather widget, the EPG image and the channel name, because they would
+                                // overlap the info pixmap
         break;
     case dcChannelList:
     case dcChannelListInfo: {
@@ -1016,12 +1042,14 @@ void cFlatDisplayChannel::SetChannelInfo(const cChannel *Channel) {
     const int MaxTextWidth {Width - m_MarginItem2 * 2};
     int top {m_MarginItem};
 
-    // Header: Channel number and name
+    // Header: Channel number and name. When view is wide (2nd 'Ok') we use the same size as in normal channel info.
+    const cFont *FontHdr {(IsWideInfo) ? m_FontBig : m_Font};  // Big or normal
+    const int FontHdrHeight {(IsWideInfo) ? m_FontBigHeight : m_FontHeight};  // Big or normal
     const cString Header {cString::sprintf("%d  %s", Channel->Number(), Channel->Name())};
-    ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, top), *ZapShortenText(*Header, m_Font, MaxTextWidth),
+    ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, top), *ZapShortenText(*Header, FontHdr, MaxTextWidth),
                             Theme.Color(clrChannelFontTitle),
-                            Theme.Color(clrChannelBg), m_Font, MaxTextWidth);
-    top += m_FontHeight;
+                            Theme.Color(clrChannelBg), FontHdr, MaxTextWidth);
+    top += FontHdrHeight;
     ZapInfoPixmap->DrawRectangle(cRect(m_MarginItem2, top + m_MarginItem / 2, MaxTextWidth, m_LineWidth),
                                  Theme.Color(clrChannelFontTitle));
     top += m_MarginItem2 + m_LineMargin;

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -18,6 +18,11 @@
 #include "./services/dvbapi.h"
 
 cFlatDisplayChannel::cFlatDisplayChannel(bool WithInfo) {
+#ifdef DEBUGFUNCSCALL
+    dsyslog("flatPlus: cFlatDisplayChannel::cFlatDisplayChannel()");
+    cTimeMs Timer;  // Start Timer
+#endif
+
     CreateFullOsd();
     TopBarCreate();
     MessageCreate();
@@ -90,22 +95,16 @@ cFlatDisplayChannel::cFlatDisplayChannel(bool WithInfo) {
     if (Config.ChannelWeatherShow) DrawWidgetWeather();
 
 #ifdef USE_ZAPCOCKPIT
-    // Geometry for the zapcockpit panels: The area between top bar and the
-    // channel info display at the bottom is used for the lists and the
-    // detailed EPG info. The lists are anchored at the side of the pressed
-    // key: The list opened with key 'right' at the left edge, the list opened
-    // with key 'left' at the right edge. With the default setup ('Key right
-    // opens channellist') the channellist is therefore shown at the left and
-    // the grouplist at the right edge (mirrored when the option is disabled).
-    // The channellist of the selected group is shown beside the grouplist and
-    // the EPG info of the selected channel in the remaining space.
-    // For dcChannelInfo (2nd 'Ok') the EPG info uses the full width.
-    // Pixmaps are created lazily when one of the extended views is opened.
-    // While a list view is shown all base OSD elements are hidden, so the
-    // lists and the EPG info beside them can use the full OSD height. Only
-    // the channel hints (shown while entering a channel number) and the full
-    // width EPG info (2nd 'Ok') use the area between top bar and the channel
-    // info display, because there the base OSD elements stay visible.
+    // Geometry for the zapcockpit panels: The area between top bar and the channel info display at the bottom is used
+    // for the lists and the detailed EPG info. The lists are anchored at the side of the pressed key: The list opened
+    // with key 'right' at the left edge, the list opened with key 'left' at the right edge. With the default setup
+    // ('Key right opens channellist') the channellist is therefore shown at the left and the grouplist at the right
+    // edge (mirrored when the option is disabled). The channellist of the selected group is shown beside the grouplist
+    // and the EPG info of the selected channel in the remaining space. For dcChannelInfo (2nd 'Ok') the EPG info uses
+    // the full width. Pixmaps are created lazily when one of the extended views is opened. While a list view is shown
+    // all base OSD elements are hidden, so the lists and the EPG info beside them can use the full OSD height. Only the
+    // channel hints (shown while entering a channel number) and the full width EPG info (2nd 'Ok') use the area between
+    // top bar and the channel info display, because there the base OSD elements stay visible.
     const int ZapTop {m_TopBarHeight + Config.decorBorderTopBarSize * 2 + m_MarginItem};
     const int ZapBottom {Config.decorBorderChannelSize + m_ChannelHeight - height - m_MarginItem2};
     const int ZapHeight {std::max(0, ZapBottom - ZapTop)};
@@ -123,9 +122,8 @@ cFlatDisplayChannel::cFlatDisplayChannel(bool WithInfo) {
     const int Rx2 {Rx1 - m_MarginItem2 - m_ZapColWidth};  // 2nd column from right
     const int Rx3 {Rx2 - m_MarginItem2 - m_ZapColWidth};  // 3rd column from right
 
-    // The list items use the same fonts as the channel info display at the
-    // bottom, scaled by the setup option 'Zapcockpit: List font size', so
-    // that more items fit on the screen
+    // The list items use the same fonts as the channel info display at the bottom, scaled by the setup option
+    // 'Zapcockpit: List font size', so that more items fit on the screen
     const int ZapFontPct {std::clamp(Config.ChannelZapcockpitFontSize, 60, 100)};
     const int ZapFontSize {std::max(1, Setup.FontOsdSize * ZapFontPct / 100)};
     const int ZapFontSmlSize {std::max(1, Setup.FontSmlSize * ZapFontPct / 100)};
@@ -158,7 +156,10 @@ cFlatDisplayChannel::cFlatDisplayChannel(bool WithInfo) {
         m_ZapInfoRectGroup.Set(Lx3, 0, std::max(0, ZapRight - Lx3), ZapFullHeight);
         m_ZapHintsRect.Set(Rx1, ZapTop, m_ZapColWidth, ZapHeight);
     }
-    m_ZapInfoWideRect.Set(ZapLeft, ZapTop, ZapRight - ZapLeft, ZapHeight);
+    // m_ZapInfoWideRect.Set(ZapLeft, ZapTop, ZapRight - ZapLeft, ZapHeight);
+    // Use m_TVSRect for the EPG info panel, because it is already calculated to fit the area between top bar and
+    // channel info display at the bottom
+    m_ZapInfoWideRect = m_TVSRect;
 #endif
 
     // Decor border depending on setting 'ChannelShowNameWithShadow'
@@ -172,6 +173,9 @@ cFlatDisplayChannel::cFlatDisplayChannel(bool WithInfo) {
                            Config.decorBorderChannelFg,
                            Config.decorBorderChannelBg};
     DecorBorderDraw(ib);
+#ifdef DEBUGFUNCSCALL
+    dsyslog("   cFlatDisplayChannel() done, elapsed time %ld ms", Timer.Elapsed());
+#endif
 }
 
 cFlatDisplayChannel::~cFlatDisplayChannel() {
@@ -376,6 +380,7 @@ void cFlatDisplayChannel::SetEvents(const cEvent *Present, const cEvent *Followi
     if (!ChanInfoBottomPixmap || !ChanEpgImagesPixmap) return;
 
     m_Present = Present;
+    m_Following = Following;  // Store the events for later use in Zapcockpit extended channel display
     Scrollers.Clear();
 
     // Epg related variables
@@ -397,7 +402,7 @@ void cFlatDisplayChannel::SetEvents(const cEvent *Present, const cEvent *Followi
     int TopSeen {0}, TopEpg {0};
 
     const int RecWidth {FontCache.GetStringWidth(m_FontSmlName, m_FontSmlHeight, "REC")};
-    const int SmlSpaceWidth2 {FontCache.GetStringWidth(m_FontSmlName, m_FontSmlHeight, "  ")};
+    const int SmlSpaceWidth2 {FontCache.GetStringWidth(m_FontSmlName, m_FontSmlHeight, " ") * 2};
 
     if (Config.ChannelShowStartTime)
         left += FontCache.GetStringWidth(m_FontName, m_FontHeight, "00:00") + SmlSpaceWidth2;
@@ -538,19 +543,16 @@ void cFlatDisplayChannel::SetMessage(eMessageType Type, const char *Text) {
 
 #ifdef USE_ZAPCOCKPIT
 //
-// Zapcockpit (extended channel display)
-// The complete input handling and list logic is implemented in the patched
-// VDR (cDisplayChannelExtended in menu.c). The skin only has to render the
-// channel-/grouplist, the channellist of the selected group, the channel
-// hints and the detailed EPG info of the selected channel.
+//* Zapcockpit (extended channel display)
+// The complete input handling and list logic is implemented in the patched VDR (cDisplayChannelExtended in menu.c). The
+// skin only has to render the channel-/grouplist, the channellist of the selected group, the channel hints and the
+// detailed EPG info of the selected channel.
 //
 
-// Alpha blends Fg over Bg (straight alpha 'over' operator). Used to compose
-// the channel logo on the 'logo_background' image and the list item
-// background in software, because cPixmap::DrawImage() replaces the pixels
-// including their alpha value instead of blending them (in the channel info
-// display at the bottom the blending is done by the OSD composition of the
-// separate logo pixmap layers)
+// Alpha blends Fg over Bg (straight alpha 'over' operator). Used to compose the channel logo on the 'logo_background'
+// image and the list item background in software, because cPixmap::DrawImage() replaces the pixels including their
+// alpha value instead of blending them (in the channel info display at the bottom the blending is done by the OSD
+// composition of the separate logo pixmap layers)
 static tColor ZapAlphaOver(tColor Fg, tColor Bg) {
     const int Af {static_cast<int>((Fg >> 24) & 0xFF)};
     if (Af == 255) return Fg;
@@ -566,9 +568,13 @@ static tColor ZapAlphaOver(tColor Fg, tColor Bg) {
     return (static_cast<tColor>(A) << 24) | (Channel(16) << 16) | (Channel(8) << 8) | Channel(0);
 }
 
-// Blends the given image at the given position over the existing content of
-// the composed image
+// Blends the given image at the given position over the existing content of the composed image
 static void ZapBlendImage(cImage &Composed, const cImage *Image, int Left, int Top) {  // NOLINT
+#ifdef DEBUGIMAGELOADTIME
+    dsyslog("flatPlus: ZapBlendImage(%d, %d)", Left, Top);
+    cTimeMs Timer;  // Start Timer
+#endif
+
     if (!Image) return;
     const int Width {Image->Width()}, Height {Image->Height()};
     for (int y {0}; y < Height; ++y) {
@@ -581,11 +587,13 @@ static void ZapBlendImage(cImage &Composed, const cImage *Image, int Left, int T
             Composed.SetPixel(Dst, ZapAlphaOver(Image->GetPixel(Src), Composed.GetPixel(Dst)));
         }
     }
+#ifdef DEBUGIMAGELOADTIME
+    if (Timer.Elapsed() > 0) dsyslog("   Done in %ld ms", Timer.Elapsed());
+#endif
 }
 
-// Shortens the given text so that it fits into MaxWidth: If the text is too
-// long, it is cut off (UTF-8 safe) and the end is replaced by '...' - like
-// the truncated texts in the extended channel lists of skindesigner
+// Shortens the given text so that it fits into MaxWidth: If the text is too long, it is cut off(UTF - 8 safe) and the
+// end is replaced by '...' - like the truncated texts in the extended channel lists of skindesigner
 static cString ZapShortenText(const char *Text, const cFont *Font, int MaxWidth) {
     if (!Text || !*Text || Font->Width(Text) <= MaxWidth) return Text;
 
@@ -602,9 +610,8 @@ static cString ZapShortenText(const char *Text, const cFont *Font, int MaxWidth)
     return cString::sprintf("%s...", Shortened.c_str());
 }
 
-// Creates the list pixmap if not yet existing and shows it. If the pixmap
-// exists but at a different position (channellist and grouplist are anchored
-// at opposite edges) it is recreated at the given position
+// Creates the list pixmap if not yet existing and shows it. If the pixmap exists but at a different position
+// (channellist and grouplist are anchored at opposite edges) it is recreated at the given position
 bool cFlatDisplayChannel::ZapEnsureListPixmap(cPixmap *&Pixmap, const char *Name, const cRect &Rect, bool Clear) {
     if (Pixmap && !(Pixmap->ViewPort() == Rect)) {  // Anchored at the other edge: Recreate
         m_Osd->DestroyPixmap(Pixmap);
@@ -658,13 +665,13 @@ void cFlatDisplayChannel::ZapHideInfo() {
     }
 }
 
-// Hides all base OSD elements (top bar, channel info display at the bottom,
-// progress bar, decor borders, weather widget and text scrollers) while one
-// of the zapcockpit list views is shown, so that only the lists are visible.
-// The original pixmap layers are stored for restoring in ZapShowBaseElements()
+// Hides all base OSD elements (Top bar, channel info display at the bottom, progress bar, decor borders, weather widget
+// and text scrollers) while one of the zapcockpit list views is shown, so that only the lists are visible. The original
+// pixmap layers are stored for restoring in ZapShowBaseElements()
 void cFlatDisplayChannel::ZapHideBaseElements() {
     if (m_ZapBaseHidden) return;
     m_ZapBaseHidden = true;
+    m_ZapEpgImagesHidden = true;  // EPG image and weather widget are also hidden when the base elements are hidden
 
     cPixmap *BasePixmaps[] {TopBarPixmap,     TopBarIconBgPixmap,      TopBarIconPixmap,   ChanInfoTopPixmap,
                             ChanInfoBottomPixmap, ChanLogoBgPixmap,    ChanLogoPixmap,     ChanIconsPixmap,
@@ -682,22 +689,36 @@ void cFlatDisplayChannel::ZapHideBaseElements() {
     WeatherWidget.SetVisible(false);
 }
 
+// Hide the weather widget and the ChanEpgImagesPixmap when the zapcockipt channel info is shown, because the weather
+// widget and the poster image of the selected channel would overlap the zapcockpit info pixmap. The original pixmap
+// layers are stored for restoring in ZapShowBaseElements()
+void cFlatDisplayChannel::ZapHideEpgImages() {
+    if (m_ZapEpgImagesHidden) return;
+    m_ZapEpgImagesHidden = true;
+
+    if (ChanEpgImagesPixmap && ChanEpgImagesPixmap->Layer() >= 0) {
+        m_ZapHiddenPixmaps.emplace_back(ChanEpgImagesPixmap, ChanEpgImagesPixmap->Layer());
+        ChanEpgImagesPixmap->SetLayer(-1);
+    }
+    WeatherWidget.SetVisible(false);
+}
+
 void cFlatDisplayChannel::ZapShowBaseElements() {
-    if (!m_ZapBaseHidden) return;
+    if (!m_ZapBaseHidden && !m_ZapEpgImagesHidden) return;
     m_ZapBaseHidden = false;
+    m_ZapEpgImagesHidden = false;
 
     for (const auto &Hidden : m_ZapHiddenPixmaps)
         Hidden.first->SetLayer(Hidden.second);
-    m_ZapHiddenPixmaps.clear();
+    m_ZapHiddenPixmaps.clear();  // Clear the list of hidden pixmaps after restoring their layers
 
     Scrollers.SetVisible(true);
     if (Config.ChannelWeatherShow) WeatherWidget.SetVisible(true);
 }
 
-// Fade-in/shift-in animation for newly shown list panels, executed in
-// Flush() after the panel content has been drawn (like fadetimezapcockpit/
-// shifttimezapcockpit in skindesigner themes). The lists slide in from the
-// edge they are anchored to. Runs blocking for at most one second
+// Fade-in/shift-in animation for newly shown list panels, executed in Flush() after the panel content has been drawn
+// (like fadetimezapcockpit/shifttimezapcockpit in skindesigner themes). The lists slide in from the edge they are
+// anchored to. Runs blocking for at most one second
 void cFlatDisplayChannel::ZapRunShowAnimation() {
     m_ZapAnimPending = false;
     cPixmap *Pixmaps[2] {m_ZapAnimPixmap1, m_ZapAnimPixmap2};
@@ -724,19 +745,19 @@ void cFlatDisplayChannel::ZapRunShowAnimation() {
             }
         }
         m_Osd->Flush();
-        cCondWait::SleepMs(FrameTime);
+        cCondWait::SleepMs(kFrameTime);
     }
     for (cPixmap *Pixmap : Pixmaps) {  // Ensure the final state
-        if (!Pixmap) continue;
-        Pixmap->SetDrawPortPoint(cPoint(0, 0));
-        Pixmap->SetAlpha(ALPHA_OPAQUE);
+        if (Pixmap) {
+            Pixmap->SetDrawPortPoint(cPoint(0, 0));
+            Pixmap->SetAlpha(ALPHA_OPAQUE);
+        }
     }
 }
 
-// Shows/hides the panels for the given view. The list contents are only
-// cleared when a view of a different kind is entered, because the VDR state
-// machine partially redraws the lists while scrolling and does not repaint
-// the group list when returning from the group channel list.
+// Shows/hides the panels for the given view. The list contents are only cleared when a view of a different kind is
+// entered, because the VDR state machine partially redraws the lists while scrolling and does not repaint the group
+// list when returning from the group channel list.
 void cFlatDisplayChannel::SetViewType(eDisplaychannelView ViewType) {
 #ifdef DEBUGFUNCSCALL
     dsyslog("flatPlus: cFlatDisplayChannel::SetViewType(%d)", ViewType);
@@ -752,6 +773,8 @@ void cFlatDisplayChannel::SetViewType(eDisplaychannelView ViewType) {
     case dcChannelInfo:  // Info pixmap is (re)created in SetChannelInfo()
         ZapHideLists();
         ZapShowBaseElements();
+        ZapHideEpgImages();  // Hide the weather widget and the poster image of the selected channel, because they would
+                             // overlap the info pixmap
         break;
     case dcChannelList:
     case dcChannelListInfo: {
@@ -801,9 +824,8 @@ void cFlatDisplayChannel::SetViewType(eDisplaychannelView ViewType) {
     }
 }
 
-// The grouplist uses single line items, the channellists use higher items
-// with three text lines. MaxItems() is queried by the VDR state machine after
-// SetViewType(), so the value can depend on the current view
+// The grouplist uses single line items, the channellists use higher items with three text lines. MaxItems() is queried
+// by the VDR state machine after SetViewType(), so the value can depend on the current view
 int cFlatDisplayChannel::MaxItems() {
     return (m_ZapViewType == dcGroupsList) ? m_ZapMaxItemsGroup : m_ZapMaxItemsChan;
 }
@@ -812,11 +834,10 @@ bool cFlatDisplayChannel::KeyRightOpensChannellist() {
     return Config.ChannelZapcockpitKeyRightOpensList;
 }
 
-// Draws one item of a channellist (channellist, group channel list, channel
-// hints): The channel logo at the left (if available) and three text lines
-// right of it: Remaining time of the running event (small font), title of
-// the running event and start-/end time plus title of the following event
-// (small font) - like the extended channel lists of skindesigner
+// Draws one item of a channellist (channellist, group channel list, channel hints): The channel logo at the left (if
+// available) and three text lines right of it: Remaining time of the running event (small font), title of the running
+// event and start-/end time plus title of the following event (small font) - like the extended channel lists of
+// skindesigner
 void cFlatDisplayChannel::ZapDrawChannelItem(cPixmap *Pixmap, const cChannel *Channel, int Index, bool Current) {
     if (!Pixmap || !Channel || Index < 0) return;
     // The hints panel is smaller than the full height channellist panels,
@@ -831,13 +852,11 @@ void cFlatDisplayChannel::ZapDrawChannelItem(cPixmap *Pixmap, const cChannel *Ch
 
     Pixmap->DrawRectangle(cRect(0, Top, Width, InnerHeight), ColorBg);
 
-    // Channel logo on the 'logo_background' image (like in the channel info
-    // display at the bottom) in a fixed width column at the left, so that
-    // the text lines of all items are aligned. Item background color,
-    // 'logo_background' and the logo are alpha blended in software into one
-    // image, because cPixmap::DrawImage() would replace the pixels including
-    // their alpha value (the semi transparent parts of the images would then
-    // punch through to the live picture instead of showing the layer below)
+    // Channel logo on the 'logo_background' image (like in the channel info display at the bottom) in a fixed width
+    // column at the left, so that the text lines of all items are aligned. Item background color, 'logo_background' and
+    // the logo are alpha blended in software into one image, because cPixmap::DrawImage() would replace the pixels
+    // including their alpha value (the semi transparent parts of the images would then punch through to the live
+    // picture instead of showing the layer below)
     const int LogoHeight {InnerHeight - m_MarginItem2};
     const int LogoWidth {static_cast<int>(LogoHeight * 1.34f)};  // 1.34 = 4:3
     int left {m_MarginItem};
@@ -893,8 +912,8 @@ void cFlatDisplayChannel::ZapDrawChannelItem(cPixmap *Pixmap, const cChannel *Ch
         // 3rd line (small font): Start-/end time and title of the following event
         const cString StrFollowing {cString::sprintf("%s–%s: %s", *Following->GetTimeString(),
                                                       *Following->GetEndTimeString(), Following->Title())};
-        Pixmap->DrawText(cPoint(left, top), *ZapShortenText(*StrFollowing, m_ZapFontSml, MaxTextWidth), ColorFg,
-                         ColorBg, m_ZapFontSml, MaxTextWidth);
+        Pixmap->DrawText(cPoint(left, top), *ZapShortenText(*StrFollowing, m_ZapFontSml, MaxTextWidth),
+                         clrChannelFontEpgFollow, ColorBg, m_ZapFontSml, MaxTextWidth);
     }
 }
 
@@ -913,16 +932,15 @@ void cFlatDisplayChannel::ZapDrawGroupItem(cPixmap *Pixmap, const cString &Text,
                      ColorBg, m_ZapFont, Width - m_MarginItem2);
 }
 
-// Also used for the channellist of the selected group: The VDR state machine
-// draws that list via SetChannelList() too, so the target panel is selected
-// by the current view type
+// Also used for the channellist of the selected group: The VDR state machine draws that list via SetChannelList() too,
+// so the target panel is selected by the current view type
 void cFlatDisplayChannel::SetChannelList(const cChannel *Channel, int Index, bool Current) {
     if (!Channel) return;
     ZapDrawChannelItem(ZapIsGroupChannelView() ? ZapList2Pixmap : ZapListPixmap, Channel, Index, Current);
 }
 
 void cFlatDisplayChannel::SetGroupList(const char *Group, int NumChannels, int Index, bool Current) {
-    const cString Text = cString::sprintf("%s (%d)", Group ? Group : "", NumChannels);
+    const cString Text {cString::sprintf("%s (%d)", Group ? Group : "", NumChannels)};
     ZapDrawGroupItem(ZapListPixmap, Text, Index, Current);
 }
 
@@ -936,9 +954,8 @@ void cFlatDisplayChannel::ClearList() {
 }
 
 void cFlatDisplayChannel::SetNumChannelHints(int Num) {
-    // Hints are shown in a smaller panel between top bar and channel info
-    // display while entering a channel number; the other OSD elements stay
-    // visible there (unlike in the full height list views)
+    // Hints are shown in a smaller panel between top bar and channel info display while entering a channel number; the
+    // other OSD elements stay visible there (unlike in the full height list views)
     ZapEnsureListPixmap(ZapListPixmap, "ZapListPixmap", m_ZapHintsRect, true);
     m_ZapNumHints = Num;
     m_ZapHintIndex = 0;
@@ -946,13 +963,17 @@ void cFlatDisplayChannel::SetNumChannelHints(int Num) {
 
 void cFlatDisplayChannel::SetChannelHint(const cChannel *Channel) {
     if (!Channel) return;
-    ZapDrawChannelItem(ZapListPixmap, Channel, m_ZapHintIndex++, false);
+    ZapDrawChannelItem(ZapListPixmap, Channel, ++m_ZapHintIndex, false);
 }
 
-// Draws the detailed EPG info for the given channel. Depending on the current
-// view type the full width (dcChannelInfo: 2nd 'Ok' on the current channel) or
-// the area beside the visible list panels is used.
+// Draws the detailed EPG info for the given channel. Depending on the current view type the full width (dcChannelInfo:
+// 2nd 'Ok' on the current channel) or the area beside the visible list panels is used.
 void cFlatDisplayChannel::SetChannelInfo(const cChannel *Channel) {
+#ifdef DEBUGFUNCSCALL
+    dsyslog("flatPlus: cFlatDisplayChannel::SetChannelInfo(%s)", Channel ? Channel->Name() : "nullptr");
+    cTimeMs Timer;  // Set Timer
+#endif
+
     if (!Channel) return;
 
     const cRect &Rect {(m_ZapViewType == dcChannelInfo)
@@ -972,11 +993,11 @@ void cFlatDisplayChannel::SetChannelInfo(const cChannel *Channel) {
                             Theme.Color(clrChannelFontTitle),
                             Theme.Color(clrChannelBg), m_Font, MaxTextWidth);
     top += m_FontHeight;
-    ZapInfoPixmap->DrawRectangle(cRect(m_MarginItem2, top + m_MarginItem / 2, MaxTextWidth, m_LineHeight),
+    ZapInfoPixmap->DrawRectangle(cRect(m_MarginItem2, top + m_MarginItem / 2, MaxTextWidth, m_LineWidth),
                                  Theme.Color(clrChannelFontTitle));
     top += m_MarginItem2 + m_LineMargin;
 
-    const cEvent *Present {nullptr}, *Following {nullptr};
+    /* const cEvent *Present {nullptr}, *Following {nullptr};
     {
         LOCK_SCHEDULES_READ;  // Creates local const cSchedules *Schedules
         const cSchedule *Schedule {Schedules->GetSchedule(Channel)};
@@ -984,47 +1005,65 @@ void cFlatDisplayChannel::SetChannelInfo(const cChannel *Channel) {
             Present = Schedule->GetPresentEvent();
             Following = Schedule->GetFollowingEvent();
         }
-    }
+    } */
+
+    // Use m_FontMedium when m_ZapViewType == dcChannelInfo, because the info pixmap is wider and can show more text
+    // lines. Use m_FontSml for other view types.
+    const cFont *Font {(m_ZapViewType == dcChannelInfo) ? m_FontMedium : m_FontSml};  // Medium or small
+    const int FontHeight {(m_ZapViewType == dcChannelInfo) ? m_FontMediumHeight : m_FontSmlHeight};  // Medium or small
+
+    // Use the events from SetEvents() instead of querying the schedule again
+    const cEvent *Present {m_Present}, *Following {m_Following};
 
     if (!Present) {
         ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, top), tr("No EPG info available."),
-                                Theme.Color(clrChannelFontEpg), Theme.Color(clrChannelBg), m_FontSml, MaxTextWidth);
+                                Theme.Color(clrChannelFontEpg), Theme.Color(clrChannelBg), Font, MaxTextWidth);
         return;
     }
 
     // Reserve one line at the bottom for the following event
-    const int BottomFollowing {(Following) ? Height - m_FontSmlHeight - m_MarginItem : Height};
+    const int BottomFollowing {(Following) ? Height - FontHeight - m_MarginItem : Height};
 
     // Present event: Time, title, short text and description
     const cString StrTime {cString::sprintf("%s–%s  (%d min)", *Present->GetTimeString(),
                                              *Present->GetEndTimeString(), Present->Duration() / 60)};
     ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, top), *StrTime, Theme.Color(clrChannelFontEpg),
-                            Theme.Color(clrChannelBg), m_FontSml, MaxTextWidth);
-    top += m_FontSmlHeight + m_MarginItem;
+                            Theme.Color(clrChannelBg), Font, MaxTextWidth);
+    top += FontHeight + m_MarginItem;
 
-    if (top + m_FontHeight <= BottomFollowing) {
+    if (top + m_FontHeight <= BottomFollowing) {  // Title
         ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, top), *ZapShortenText(Present->Title(), m_Font, MaxTextWidth),
                                 Theme.Color(clrChannelFontEpg), Theme.Color(clrChannelBg), m_Font, MaxTextWidth);
         top += m_FontHeight;
     }
-    if (!isempty(Present->ShortText()) && (top + m_FontSmlHeight <= BottomFollowing)) {
+    if (!isempty(Present->ShortText()) && (top + FontHeight <= BottomFollowing)) {  // Short text
         ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, top),
-                                *ZapShortenText(Present->ShortText(), m_FontSml, MaxTextWidth),
-                                Theme.Color(clrChannelFontEpgFollow), Theme.Color(clrChannelBg), m_FontSml,
+                                *ZapShortenText(Present->ShortText(), Font, MaxTextWidth),
+                                Theme.Color(clrChannelFontEpgFollow), Theme.Color(clrChannelBg), Font,
                                 MaxTextWidth);
-        top += m_FontSmlHeight;
+        top += FontHeight;
     }
     top += m_MarginItem;
 
+    // TODO: Show the EPG image of the present event if available, like in VDR's channel info display.
+
     if (!isempty(Present->Description())) {  // Description (wrapped, cut off at the bottom)
-        // cTextWrapper Description(Present->Description(), m_FontSml, MaxTextWidth);
-        cTextFloatingWrapper Description;
-        Description.Set(Present->Description(), m_FontSml, MaxTextWidth);
-        for (int i {0}; i < Description.Lines() && (top + m_FontSmlHeight <= BottomFollowing); ++i) {
-            ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, top), Description.GetLine(i),
-                                    Theme.Color(clrChannelFontEpg), Theme.Color(clrChannelBg), m_FontSml,
+        cTextFloatingWrapper Description;  // Wraps the description text into lines of the given width and font
+        Description.Set(Present->Description(), Font, MaxTextWidth);
+        const int NumLines {Description.Lines()};
+        std::string Line {""};
+        Line.reserve(128);
+
+        for (int i {0}; i < NumLines && (top + FontHeight <= BottomFollowing); ++i) {
+            Line = Description.GetLine(i);
+            // Justify all lines except the last one
+            if (Config.MenuEventRecordingViewJustify == 1 && i < (NumLines - 1))
+                JustifyLine(Line, Font, MaxTextWidth);
+
+            ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, top), Line.c_str(),
+                                    Theme.Color(clrChannelFontEpg), Theme.Color(clrChannelBg), Font,
                                     MaxTextWidth);
-            top += m_FontSmlHeight;
+            top += FontHeight;
         }
     }
 
@@ -1032,11 +1071,14 @@ void cFlatDisplayChannel::SetChannelInfo(const cChannel *Channel) {
         const cString Next {cString::sprintf("%s  %s%s%s", *Following->GetTimeString(), Following->Title(),
                                               isempty(Following->ShortText()) ? "" : " - ",
                                               isempty(Following->ShortText()) ? "" : Following->ShortText())};
-        ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, Height - m_FontSmlHeight),
-                                *ZapShortenText(*Next, m_FontSml, MaxTextWidth),
-                                Theme.Color(clrChannelFontEpgFollow), Theme.Color(clrChannelBg), m_FontSml,
+        ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, Height - FontHeight),
+                                *ZapShortenText(*Next, Font, MaxTextWidth),
+                                Theme.Color(clrChannelFontEpgFollow), Theme.Color(clrChannelBg), Font,
                                 MaxTextWidth);
     }
+#ifdef DEBUGFUNCSCALL
+    dsyslog("   SetChannelInfo() done in %ld ms", Timer.Elapsed());
+#endif
 }
 #endif  // USE_ZAPCOCKPIT
 

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -606,22 +606,32 @@ static void ZapBlendImage(cImage &Composed, const cImage *Image, int Left, int T
 #endif
 }
 
-// Shortens the given text so that it fits into MaxWidth: If the text is too long, it is cut off(UTF - 8 safe) and the
-// end is replaced by '...' - like the truncated texts in the extended channel lists of skindesigner
+// Shortens the given text so that it fits into MaxWidth: If the text is too long, it is cut off (UTF-8 safe) and the
+// end is replaced by '...' - like the truncated texts in the extended channel lists of skindesigner.
 static cString ZapShortenText(const char *Text, const cFont *Font, int MaxWidth) {
-    if (!Text || !*Text || Font->Width(Text) <= MaxWidth) return Text;
+    if (!Text || !*Text || MaxWidth <= 0) return "";
 
     const int EllipsisWidth {Font->Width("...")};
+    if (EllipsisWidth >= MaxWidth) return "";
+
     std::string Shortened {Text};
-    while (!Shortened.empty()) {
-        std::size_t i {Shortened.size()};  // Remove the last UTF-8 character
+    int CurrentWidth {Font->Width(Shortened.c_str())};
+
+    while (!Shortened.empty() && CurrentWidth + EllipsisWidth > MaxWidth) {
+        std::size_t i {Shortened.size()};  // Remove the last UTF-8 character.
         do {
             --i;
-        } while (i > 0 && (Shortened[i] & 0xC0) == 0x80);  // Skip UTF-8 continuation bytes
+        } while (i > 0 && (Shortened[i] & 0xC0) == 0x80);  // Skip UTF-8 continuation bytes.
+
+        if (i == 0) break;
+
+        const std::string Removed {Shortened.substr(i)};
+        const int RemovedWidth {Font->Width(Removed.c_str())};  // Or better: Width of one char
         Shortened.erase(i);
-        if (Font->Width(Shortened.c_str()) + EllipsisWidth <= MaxWidth) break;
+        CurrentWidth -= RemovedWidth;
     }
-    return cString::sprintf("%s...", Shortened.c_str());
+
+    return Shortened.empty() ? cString("...") : cString::sprintf("%s...", Shortened.c_str());
 }
 
 // Creates the list pixmap if not yet existing and shows it. If the pixmap exists but at a different position

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -45,15 +45,6 @@ cFlatDisplayChannel::cFlatDisplayChannel(bool WithInfo) {
     ChanInfoBottomPixmap = CreatePixmap(m_Osd, "ChanInfoBottomPixmap", 1, ChanInfoViewPort);
     ChanIconsPixmap = CreatePixmap(m_Osd, "ChanIconsPixmap", 2, ChanInfoViewPort);
 
-    // Area for TVScraper images
-    m_TVSRect.Set(
-        m_MarginEPGImage + Config.decorBorderChannelEPGSize,
-        m_TopBarHeight + Config.decorBorderTopBarSize * 2 + m_MarginEPGImage + Config.decorBorderChannelEPGSize,
-        m_OsdWidth - m_MarginEPGImage * 2 - Config.decorBorderChannelEPGSize * 2,
-        m_OsdHeight - m_TopBarHeight - m_HeightBottom - m_MarginEPGImage * 2 - Config.decorBorderChannelEPGSize * 2);
-
-    ChanEpgImagesPixmap = CreatePixmap(m_Osd, "ChanEpgImagesPixmap", 2, m_TVSRect);
-
     // Pixmap for channel logo and background (4:3 aspect ratio, scaled to height of m_HeightImageLogo)
     const cRect ChanLogoViewPort {Config.decorBorderChannelSize,
                                   Config.decorBorderChannelSize + m_ChannelHeight - height,
@@ -80,6 +71,17 @@ cFlatDisplayChannel::cFlatDisplayChannel(bool WithInfo) {
                                      HeightTop};
     ChanInfoTopPixmap = CreatePixmap(m_Osd, "ChanInfoTopPixmap", 1, ChanInfoTopViewPort);
 
+    // Area for TVScraper images
+    m_TVSRect.Set(m_MarginEPGImage + Config.decorBorderChannelEPGSize,
+                  m_TopBarHeight + Config.decorBorderTopBarSize * 2 + m_MarginEPGImage +
+                      Config.decorBorderChannelEPGSize,
+                  m_OsdWidth - m_MarginEPGImage * 2 - Config.decorBorderChannelEPGSize * 2,
+                  m_ChannelHeight - m_TopBarHeight - Config.decorBorderTopBarSize * 2 - HeightTop - m_HeightBottom -
+                      m_MarginEPGImage * 2 - Config.decorBorderChannelEPGSize * 2);
+
+    ChanEpgImagesPixmap = CreatePixmap(m_Osd, "ChanEpgImagesPixmap", 2, m_TVSRect);
+
+    // Clear Pixmaps
     PixmapFill(ChanInfoBottomPixmap, Theme.Color(clrChannelBg));
     PixmapClear(ChanIconsPixmap);
     PixmapClear(ChanEpgImagesPixmap);
@@ -171,7 +173,8 @@ cFlatDisplayChannel::cFlatDisplayChannel(bool WithInfo) {
                            Config.decorBorderChannelSize,
                            Config.decorBorderChannelType,
                            Config.decorBorderChannelFg,
-                           Config.decorBorderChannelBg};
+                           Config.decorBorderChannelBg,
+                           BorderChannelInfo};
     DecorBorderDraw(ib);
 #ifdef DEBUGFUNCSCALL
     dsyslog("   cFlatDisplayChannel() done, elapsed time %ld ms", Timer.Elapsed());
@@ -699,6 +702,8 @@ void cFlatDisplayChannel::ZapHideEpgImages() {
     if (ChanEpgImagesPixmap && ChanEpgImagesPixmap->Layer() >= 0) {
         m_ZapHiddenPixmaps.emplace_back(ChanEpgImagesPixmap, ChanEpgImagesPixmap->Layer());
         ChanEpgImagesPixmap->SetLayer(-1);
+        // Remove the border around the poster image, because it would overlap the zapcockpit info pixmap
+        DecorBorderClearByFrom(BorderTVSPoster);
     }
     WeatherWidget.SetVisible(false);
 }
@@ -976,9 +981,10 @@ void cFlatDisplayChannel::SetChannelInfo(const cChannel *Channel) {
 
     if (!Channel) return;
 
-    const cRect &Rect {(m_ZapViewType == dcChannelInfo)
-                           ? m_ZapInfoWideRect
-                           : (m_ZapViewType == dcGroupsChannelListInfo) ? m_ZapInfoRectGroup : m_ZapInfoRectChan};
+    const bool IsWide {m_ZapViewType == dcChannelInfo};  // Full width info pixmap (2nd 'Ok' on the current channel)
+    const cRect &Rect {(IsWide)                                     ? m_ZapInfoWideRect
+                       : (m_ZapViewType == dcGroupsChannelListInfo) ? m_ZapInfoRectGroup
+                                                                    : m_ZapInfoRectChan};
     ZapCreateInfoPixmap(Rect);
     if (!ZapInfoPixmap) return;
 
@@ -997,23 +1003,24 @@ void cFlatDisplayChannel::SetChannelInfo(const cChannel *Channel) {
                                  Theme.Color(clrChannelFontTitle));
     top += m_MarginItem2 + m_LineMargin;
 
-    /* const cEvent *Present {nullptr}, *Following {nullptr};
-    {
+    // Use m_FontMedium when m_ZapViewType == dcChannelInfo, because the info pixmap is wider and can show more text
+    // lines. Use m_FontSml for other view types.
+    const cFont *Font {(IsWide) ? m_FontMedium : m_FontSml};  // Medium or small
+    const int FontHeight {(IsWide) ? m_FontMediumHeight : m_FontSmlHeight};  // Medium or small
+
+    const cEvent *Present {nullptr}, *Following {nullptr};
+    if (IsWide) {
+        // Use the events from SetEvents() instead of querying the schedule again
+        Present = m_Present;
+        Following = m_Following;
+    } else {
         LOCK_SCHEDULES_READ;  // Creates local const cSchedules *Schedules
         const cSchedule *Schedule {Schedules->GetSchedule(Channel)};
         if (Schedule) {
             Present = Schedule->GetPresentEvent();
             Following = Schedule->GetFollowingEvent();
         }
-    } */
-
-    // Use m_FontMedium when m_ZapViewType == dcChannelInfo, because the info pixmap is wider and can show more text
-    // lines. Use m_FontSml for other view types.
-    const cFont *Font {(m_ZapViewType == dcChannelInfo) ? m_FontMedium : m_FontSml};  // Medium or small
-    const int FontHeight {(m_ZapViewType == dcChannelInfo) ? m_FontMediumHeight : m_FontSmlHeight};  // Medium or small
-
-    // Use the events from SetEvents() instead of querying the schedule again
-    const cEvent *Present {m_Present}, *Following {m_Following};
+    }
 
     if (!Present) {
         ZapInfoPixmap->DrawText(cPoint(m_MarginItem2, top), tr("No EPG info available."),
@@ -1043,16 +1050,14 @@ void cFlatDisplayChannel::SetChannelInfo(const cChannel *Channel) {
                                 MaxTextWidth);
         top += FontHeight;
     }
-    top += m_MarginItem;
-
-    // TODO: Show the EPG image of the present event if available, like in VDR's channel info display.
+    top += m_MarginItem2;  // Some space between the short text and the description.
 
     if (!isempty(Present->Description())) {  // Description (wrapped, cut off at the bottom)
         cTextFloatingWrapper Description;  // Wraps the description text into lines of the given width and font
         Description.Set(Present->Description(), Font, MaxTextWidth);
         const int NumLines {Description.Lines()};
         std::string Line {""};
-        Line.reserve(128);
+        Line.reserve(256);  // Avoids repeated memory allocations when appending the lines
 
         for (int i {0}; i < NumLines && (top + FontHeight <= BottomFollowing); ++i) {
             Line = Description.GetLine(i);

--- a/displaychannel.c
+++ b/displaychannel.c
@@ -1004,8 +1004,8 @@ void cFlatDisplayChannel::SetChannelInfo(const cChannel *Channel) {
 
     if (!Channel) return;
 
-    const bool IsWide {m_ZapViewType == dcChannelInfo};  // Full width info pixmap (2nd 'Ok' on the current channel)
-    const cRect &Rect {(IsWide)                                     ? m_ZapInfoWideRect
+    const bool IsWideInfo {m_ZapViewType == dcChannelInfo};  // Full width info pixmap (2nd 'Ok' on the current channel)
+    const cRect &Rect {(IsWideInfo)                                 ? m_ZapInfoWideRect
                        : (m_ZapViewType == dcGroupsChannelListInfo) ? m_ZapInfoRectGroup
                                                                     : m_ZapInfoRectChan};
     ZapCreateInfoPixmap(Rect);
@@ -1028,11 +1028,11 @@ void cFlatDisplayChannel::SetChannelInfo(const cChannel *Channel) {
 
     // Use m_FontMedium when m_ZapViewType == dcChannelInfo, because the info pixmap is wider and can show more text
     // lines. Use m_FontSml for other view types.
-    const cFont *Font {(IsWide) ? m_FontMedium : m_FontSml};  // Medium or small
-    const int FontHeight {(IsWide) ? m_FontMediumHeight : m_FontSmlHeight};  // Medium or small
+    const cFont *Font {(IsWideInfo) ? m_FontMedium : m_FontSml};  // Medium or small
+    const int FontHeight {(IsWideInfo) ? m_FontMediumHeight : m_FontSmlHeight};  // Medium or small
 
     const cEvent *Present {nullptr}, *Following {nullptr};
-    if (IsWide) {
+    if (IsWideInfo) {
         // Use the events from SetEvents() instead of querying the schedule again
         Present = m_Present;
         Following = m_Following;

--- a/displaychannel.h
+++ b/displaychannel.h
@@ -136,7 +136,8 @@ class cFlatDisplayChannel : public cFlatBaseRender, public cSkinDisplayChannel, 
         void ZapHideBaseElements();  // Hide the base OSD elements (top bar and channel info display at the bottom)
                                      // while a list view is shown
         void ZapHideInfoElements();  // Hide the weather widget, EPG image and channel name
-        void ZapShowBaseElements();
+        void ZapShowBaseElements();  // Show the base OSD elements (top bar and channel info display at the bottom)
+                                     // including the weather widget and EPG image
         void ZapRunShowAnimation();
         void ZapDrawChannelItem(cPixmap *Pixmap, const cChannel *Channel, int Index, bool Current);
         void ZapDrawGroupItem(cPixmap *Pixmap, const cString &Text, int Index, bool Current);

--- a/displaychannel.h
+++ b/displaychannel.h
@@ -47,6 +47,7 @@ class cFlatDisplayChannel : public cFlatBaseRender, public cSkinDisplayChannel, 
 
  private:
         const cEvent *m_Present {nullptr};
+        const cEvent *m_Following {nullptr};
 
         int m_ChannelWidth {0}, m_ChannelHeight {0};
 
@@ -81,30 +82,26 @@ class cFlatDisplayChannel : public cFlatBaseRender, public cSkinDisplayChannel, 
 
 #ifdef USE_ZAPCOCKPIT
         // Zapcockpit rendering
-        // The group list and the channellist of the selected group are two
-        // separate panels which are visible side by side, because the VDR
-        // state machine does not redraw the group list when returning from
-        // the group channel list (dcGroupsChannelList -> dcGroupsList).
-        // The lists slide in from the side of the pressed key: The list opened
-        // with 'right' is anchored at the left edge, the list opened with
-        // 'left' at the right edge (mirrored when the setup option
-        // 'Zapcockpit: Key right opens channellist' is disabled).
-        // While a list view is shown, all other OSD elements (top bar and the
-        // channel info display at the bottom) are hidden.
-        cPixmap *ZapListPixmap {nullptr};      // 1st column: Channellist, grouplist, channel hints
-        cPixmap *ZapList2Pixmap {nullptr};     // 2nd column: Channellist of the selected group
-        cPixmap *ZapInfoPixmap {nullptr};      // Detailed EPG info panel (beside the lists or full width)
+        // The group list and the channellist of the selected group are two separate panels which are visible side by
+        // side, because the VDR state machine does not redraw the group list when returning from the group channel list
+        // (dcGroupsChannelList -> dcGroupsList). The lists slide in from the side of the pressed key: The list opened
+        // with 'right' is anchored at the left edge, the list opened with 'left' at the right edge (mirrored when the
+        // setup option 'Zapcockpit: Key right opens channellist' is disabled). While a list view is shown, all other
+        // OSD elements (top bar and the channel info display at the bottom) are hidden.
+        cPixmap *ZapListPixmap {nullptr};   // 1st column: Channellist, grouplist, channel hints
+        cPixmap *ZapList2Pixmap {nullptr};  // 2nd column: Channellist of the selected group
+        cPixmap *ZapInfoPixmap {nullptr};   // Detailed EPG info panel (beside the lists or full width)
 
         eDisplaychannelView m_ZapViewType {dcDefault};
-        cRect m_ZapListRectChan {0, 0, 0, 0};   // Channellist panel
-        cRect m_ZapInfoRectChan {0, 0, 0, 0};   // Info panel beside the channellist
-        cRect m_ZapListRectGroup {0, 0, 0, 0};  // Grouplist panel (opposite side of the channellist)
+        cRect m_ZapListRectChan {0, 0, 0, 0};    // Channellist panel
+        cRect m_ZapInfoRectChan {0, 0, 0, 0};    // Info panel beside the channellist
+        cRect m_ZapListRectGroup {0, 0, 0, 0};   // Grouplist panel (opposite side of the channellist)
         cRect m_ZapList2RectGroup {0, 0, 0, 0};  // Channellist of the selected group (beside the grouplist)
         cRect m_ZapInfoRectGroup {0, 0, 0, 0};   // Info panel beside the group channel list
         cRect m_ZapInfoWideRect {0, 0, 0, 0};    // Info panel over the full width (dcChannelInfo)
         cRect m_ZapHintsRect {0, 0, 0, 0};       // Channel hints panel (base OSD elements stay visible)
-        // Fonts of the list items: The same fonts as in the channel info
-        // display at the bottom, scaled by 'ChannelZapcockpitFontSize'
+        // Fonts of the list items: The same fonts as in the channel info display at the bottom, scaled by
+        // 'ChannelZapcockpitFontSize'
         cFont *m_ZapFont {nullptr}, *m_ZapFontSml {nullptr};
         int m_ZapFontHeight {0}, m_ZapFontSmlHeight {0};
 
@@ -117,10 +114,11 @@ class cFlatDisplayChannel : public cFlatBaseRender, public cSkinDisplayChannel, 
         int m_ZapNumHints {0};                 // Number of currently displayed channel hints
 
         bool m_ZapBaseHidden {false};          // Base OSD elements currently hidden?
+        bool m_ZapEpgImagesHidden {false};     // EPG image and weather widget currently hidden?
         std::vector<std::pair<cPixmap *, int>> m_ZapHiddenPixmaps;  // Hidden pixmaps with their original layer
 
-        // Show animation (fade-in/shift-in of newly shown list panels),
-        // executed in Flush() after the panel content has been drawn
+        // Show animation (fade-in/shift-in of newly shown list panels), executed in Flush() after the panel content has
+        // been drawn
         bool m_ZapAnimPending {false};
         cPixmap *m_ZapAnimPixmap1 {nullptr}, *m_ZapAnimPixmap2 {nullptr};
 
@@ -132,7 +130,9 @@ class cFlatDisplayChannel : public cFlatBaseRender, public cSkinDisplayChannel, 
         void ZapHideList(cPixmap *Pixmap);
         void ZapHideLists();
         void ZapHideInfo();
-        void ZapHideBaseElements();
+        void ZapHideBaseElements();  // Hide the base OSD elements (top bar and channel info display at the bottom)
+                                     // while a list view is shown
+        void ZapHideEpgImages();     // Hide the weather widget and the EPG image
         void ZapShowBaseElements();
         void ZapRunShowAnimation();
         void ZapDrawChannelItem(cPixmap *Pixmap, const cChannel *Channel, int Index, bool Current);

--- a/displaychannel.h
+++ b/displaychannel.h
@@ -105,6 +105,9 @@ class cFlatDisplayChannel : public cFlatBaseRender, public cSkinDisplayChannel, 
         cFont *m_ZapFont {nullptr}, *m_ZapFontSml {nullptr};
         int m_ZapFontHeight {0}, m_ZapFontSmlHeight {0};
 
+        // DecorBorder for the channel info display at the bottom without the ChanInfoTopPixmap area
+        sDecorBorder m_ZapChanInfoBottomDecorBorder {0, 0, 0, 0, 0, 0, clrTransparent, clrTransparent, 0};
+
         int m_ZapColWidth {0};                 // Width of one list column
         int m_ZapItemHeightChan {0};           // Height of one channellist item (logo + 3 text lines)
         int m_ZapItemHeightGroup {0};          // Height of one grouplist item (one text line)
@@ -132,7 +135,7 @@ class cFlatDisplayChannel : public cFlatBaseRender, public cSkinDisplayChannel, 
         void ZapHideInfo();
         void ZapHideBaseElements();  // Hide the base OSD elements (top bar and channel info display at the bottom)
                                      // while a list view is shown
-        void ZapHideEpgImages();     // Hide the weather widget and the EPG image
+        void ZapHideInfoElements();  // Hide the weather widget, EPG image and channel name
         void ZapShowBaseElements();
         void ZapRunShowAnimation();
         void ZapDrawChannelItem(cPixmap *Pixmap, const cChannel *Channel, int Index, bool Current);

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -559,9 +559,10 @@ bool cFlatDisplayMenu::SetItemChannel(const cChannel *Channel, int Index, bool C
     int ImageTop {Top};
     int ImageBgWidth {static_cast<int>(m_FontHeight * 1.34f)};
     int ImageBgHeight {m_FontHeight};
-
     cImage *img {nullptr};
-    if (!IsGroup) {
+    if (IsGroup) {
+        img = ImgLoader.GetIcon("changroup", ImageBgWidth - 10, ImageBgHeight - 10);
+    } else {
         img = ImgLoader.GetLogoBg(ImageBgWidth, ImageBgHeight);  // Load 'logo_background'
         if (img) {
             ImageBgHeight = img->Height();
@@ -571,20 +572,18 @@ bool cFlatDisplayMenu::SetItemChannel(const cChannel *Channel, int Index, bool C
         }
         // Load named logo only for channels
         img = ImgLoader.GetLogo(Channel->Name(), ImageBgWidth - 4, ImageBgHeight - 4);
-    }
-
-    if (!img) {
-        const bool IsRadioChannel {((!Channel->Vpid()) && (Channel->Apid(0))) ? true : false};
-        if (IsRadioChannel) {
-            if (Current) img = ImgLoader.GetIcon("radio_cur", ImageBgWidth - 10, ImageBgHeight - 10);
-            if (!img) img = ImgLoader.GetIcon("radio", ImageBgWidth - 10, ImageBgHeight - 10);
-        } else if (IsGroup) {
-            img = ImgLoader.GetIcon("changroup", ImageBgWidth - 10, ImageBgHeight - 10);
-        } else {
-            if (Current) img = ImgLoader.GetIcon("tv_cur", ImageBgWidth - 10, ImageBgHeight - 10);
-            if (!img) img = ImgLoader.GetIcon("tv", ImageBgWidth - 10, ImageBgHeight - 10);
+        if (!img) {
+            const bool IsRadioChannel {((!Channel->Vpid()) && (Channel->Apid(0))) ? true : false};
+            if (IsRadioChannel) {
+                if (Current) img = ImgLoader.GetIcon("radio_cur", ImageBgWidth - 10, ImageBgHeight - 10);
+                if (!img) img = ImgLoader.GetIcon("radio", ImageBgWidth - 10, ImageBgHeight - 10);
+            } else {
+                if (Current) img = ImgLoader.GetIcon("tv_cur", ImageBgWidth - 10, ImageBgHeight - 10);
+                if (!img) img = ImgLoader.GetIcon("tv", ImageBgWidth - 10, ImageBgHeight - 10);
+            }
         }
     }
+
     if (img) {  // Draw the logo
         ImageTop = Top + (ImageBgHeight - img->Height()) / 2;
         ImageLeft = Left + (ImageBgWidth - img->Width()) / 2;
@@ -1145,7 +1144,9 @@ bool cFlatDisplayMenu::SetItemEvent(const cEvent *Event, int Index, bool Current
         int ImageLeft {Left};
         int ImageBgWidth {static_cast<int>(m_FontHeight * 1.34f)};
         int ImageBgHeight {m_FontHeight};
-        if (!IsGroup) {
+        if (IsGroup) {
+            img = ImgLoader.GetIcon("changroup", ImageBgWidth - 10, ImageBgHeight - 10);
+        } else {
             img = ImgLoader.GetLogoBg(ImageBgWidth, ImageBgHeight);  // Load 'logo_background'
             if (img) {
                 ImageBgWidth = img->Width();
@@ -1155,20 +1156,18 @@ bool cFlatDisplayMenu::SetItemEvent(const cEvent *Event, int Index, bool Current
             }
             // Load named logo only for channels
             img = ImgLoader.GetLogo(*ChannelName, ImageBgWidth - 4, ImageBgHeight - 4);
-        }
-
-        if (!img) {
-            const bool IsRadioChannel {((!Channel->Vpid()) && (Channel->Apid(0))) ? true : false};
-            if (IsRadioChannel) {
-                if (Current) img = ImgLoader.GetIcon("radio_cur", ImageBgWidth - 10, ImageBgHeight - 10);
-                if (!img) img = ImgLoader.GetIcon("radio", ImageBgWidth - 10, ImageBgHeight - 10);
-            } else if (IsGroup) {
-                img = ImgLoader.GetIcon("changroup", ImageBgWidth - 10, ImageBgHeight - 10);
-            } else {
-                if (Current) img = ImgLoader.GetIcon("tv_cur", ImageBgWidth - 10, ImageBgHeight - 10);
-                if (!img) img = ImgLoader.GetIcon("tv", ImageBgWidth - 10, ImageBgHeight - 10);
+            if (!img) {
+                const bool IsRadioChannel {((!Channel->Vpid()) && (Channel->Apid(0))) ? true : false};
+                if (IsRadioChannel) {
+                    if (Current) img = ImgLoader.GetIcon("radio_cur", ImageBgWidth - 10, ImageBgHeight - 10);
+                    if (!img) img = ImgLoader.GetIcon("radio", ImageBgWidth - 10, ImageBgHeight - 10);
+                } else {
+                    if (Current) img = ImgLoader.GetIcon("tv_cur", ImageBgWidth - 10, ImageBgHeight - 10);
+                    if (!img) img = ImgLoader.GetIcon("tv", ImageBgWidth - 10, ImageBgHeight - 10);
+                }
             }
         }
+
         if (img) {  // Draw the logo
             ImageLeft = Left + (ImageBgWidth - img->Width()) / 2;
             ImageTop = Top + (ImageBgHeight - img->Height()) / 2;
@@ -1771,7 +1770,7 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
             if (Config.MenuItemRecordingShowRecordingErrors) DrawRecordingErrorIcon(Recording, Left, Top, Current);
 #endif
 
-            Left += m_FontSmlHeight + m_MarginItem;
+            Left += m_FontHeight + m_MarginItem;
             if (IsEdited && ImgRecCut) {
                 const int ImageTop {Top + m_FontHeight - ImgRecCutHeight};  // 2/3 image height
                 MenuIconsPixmap->DrawImage(cPoint(Left, ImageTop), *ImgRecCut);
@@ -1796,11 +1795,12 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
             Top += m_FontHeight;
             const int DigitsMaxWidth {FontCache.GetStringWidth(m_FontSmlName, m_FontSmlHeight, "0000") +
                                       m_MarginItem};  // Use same width for recs and new recs
+            const int TotalPrefixWidth {FontCache.GetStringWidth(m_FontSmlName, m_FontSmlHeight, "Σ ")};
             // Total recordings in folder preceeded by Σ (Sigma) symbol
             Buffer = cString::sprintf("Σ %d", Total);
-            MenuPixmap->DrawText(cPoint(Left, Top), *Buffer, ColorFg, ColorBg, m_FontSml, DigitsMaxWidth,
-                                 m_FontSmlHeight, taRight);
-            Left += DigitsMaxWidth + m_MarginItem3;  // Add margin between total and new recordings
+            MenuPixmap->DrawText(cPoint(Left, Top), *Buffer, ColorFg, ColorBg, m_FontSml,
+                                 TotalPrefixWidth + DigitsMaxWidth, m_FontSmlHeight);
+            Left += TotalPrefixWidth + DigitsMaxWidth + m_MarginItem3;  // Add margin between total and new recordings
 
             Left = DrawRecordingIcon("recording_new", Left, Top, Current, true);  // Draw small new icon
 

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -1918,16 +1918,16 @@ int cFlatDisplayMenu::DrawContentHeadFskGenre(const cString &Fsk, std::vector<st
  * @param Title The title of the extra information block.
  * @param Text The text to display in the extra information block.
  * @param ComplexContent The ComplexContent to add the extra information to.
- * @param ContentTop The top position of the extra information block.
  * @param IsEvent true if this block is for an event, false if it is for a recording.
+ * @return The height of the extra information block without the text!
  */
-void cFlatDisplayMenu::AddExtraInfo(const char *Title, const cString &Text, cComplexContent &ComplexContent,
-                                    int &ContentTop, bool IsEvent) {
+int cFlatDisplayMenu::AddExtraInfo(const char *Title, const cString &Text, cComplexContent &ComplexContent,
+                                   bool IsEvent) {
     const tColor ColorMenuBg {Theme.Color(IsEvent ? clrMenuEventBg : clrMenuRecBg)};
     const tColor ColorMenuFontTitle {Theme.Color(IsEvent ? clrMenuEventFontTitle : clrMenuRecFontTitle)};
     const tColor ColorTitleLine {Theme.Color(IsEvent ? clrMenuEventTitleLine : clrMenuRecTitleLine)};
     const tColor ColorMenuFontInfo {Theme.Color(IsEvent ? clrMenuEventFontInfo : clrMenuRecFontInfo)};
-    ContentTop = ComplexContent.BottomContent() + m_FontHeight;
+    int ContentTop {ComplexContent.BottomContent() + m_FontHeight};
     ComplexContent.AddText(Title, false, cRect(m_MarginItem10, ContentTop, 0, 0), ColorMenuFontTitle, ColorMenuBg,
                            m_Font);
     ContentTop += m_FontHeight;
@@ -1937,6 +1937,8 @@ void cFlatDisplayMenu::AddExtraInfo(const char *Title, const cString &Text, cCom
         ComplexContent.AddText(*Text, true,
                                cRect(m_MarginItem, ContentTop, m_cWidth - m_MarginItem2, m_cHeight - m_MarginItem2),
                                ColorMenuFontInfo, ColorMenuBg, m_FontMedium);
+
+    return ContentTop;
 }
 
 void cFlatDisplayMenu::SetEvent(const cEvent *Event) {
@@ -2131,10 +2133,10 @@ void cFlatDisplayMenu::DrawEventInfo(const cEvent *Event) {
         }
 
         // Add movie information if available
-        if (MovieInfo[0] != '\0') AddExtraInfo(tr("Movie information"), MovieInfo, ComplexContent, ContentTop, true);
+        if (MovieInfo[0] != '\0') AddExtraInfo(tr("Movie information"), MovieInfo, ComplexContent, true);
 
         // Add series information if available
-        if (SeriesInfo[0] != '\0') AddExtraInfo(tr("Series information"), SeriesInfo, ComplexContent, ContentTop, true);
+        if (SeriesInfo[0] != '\0') AddExtraInfo(tr("Series information"), SeriesInfo, ComplexContent, true);
 #ifdef DEBUGEPGTIME
         dsyslog("flatPlus: DrawEventInfo() Epgtext time @ %ld ms", Timer.Elapsed());
 #endif
@@ -2148,11 +2150,11 @@ void cFlatDisplayMenu::DrawEventInfo(const cEvent *Event) {
 #endif
 
         // Add reruns information if available
-        if (Reruns[0] != '\0') AddExtraInfo(tr("Reruns"), Reruns, ComplexContent, ContentTop, true);
+        if (Reruns[0] != '\0') AddExtraInfo(tr("Reruns"), Reruns, ComplexContent, true);
 
         // Add video information if available
         if (TextAdditional[0] != '\0')
-            AddExtraInfo(tr("Video information"), TextAdditional, ComplexContent, ContentTop, true);
+            AddExtraInfo(tr("Video information"), TextAdditional, ComplexContent, true);
 
         Scrollable = ComplexContent.Scrollable(m_cHeight - m_MarginItem2);
 
@@ -2411,9 +2413,6 @@ void cFlatDisplayMenu::AddActors(cComplexContent &ComplexContent, std::vector<sA
     if (ShowMaxActors == 0) return;  // Do not show actors (-1 = Show all actors)
     if (ShowMaxActors > 0) NumActors = std::min(NumActors, ShowMaxActors);  // Limit to ShowMaxActors
 
-    int ContentTop {0};  // Calculated by 'AddExtraInfo()'
-    AddExtraInfo(tr("Actors"), "", ComplexContent, ContentTop, IsEvent);
-
     const tColor ColorMenuBg {Theme.Color(IsEvent ? clrMenuEventBg : clrMenuRecBg)};
     const tColor ColorMenuFontInfo {Theme.Color(IsEvent ? clrMenuEventFontInfo : clrMenuRecFontInfo)};
 
@@ -2426,7 +2425,7 @@ void cFlatDisplayMenu::AddActors(cComplexContent &ComplexContent, std::vector<sA
     const int PicLines {NumActors / ActorsPerLine + (NumActors % ActorsPerLine != 0)};  // Number of lines needed
     int ImgHeight {0}, MaxImgHeight {0};
     int x {m_MarginItem};
-    int y {ContentTop};
+    int y {AddExtraInfo(tr("Actors"), "", ComplexContent, IsEvent)};
     if (NumActors > 48) isyslog("flatPlus: First display of %d actor images will probably be slow!", NumActors);
 
     for (int row {0}; row < PicLines; ++row) {
@@ -2661,10 +2660,10 @@ void cFlatDisplayMenu::DrawRecordingInfo(const cRecording *Recording) {
         }
 
         // Add movie information if available
-        if (MovieInfo[0] != '\0') AddExtraInfo(tr("Movie information"), MovieInfo, ComplexContent, ContentTop);
+        if (MovieInfo[0] != '\0') AddExtraInfo(tr("Movie information"), MovieInfo, ComplexContent);
 
         // Add series information if available
-        if (SeriesInfo[0] != '\0') AddExtraInfo(tr("Series information"), SeriesInfo, ComplexContent, ContentTop);
+        if (SeriesInfo[0] != '\0') AddExtraInfo(tr("Series information"), SeriesInfo, ComplexContent);
 #ifdef DEBUGEPGTIME
         dsyslog("flatPlus: DrawRecordingInfo() Epgtext time @ %ld ms", Timer.Elapsed());
 #endif
@@ -2679,11 +2678,11 @@ void cFlatDisplayMenu::DrawRecordingInfo(const cRecording *Recording) {
 
         // Add recording information if available
         if (RecAdditional[0] != '\0')
-            AddExtraInfo(tr("Recording information"), RecAdditional, ComplexContent, ContentTop);
+            AddExtraInfo(tr("Recording information"), RecAdditional, ComplexContent);
 
         // Add video information if available
         if (TextAdditional[0] != '\0')
-            AddExtraInfo(tr("Video information"), TextAdditional, ComplexContent, ContentTop);
+            AddExtraInfo(tr("Video information"), TextAdditional, ComplexContent);
 
         Scrollable = ComplexContent.Scrollable(m_cHeight - m_MarginItem2);
 

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -98,7 +98,7 @@ cFlatDisplayMenu::cFlatDisplayMenu() {
     static constexpr std::size_t kDefaultItemBorderSize {64};
     ItemsBorder.reserve(kDefaultItemBorderSize);
 #ifdef DEBUGFUNCSCALL
-    if (Timer.Elapsed() > 0) dsyslog("   Done in %ld ms", Timer.Elapsed());
+    if (Timer.Elapsed() > 0) dsyslog("   cFlatDisplayMenu() Done in %ld ms", Timer.Elapsed());
 #endif
 }
 
@@ -524,7 +524,7 @@ bool cFlatDisplayMenu::SetItemChannel(const cChannel *Channel, int Index, bool C
     int Height {m_FontHeight};
     m_MenuItemWidth = m_MenuWidth - Config.decorBorderMenuItemSize * 2;
     if (MenuChannelViewShort) {  // flatPlus short, flatPlus short + EPG
-        Height = m_FontHeight + m_FontSmlHeight + m_MarginItem + Config.decorProgressMenuItemSize;
+        Height += m_FontSmlHeight + m_MarginItem + Config.decorProgressMenuItemSize;
         m_MenuItemWidth /= 2;
     }
 
@@ -609,10 +609,9 @@ bool cFlatDisplayMenu::SetItemChannel(const cChannel *Channel, int Index, bool C
             }
         }
     }
-    if (WithProvider)
-        Buffer = cString::sprintf("%s - %s", Channel->Provider(), Channel->Name());
-    else
-        Buffer = Channel->Name();
+    (WithProvider)  // Append provider name
+        ? Buffer = cString::sprintf("%s (%s)", Channel->Name(), Channel->Provider())
+        : Buffer = Channel->Name();
 
     const int LeftName {Left};
     if (Config.MenuChannelView == 1) {  // flatPlus long
@@ -862,7 +861,7 @@ bool cFlatDisplayMenu::SetItemTimer(const cTimer *Timer, int Index, bool Current
     int Height {m_FontHeight};
     m_MenuItemWidth = m_MenuWidth - Config.decorBorderMenuItemSize * 2;
     if (Config.MenuTimerView == 2 || Config.MenuTimerView == 3) {  // flatPlus short, flatPlus short + EPG
-        Height = m_FontHeight + m_FontSmlHeight + m_MarginItem;
+        Height += m_FontSmlHeight + m_MarginItem;
         m_MenuItemWidth /= 2;
     }
 
@@ -1096,7 +1095,7 @@ bool cFlatDisplayMenu::SetItemEvent(const cEvent *Event, int Index, bool Current
     int Height {m_FontHeight};
     m_MenuItemWidth = m_MenuWidth - Config.decorBorderMenuItemSize * 2;
     if (MenuEventViewShort) {  // flatPlus short. flatPlus short + EPG
-        Height = m_FontHeight + m_FontSmlHeight + m_MarginItem2 + Config.decorProgressMenuItemSize / 2;
+        Height += m_FontSmlHeight + m_MarginItem2 + Config.decorProgressMenuItemSize / 2;
         m_MenuItemWidth *= 0.6;
     }
 
@@ -2927,19 +2926,29 @@ cString cFlatDisplayMenu::MainMenuText(const cString &Text) const {
     return found ? skipspace(text.substr(i).data()) : text.data();
 }
 
+
+/**
+ * Returns the icon name for a menu entry.
+ *
+ * The function resolves standard VDR menu entries to their corresponding icon names,
+ * checks plugin-provided main menu entries, and falls back to a generic icon for
+ * unknown entries. The icon names are stored in a static cache for faster access.
+ *
+ * @param element The menu entry name to resolve.
+ * @return The icon name associated with the menu entry.
+ */
 cString cFlatDisplayMenu::GetIconName(const cString &element) const {
 #ifdef DEBUGFUNCSCALL
     dsyslog("flatPlus: cFlatDisplayMenu::GetIconName() '%s'", *element);
 #endif
+
+    static constexpr const char *items[] {"Schedule", "Channels", "Timers", "Recordings", "Setup",
 #if VDRVERSNUM >= 20708
-    static constexpr const char *items[] {
-        "Schedule", "Channels", "Timers", "Recordings", "Setup",  "Button$Commands", "OSD",     "EPG",
-        "DVB",      "LNB",      "CAM",    "Recording",  "Replay", "Miscellaneous",   "Plugins", "Restart"};
+        "Button$Commands",
 #else
-    static constexpr const char *items[] {"Schedule", "Channels",      "Timers",  "Recordings", "Setup", "Commands",
-                                          "OSD",      "EPG",           "DVB",     "LNB",        "CAM",   "Recording",
-                                          "Replay",   "Miscellaneous", "Plugins", "Restart"};
+        "Commands",
 #endif
+        "OSD", "EPG", "DVB", "LNB", "CAM", "Recording", "Replay", "Miscellaneous", "Plugins", "Restart"};
 
     // Static cache to store the names of main menu entries
     static std::unordered_map<std::string, cString> cache;
@@ -3457,10 +3466,9 @@ int cFlatDisplayMenu::DrawMainMenuWidgetDVBDevices(int wLeft, int wWidth, int Co
     int DeviceLiveTV {-1};
     cDevice *PrimaryDevice {cDevice::PrimaryDevice()};
     if (PrimaryDevice) {
-        if (!PrimaryDevice->Replaying() || PrimaryDevice->Transferring())
-            DeviceLiveTV = cDevice::ActualDevice()->DeviceNumber();
-        else
-            DeviceLiveTV = PrimaryDevice->DeviceNumber();
+        (!PrimaryDevice->Replaying() || PrimaryDevice->Transferring())
+            ? DeviceLiveTV = cDevice::ActualDevice()->DeviceNumber()
+            : DeviceLiveTV = PrimaryDevice->DeviceNumber();
     }
 
     // Find all recording devices and set RecDevices[] to true for these devices
@@ -3499,10 +3507,9 @@ int cFlatDisplayMenu::DrawMainMenuWidgetDVBDevices(int wLeft, int wWidth, int Co
         StrDevice = "";  // Reset string
 
         const cChannel *channel {device->GetCurrentlyTunedTransponder()};
-        if (channel && channel->Number() > 0)
-            ChannelName = channel->Name();
-        else
-            ChannelName = tr("Unknown");
+        (channel && channel->Number() > 0)
+            ? ChannelName = channel->Name()
+            : ChannelName = tr("Unknown");
 
         if (i == DeviceLiveTV) {
             StrDevice.Append(cString::sprintf("%s (%s)", tr("LiveTV"), *ChannelName));

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -771,13 +771,7 @@ void cFlatDisplayMenu::DrawItemExtraEvent(const cEvent *Event, const cString Emp
                 Text.Append(cString::sprintf("\n%s: %s", tr("FSK"), *Event->GetParentalRatingString()));
 
             const cComponents *Components {Event->Components()};
-            if (Components) {
-                cString Audio {""}, Subtitle {""};
-                InsertComponents(Components, Text, Audio, Subtitle, true);  // Get info for audio/video and subtitle
-
-                // if (Audio[0] != '\0') Text.Append(cString::sprintf("\n%s: %s", tr("Audio"), *Audio));
-                // if (Subtitle[0] != '\0') Text.Append(cString::sprintf("\n%s: %s", tr("Subtitle"), *Subtitle));
-            }  // if Components
+            if (Components) InsertComponents(Components, Text, true);  // Get info for audio/video and subtitle
         }  // EpgAdditionalInfoShow
     } else {
         Text.Append(*EmptyText);
@@ -2003,19 +1997,7 @@ void cFlatDisplayMenu::DrawEventInfo(const cEvent *Event) {
         }
 
         const cComponents *Components {Event->Components()};
-        if (Components) {
-            cString Audio {""}, Subtitle {""};
-            InsertComponents(Components, TextAdditional, Audio, Subtitle);  // Get info for audio/video and subtitle
-
-            /* if (Audio[0] != '\0') {
-                if (TextAdditional[0] != '\0') TextAdditional.Append('\n');
-                TextAdditional.Append(cString::sprintf("%s: %s", tr("Audio"), *Audio));
-            }
-            if (Subtitle[0] != '\0') {
-                if (TextAdditional[0] != '\0') TextAdditional.Append('\n');
-                TextAdditional.Append(cString::sprintf("\n%s: %s", tr("Subtitle"), *Subtitle));
-            } */
-        }  // if Components
+        if (Components) InsertComponents(Components, TextAdditional);  // Get info for audio/video and subtitle
     }  // EpgAdditionalInfoShow
 
     // Draw FSK and genre icons and get the left position for the title
@@ -2299,13 +2281,8 @@ void cFlatDisplayMenu::DrawItemExtraRecording(const cRecording *Recording, const
 #endif
 
             const cComponents *Components {RecInfo->Components()};
-            if (Components) {
-                cString Audio {""}, Subtitle {""};
-                InsertComponents(Components, Text, Audio, Subtitle, true);  // Get info for audio/video and subtitle
+            if (Components) InsertComponents(Components, Text, true);  // Get info for audio/video and subtitle
 
-                // if (Audio[0] != '\0') Text.Append(cString::sprintf("\n%s: %s", tr("Audio"), *Audio));
-                // if (Subtitle[0] != '\0') Text.Append(cString::sprintf("\n%s: %s", tr("Subtitle"), *Subtitle));
-            }
             if (RecInfo->Aux()) InsertAuxInfos(RecInfo, Text, true);  // Insert aux infos with info line
         }  // if Config.RecordingAdditionalInfoShow
     } else {
@@ -2563,19 +2540,8 @@ void cFlatDisplayMenu::DrawRecordingInfo(const cRecording *Recording) {
 #endif
 
         const cComponents *Components {RecInfo->Components()};
-        if (Components) {
-            cString Audio {""}, Subtitle {""};
-            InsertComponents(Components, TextAdditional, Audio, Subtitle);  // Get info for audio/video and subtitle
+        if (Components) InsertComponents(Components, TextAdditional);  // Get info for audio/video and subtitle
 
-            /* if (Audio[0] != '\0') {
-                if (TextAdditional[0] != '\0') TextAdditional.Append('\n');
-                TextAdditional.Append(cString::sprintf("%s: %s", tr("Audio"), *Audio));
-            }
-            if (Subtitle[0] != '\0') {
-                if (TextAdditional[0] != '\0') TextAdditional.Append('\n');
-                TextAdditional.Append(cString::sprintf("\n%s: %s", tr("Subtitle"), *Subtitle));
-            } */
-        }
         if (RecInfo->Aux()) InsertAuxInfos(RecInfo, RecAdditional, false);  // Insert aux infos without info line
     }  // if Config.RecordingAdditionalInfoShow
 

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -2030,7 +2030,7 @@ void cFlatDisplayMenu::DrawEventInfo(const cEvent *Event) {
         // Lent from nopacity
         cPlugin *pEpgSearchPlugin {cPluginSkinFlatPlus::GetEpgSearchPlugin()};
         cString SearchTerm {Event->Title()};  // Search term
-        if (pEpgSearchPlugin && !isempty(Event->Title())) {
+        if (pEpgSearchPlugin && !isempty(SearchTerm)) {
             Epgsearch_searchresults_v1_0 data {
                 .query = const_cast<char *>(static_cast<const char *>(SearchTerm)),
                 .mode = 0,               // Search mode (0=phrase, 1=and, 2=or, 3=regular expression)

--- a/displaymenu.c
+++ b/displaymenu.c
@@ -1755,8 +1755,8 @@ bool cFlatDisplayMenu::SetItemRecording(const cRecording *Recording, int Index, 
                 MenuPixmap->DrawText(cPoint(Left, Top), *RecName, ColorFg, ColorBg, m_Font,
                                      m_MenuItemWidth - Left - m_MarginItem - ImagesWidth);
             }
-
-            Buffer = cString::sprintf("%s  %s  Σ %s ", *ShortDateString(Recording->Start()),
+            // Draw recording date, time and length (00.00.00 00:00 Σ 00:00)
+            Buffer = cString::sprintf("%s %s Σ %s ", *ShortDateString(Recording->Start()),
                                       *TimeString(Recording->Start()), *Length);
             Top += m_FontHeight;
             MenuPixmap->DrawText(cPoint(Left, Top), *Buffer, ColorFg, ColorBg, m_FontSml,
@@ -2172,9 +2172,9 @@ void cFlatDisplayMenu::DrawEventInfo(const cEvent *Event) {
 
     PixmapClear(ContentHeadPixmap);
     ContentHeadPixmap->DrawRectangle(cRect(0, 0, m_MenuWidth, m_chHeight), Theme.Color(clrScrollbarBg));
-
+    // Draw event time, title and short text (00.00.0000 00:00–00:00)
     const cString StrTime {
-        cString::sprintf("%s  %s–%s", *Event->GetDateString(), *Event->GetTimeString(), *Event->GetEndTimeString())};
+        cString::sprintf("%s %s–%s", *Event->GetDateString(), *Event->GetTimeString(), *Event->GetEndTimeString())};
 
     const cString Title {Event->Title()};
     const cString ShortText {(Event->ShortText()) ? Event->ShortText() : ""};  // No short text. Show empty string
@@ -2703,8 +2703,8 @@ void cFlatDisplayMenu::DrawRecordingInfo(const cRecording *Recording) {
 
     PixmapClear(ContentHeadPixmap);
     ContentHeadPixmap->DrawRectangle(cRect(0, 0, m_MenuWidth, m_chHeight), Theme.Color(clrScrollbarBg));
-
-    const cString StrTime {cString::sprintf("%s  %s  %s", *DateString(Recording->Start()),
+    // Date/Time (00.00.0000 00:00  Channel name)
+    const cString StrTime {cString::sprintf("%s %s  %s", *DateString(Recording->Start()),
                                             *TimeString(Recording->Start()),
                                             (RecInfo->ChannelName()) ? RecInfo->ChannelName() : "")};
 

--- a/displaymenu.h
+++ b/displaymenu.h
@@ -140,9 +140,8 @@ class cFlatDisplayMenu : public cFlatBaseRender, public cSkinDisplayMenu {
     void InsertGenreInfo(const cEvent *Event, cString &Text, std::vector<std::string> &GenreIcons) const;  // NOLINT
     void InsertTSErrors(const cRecordingInfo *RecInfo, cString &Text) const;                               // NOLINT
 
-    void AddExtraInfo(const char *Title, const cString &Text, cComplexContent &ComplexContent,             // NOLINT
-                      int &ContentTop,        // NOLINT
-                      bool IsEvent = false);  // NOLINT
+    int AddExtraInfo(const char *Title, const cString &Text, cComplexContent &ComplexContent,             // NOLINT
+                     bool IsEvent = false);  // NOLINT
 
     time_t GetLastRecTimeFromFolder(const cRecording *Recording, int Level) const;
 

--- a/displayreplay.c
+++ b/displayreplay.c
@@ -419,18 +419,18 @@ void cFlatDisplayReplay::UpdateInfo() {
         // left += TimeShiftWidth + m_MarginItem;
     }
 
-    // Check if m_Recording is null and return if so
-    if (!m_Recording) return;
+    // Without a recording (media player replay) only the total length can be drawn
+    if (!m_Recording && isempty(*m_Total)) return;
 
     int FramesAfterEdit {-1};
     int CurrentFramesAfterEdit {-1};
-    const int NumFrames {m_Recording->NumFrames()};  // Total frames in recording
-    if (NumFrames <= 0) {
+    const int NumFrames {m_Recording ? m_Recording->NumFrames() : 0};  // Total frames in recording
+    if (m_Recording && NumFrames <= 0) {
         esyslog("flatPlus: cFlatDisplayReplay::UpdateInfo() Invalid NumFrames: %d", NumFrames);
         return;
     }
 
-    if (marks && m_Recording->HasMarks()) {
+    if (m_Recording && marks && m_Recording->HasMarks()) {
 #if APIVERSNUM >= 20608
         FramesAfterEdit = marks->GetFrameAfterEdit(NumFrames, NumFrames);
         if (FramesAfterEdit >= 0) CurrentFramesAfterEdit = marks->GetFrameAfterEdit(m_CurrentFrame, NumFrames);
@@ -440,8 +440,8 @@ void cFlatDisplayReplay::UpdateInfo() {
 #endif
     }
 
-    const double FramesPerSecond {m_Recording->FramesPerSecond()};
-    if (FramesPerSecond <= 0.0) {  // Avoid DIV/0
+    const double FramesPerSecond {m_Recording ? m_Recording->FramesPerSecond() : 0.0};
+    if (m_Recording && FramesPerSecond <= 0.0) {  // Avoid DIV/0
         esyslog("flatPlus: cFlatDisplayReplay::UpdateInfo() Invalid FramesPerSecond: %.2f", FramesPerSecond);
         return;
     }
@@ -579,6 +579,8 @@ void cFlatDisplayReplay::UpdateInfo() {
                                   m_Font, TotalWidth, m_FontHeight);
         }
     }  // HasMarks
+
+    if (!m_Recording) return;  // End time and poster need the recording
 
     //* Draw end time of recording with symbol for cutted end time (2. line)
     const time_t now {time(0)};  // Fix 'jumping' end times - Update once per minute or 'm_Current' changed

--- a/displayreplay.c
+++ b/displayreplay.c
@@ -107,11 +107,11 @@ void cFlatDisplayReplay::SetRecording(const cRecording *Recording) {
     }
 
     cString InfoText {""};
-    if (isempty(RecInfo->ShortText())) {  // No short text. Show date and time instead
-        InfoText = cString::sprintf("%s  %s", *ShortDateString(Recording->Start()), *TimeString(Recording->Start()));
+    if (isempty(RecInfo->ShortText())) {  // No short text. Show date and time instead (00.00.00 00:00)
+        InfoText = cString::sprintf("%s %s", *ShortDateString(Recording->Start()), *TimeString(Recording->Start()));
     } else {
         if (Config.PlaybackShowRecordingDate)  // Date  Time - ShortText
-            InfoText = cString::sprintf("%s  %s - %s", *ShortDateString(Recording->Start()),
+            InfoText = cString::sprintf("%s %s - %s", *ShortDateString(Recording->Start()),
                                         *TimeString(Recording->Start()), RecInfo->ShortText());
         else
             InfoText = RecInfo->ShortText();

--- a/displayreplay.c
+++ b/displayreplay.c
@@ -157,7 +157,7 @@ void cFlatDisplayReplay::SetRecording(const cRecording *Recording) {
 
 #if APIVERSNUM >= 20505
     if (Config.PlaybackShowRecordingErrors) {  // Separate config option
-        const cString RecErrIcon = cString::sprintf("%s_replay", *GetRecordingErrorIcon(RecInfo->Errors()));
+        const cString RecErrIcon {cString::sprintf("%s_replay", *GetRecordingErrorIcon(RecInfo->Errors()))};
 
         img = ImgLoader.GetIcon(*RecErrIcon, kIconMaxSize, m_FontSmlHeight);  // Small image
         if (img) {
@@ -219,7 +219,7 @@ void cFlatDisplayReplay::SetMode(bool Play, bool Forward, int Speed) {
     }
 
     int left {0};
-    const int FontWidth00 {FontCache.GetStringWidth(m_FontName, m_FontHeight, "00")};  // Width of '00'
+    const int ExtraMargin {FontCache.GetStringWidth(m_FontName, m_FontHeight, "0") * 2};  // Width of two '0'
     const int EffectiveOsdWidth {m_OsdWidth - Config.decorBorderReplaySize * 2};
     if (Setup.ShowReplayMode) {
         left = (EffectiveOsdWidth - (m_FontHeight * 4 + m_MarginItem3)) / 2;
@@ -227,15 +227,15 @@ void cFlatDisplayReplay::SetMode(bool Play, bool Forward, int Speed) {
         if (m_ModeOnly) PixmapClear(LabelPixmap);
 
         // PixmapClear(IconsPixmap);  //* Moved to SetRecording
-        LabelPixmap->DrawRectangle(cRect(left - FontWidth00 - m_MarginItem, 0,
-                                         m_FontHeight * 4 + m_MarginItem * 6 + FontWidth00 * 2, m_FontHeight),
+        LabelPixmap->DrawRectangle(cRect(left - ExtraMargin - m_MarginItem, 0,
+                                         m_FontHeight * 4 + m_MarginItem * 6 + ExtraMargin * 2, m_FontHeight),
                                    Theme.Color(clrReplayBg));
 
         cString rewind {"rewind"}, pause {"pause"}, play {"play"}, forward {"forward"};
         if (Speed == -1) {  // Replay or pause
             (Play) ? play = "play_sel" : pause = "pause_sel";
         } else {
-            const cString speed = itoa(Speed);
+            const cString speed {itoa(Speed)};
             if (Forward) {
                 forward = "forward_sel";
                 LabelPixmap->DrawText(cPoint(left + m_FontHeight * 4 + m_MarginItem * 4, 0), speed,
@@ -272,9 +272,9 @@ void cFlatDisplayReplay::SetMode(bool Play, bool Forward, int Speed) {
         DecorBorderDraw(ib);
     } else {
         if (m_ModeOnly) {
-            const sDecorBorder ib {left - FontWidth00 - m_MarginItem + Config.decorBorderReplaySize,
+            const sDecorBorder ib {left - ExtraMargin - m_MarginItem + Config.decorBorderReplaySize,
                                    m_OsdHeight - m_LabelHeight - Config.decorBorderReplaySize,
-                                   m_FontHeight * 4 + m_MarginItem * 6 + FontWidth00 * 2,
+                                   m_FontHeight * 4 + m_MarginItem * 6 + ExtraMargin * 2,
                                    m_FontHeight,
                                    Config.decorBorderReplaySize,
                                    Config.decorBorderReplayType,

--- a/displayreplay.c
+++ b/displayreplay.c
@@ -322,15 +322,15 @@ void cFlatDisplayReplay::SetCurrent(const char *Current) {
 #endif
     if (m_ModeOnly) return;
 
-    m_Current = Current;
+    m_Current = Current ? Current : "";  // Never store a nullptr, it is dereferenced unchecked below
     UpdateInfo();
 }
 
 void cFlatDisplayReplay::SetTotal(const char *Total) {
     if (m_ModeOnly) return;
 
-    m_Total = Total;
-    if (m_Current[0] != '\0')  // Do not call 'UpdateInfo()' when 'm_Current' is not set
+    m_Total = Total ? Total : "";
+    if (!isempty(*m_Current))  // Do not call 'UpdateInfo()' when 'm_Current' is not set
         UpdateInfo();
 }
 

--- a/displayreplay.c
+++ b/displayreplay.c
@@ -623,21 +623,19 @@ void cFlatDisplayReplay::UpdateInfo() {
     }  // Config.PlaybackShowEndTime
 
     //* Draw Banner/Poster (Update only every 5 seconds)
-    if (m_LastPosterBannerUpdate + 5 < now) {
+    if (Config.TVScraperReplayInfoShowPoster && m_LastPosterBannerUpdate + 5 < now) {
         m_LastPosterBannerUpdate = now;
         cString MediaPath {""};
         cSize MediaSize {0, 0};
-        if (Config.TVScraperReplayInfoShowPoster) {
-            GetScraperMediaTypeSize(MediaPath, MediaSize, nullptr, m_Recording);
-            if (MediaPath[0] == '\0' && Config.TVScraperSearchLocalPosters) {  // Prio for tvscraper poster
-                const cString RecPath {m_Recording->FileName()};
-                if (ImgLoader.SearchRecordingPoster(RecPath, MediaPath)) {
-                    img = ImgLoader.GetFile(*MediaPath, m_TVSRect.Width(), m_TVSRect.Height());
-                    if (img)
-                        MediaSize.Set(img->Width(), img->Height());  // Get values for SetMediaSize()
-                    else
-                        MediaPath = "";  // Just in case image can not be loaded
-                }
+        GetScraperMediaTypeSize(MediaPath, MediaSize, nullptr, m_Recording);
+        if (MediaPath[0] == '\0' && Config.TVScraperSearchLocalPosters) {  // Prio for tvscraper poster
+            const cString RecPath {m_Recording->FileName()};
+            if (ImgLoader.SearchRecordingPoster(RecPath, MediaPath)) {
+                img = ImgLoader.GetFile(*MediaPath, m_TVSRect.Width(), m_TVSRect.Height());
+                if (img)
+                    MediaSize.Set(img->Width(), img->Height());  // Get values for SetMediaSize()
+                else
+                    MediaPath = "";  // Just in case image can not be loaded
             }
         }
 
@@ -664,7 +662,7 @@ void cFlatDisplayReplay::UpdateInfo() {
                 DecorBorderDraw(ib);
             }
         }
-    }  // m_LastPosterBannerUpdate
+    }  // Config.TVScraperReplayInfoShowPoster && m_LastPosterBannerUpdate
 }
 
 void cFlatDisplayReplay::SetJump(const char *Jump) {

--- a/flat.c
+++ b/flat.c
@@ -471,7 +471,8 @@ void InsertComponents(const cComponents *Components, cString &Text, bool NewLine
     }  // for
 
     if (NewLine) Text.Append('\n');
-    Text.Append(ossVideo.str().c_str());
+
+    if (!ossVideo.str().empty()) Text.Append(ossVideo.str().c_str());
 
     if (!ossAudio.str().empty()) Text.Append(cString::sprintf("\n%s: %s", tr("Audio"), ossAudio.str().c_str()));
 

--- a/flat.c
+++ b/flat.c
@@ -422,8 +422,7 @@ void SetMediaSize(const cSize &ContentSize, cSize &MediaSize, float MediaSizeUse
 #endif
 }
 
-void InsertComponents(const cComponents *Components, cString &Text, cString &Audio, cString &Subtitle,  // NOLINT
-                      bool NewLine) {
+void InsertComponents(const cComponents *Components, cString &Text, bool NewLine) {  // NOLINT
     std::ostringstream ossVideo {""}, ossAudio {""}, ossSubtitle {""};
     const int NumComponents {Components->NumComponents()};
     for (int i {0}; i < NumComponents; ++i) {
@@ -475,11 +474,9 @@ void InsertComponents(const cComponents *Components, cString &Text, cString &Aud
     Text.Append(ossVideo.str().c_str());
 
     if (!ossAudio.str().empty()) Text.Append(cString::sprintf("\n%s: %s", tr("Audio"), ossAudio.str().c_str()));
-    // Audio.Append(ossAudio.str().c_str());
 
     if (!ossSubtitle.str().empty())
         Text.Append(cString::sprintf("\n%s: %s", tr("Subtitle"), ossSubtitle.str().c_str()));
-    // Subtitle.Append(ossSubtitle.str().c_str());
 }
 
 void InsertAuxInfos(const cRecordingInfo *RecInfo, cString &Text, bool InfoLine) {  // NOLINT

--- a/flat.h
+++ b/flat.h
@@ -295,8 +295,7 @@ std::string_view rtrim(std::string_view str);
 std::string_view trim(std::string_view str); */
 
 void SetMediaSize(const cSize &ContentSize, cSize &MediaSize, float MediaSizeUser);  // NOLINT in/out
-void InsertComponents(const cComponents *Components, cString &Text, cString &Audio,        // NOLINT
-                      cString &Subtitle, bool NewLine = false);                            // NOLINT
+void InsertComponents(const cComponents *Components, cString &Text, bool NewLine = false);  // NOLINT
 void InsertAuxInfos(const cRecordingInfo *RecInfo, cString &Text, bool InfoLine = false);  // NOLINT
 int GetEpgsearchConflicts();
 int GetFrameAfterEdit(const cMarks *marks = nullptr, int Frame = 0, int LastFrame = 0);

--- a/imagecache.c
+++ b/imagecache.c
@@ -184,18 +184,12 @@ bool cImageCache::RemoveFromCache(const cString &Name) {
 void cImageCache::PreLoadImage() {
     cTimeMs Timer;
 
-    cFlatDisplayChannel DisplayChannel(false);
+    // Only one OSD may be open at a time, so scope each object to close its OSD before the next one
     // Called first. Also used to determine if 'logo_background' should be loaded from logo path or theme path
-    DisplayChannel.PreLoadImages();
-
-    cFlatDisplayMenu Display_Menu;
-    Display_Menu.PreLoadImages();
-
-    cFlatDisplayReplay DisplayReplay(false);
-    DisplayReplay.PreLoadImages();
-
-    cFlatDisplayVolume DisplayVolume;
-    DisplayVolume.PreLoadImages();
+    { cFlatDisplayChannel DisplayChannel(false); DisplayChannel.PreLoadImages(); }
+    { cFlatDisplayMenu Display_Menu; Display_Menu.PreLoadImages(); }
+    { cFlatDisplayReplay DisplayReplay(false); DisplayReplay.PreLoadImages(); }
+    { cFlatDisplayVolume DisplayVolume; DisplayVolume.PreLoadImages(); }
 
     m_InsertIndexBase = GetCacheCount();
     m_InsertIconIndexBase = GetIconCacheCount();

--- a/imagecache.h
+++ b/imagecache.h
@@ -14,6 +14,7 @@
 #include <memory>  // For std::unique_ptr
 #include <unordered_map>
 #include <vector>  // For std::vector
+#include <string_view>
 
 static constexpr std::size_t kMaxImageCache {1024};  // Image cache including two times 'kLogoPreCache'
 static constexpr std::size_t kMaxIconCache {512};    // Icon cache (Skin icons)

--- a/imageloader.c
+++ b/imageloader.c
@@ -35,7 +35,7 @@ cImageLoader::~cImageLoader() {}
  * @param height The desired height of the logo.
  * @return The loaded and scaled logo, or nullptr if the logo could not be loaded.
  */
-cImage* cImageLoader::GetLogo(const char *logo, int width, int height) {
+cImage* cImageLoader::GetLogo(const char *logo, int width, int height, bool Quiet) {
     if (width < 0 || height < 0 || isempty(logo)) return nullptr;
 
 #ifdef DEBUGIMAGELOADTIME
@@ -70,7 +70,7 @@ cImage* cImageLoader::GetLogo(const char *logo, int width, int height) {
 
         success = LoadImage(*File);  // Try to load image from disk
         if (!success) {              // Image not found on disk
-            if (i == 2)              // Third try and not found
+            if (i == 2 && !Quiet)    // Third try and not found
                 isyslog("flatPlus: cImageLoader::GetLogo() %s/%s.%s could not be loaded", *Config.LogoPath, logo,
                         *m_LogoExtension);
             continue;

--- a/imageloader.h
+++ b/imageloader.h
@@ -29,7 +29,7 @@ class cImageLoader : public cImageMagickWrapper {
     cImageLoader();
     ~cImageLoader();
 
-    cImage* GetLogo(const char *logo, int width, int height);
+    cImage* GetLogo(const char *logo, int width, int height, bool Quiet = false);  // 'Quiet': Do not log a miss
     cImage* GetIcon(const char *cIcon, int width, int height);
     cImage* GetFile(const char *cFile, int width, int height);
     cImage* GetLogoBg(int Width, int Height);  // Load 'logo_background'

--- a/imagescaler.c
+++ b/imagescaler.c
@@ -201,11 +201,11 @@ inline static unsigned int shift_clamp(int x) {
  * @param pixel The TmpPixel to pack.
  * @return A 32-bit unsigned integer representing the packed pixel.
  */
-inline unsigned int ImageScaler::PackPixel(const TmpPixel &pixel) {
-    return shift_clamp(pixel[0]) |
-           (shift_clamp(pixel[1]) << 8) |
-           (shift_clamp(pixel[2]) << 16) |
-           (shift_clamp(pixel[3]) << 24);
+inline unsigned int ImageScaler::PackPixel(int c0, int c1, int c2, int c3) {
+    return shift_clamp(c0) |
+           (shift_clamp(c1) << 8) |
+           (shift_clamp(c2) << 16) |
+           (shift_clamp(c3) << 24);
 }
 
 /**
@@ -242,21 +242,36 @@ void ImageScaler::NextSourceLine() {
 
         // Unroll 4 pixels at a time for speed
         for (; i + 3 < m_dst_width; i += 4) {
-            // Calculate four pixels at a time
-            const TmpPixel t0(src[0] * h0 + src[1] * h1 + src[2] * h2 + src[3] * h3);
-            const TmpPixel t1(src[4] * h0 + src[5] * h1 + src[6] * h2 + src[7] * h3);
-            const TmpPixel t2(src[8] * h0 + src[9] * h1 + src[10] * h2 + src[11] * h3);
-            const TmpPixel t3(src[12] * h0 + src[13] * h1 + src[14] * h2 + src[15] * h3);
-            dst[i] = PackPixel(t0);
-            dst[i+1] = PackPixel(t1);
-            dst[i+2] = PackPixel(t2);
-            dst[i+3] = PackPixel(t3);
+            // Calculate four pixels at a time using direct component math to avoid temporary objects.
+            const int c00 = src[0][0] * h0 + src[1][0] * h1 + src[2][0] * h2 + src[3][0] * h3;
+            const int c01 = src[0][1] * h0 + src[1][1] * h1 + src[2][1] * h2 + src[3][1] * h3;
+            const int c02 = src[0][2] * h0 + src[1][2] * h1 + src[2][2] * h2 + src[3][2] * h3;
+            const int c03 = src[0][3] * h0 + src[1][3] * h1 + src[2][3] * h2 + src[3][3] * h3;
+            const int c10 = src[4][0] * h0 + src[5][0] * h1 + src[6][0] * h2 + src[7][0] * h3;
+            const int c11 = src[4][1] * h0 + src[5][1] * h1 + src[6][1] * h2 + src[7][1] * h3;
+            const int c12 = src[4][2] * h0 + src[5][2] * h1 + src[6][2] * h2 + src[7][2] * h3;
+            const int c13 = src[4][3] * h0 + src[5][3] * h1 + src[6][3] * h2 + src[7][3] * h3;
+            const int c20 = src[8][0] * h0 + src[9][0] * h1 + src[10][0] * h2 + src[11][0] * h3;
+            const int c21 = src[8][1] * h0 + src[9][1] * h1 + src[10][1] * h2 + src[11][1] * h3;
+            const int c22 = src[8][2] * h0 + src[9][2] * h1 + src[10][2] * h2 + src[11][2] * h3;
+            const int c23 = src[8][3] * h0 + src[9][3] * h1 + src[10][3] * h2 + src[11][3] * h3;
+            const int c30 = src[12][0] * h0 + src[13][0] * h1 + src[14][0] * h2 + src[15][0] * h3;
+            const int c31 = src[12][1] * h0 + src[13][1] * h1 + src[14][1] * h2 + src[15][1] * h3;
+            const int c32 = src[12][2] * h0 + src[13][2] * h1 + src[14][2] * h2 + src[15][2] * h3;
+            const int c33 = src[12][3] * h0 + src[13][3] * h1 + src[14][3] * h2 + src[15][3] * h3;
+            dst[i] = PackPixel(c00, c01, c02, c03);
+            dst[i+1] = PackPixel(c10, c11, c12, c13);
+            dst[i+2] = PackPixel(c20, c21, c22, c23);
+            dst[i+3] = PackPixel(c30, c31, c32, c33);
             src += 16;
         }
         // If num pixels is not a multiple of 4, finish the remaining ones
         for (; i < m_dst_width; ++i) {
-            const TmpPixel t(src[0] * h0 + src[1] * h1 + src[2] * h2 + src[3] * h3);
-            dst[i] = PackPixel(t);
+            const int c0 = src[0][0] * h0 + src[1][0] * h1 + src[2][0] * h2 + src[3][0] * h3;
+            const int c1 = src[0][1] * h0 + src[1][1] * h1 + src[2][1] * h2 + src[3][1] * h3;
+            const int c2 = src[0][2] * h0 + src[1][2] * h1 + src[2][2] * h2 + src[3][2] * h3;
+            const int c3 = src[0][3] * h0 + src[1][3] * h1 + src[2][3] * h2 + src[3][3] * h3;
+            dst[i] = PackPixel(c0, c1, c2, c3);
             src += 4;
         }
         ++m_dst_y;

--- a/imagescaler.h
+++ b/imagescaler.h
@@ -32,15 +32,24 @@ class ImageScaler {
      * SetImageParameters() must be called first
      */
     void PutSourcePixel(unsigned char c0, unsigned char c1, unsigned char c2, unsigned char c3) {
-        m_hbuf[ (m_src_x++) & 3 ].Set(c0, c1, c2, c3);
+        TmpPixel &current = m_hbuf[(m_src_x++) & 3];
+        current.Set(c0, c1, c2, c3);
 
-        TmpPixel      *bp = m_buffer + 4 * m_dst_x + (m_src_y & 3);
-        const Filter  *fh;
+        TmpPixel *bp = m_buffer + 4 * m_dst_x + (m_src_y & 3);
+        const Filter *fh;
 
-        while ((fh=m_hor_filters + m_dst_x)->m_offset == m_src_x) {
-            *bp = m_hbuf[0] * fh->m_coeff[0] + m_hbuf[1] * fh->m_coeff[1] + m_hbuf[2] * fh->m_coeff[2]
-                  + m_hbuf[3]*fh->m_coeff[3];
-            m_dst_x++;
+        while ((fh = m_hor_filters + m_dst_x)->m_offset == m_src_x) {
+            const int h0 = fh->m_coeff[0];
+            const int h1 = fh->m_coeff[1];
+            const int h2 = fh->m_coeff[2];
+            const int h3 = fh->m_coeff[3];
+            const int c0v = m_hbuf[0][0] * h0 + m_hbuf[1][0] * h1 + m_hbuf[2][0] * h2 + m_hbuf[3][0] * h3;
+            const int c1v = m_hbuf[0][1] * h0 + m_hbuf[1][1] * h1 + m_hbuf[2][1] * h2 + m_hbuf[3][1] * h3;
+            const int c2v = m_hbuf[0][2] * h0 + m_hbuf[1][2] * h1 + m_hbuf[2][2] * h2 + m_hbuf[3][2] * h3;
+            const int c3v = m_hbuf[0][3] * h0 + m_hbuf[1][3] * h1 + m_hbuf[2][3] * h2 + m_hbuf[3][3] * h3;
+
+            bp->Set(c0v, c1v, c2v, c3v);
+            ++m_dst_x;
             bp += 4;
         }
 
@@ -84,7 +93,7 @@ class ImageScaler {
 
     //! This is called whenever one input line is processed completely
     void NextSourceLine();
-    unsigned int PackPixel(const TmpPixel &pixel);
+    unsigned int PackPixel(int c0, int c1, int c2, int c3);
 
     TmpPixel      m_hbuf[4];      //! Ring buffer for 4 input pixels
     // char      *m_memory;

--- a/skinflatplus.c
+++ b/skinflatplus.c
@@ -19,7 +19,7 @@
 #include "./setup.h"
 #include "./imageloader.h"
 
-static const char *VERSION     {"1.3.0"};
+static const char *VERSION     {"1.3.1"};
 static const char *DESCRIPTION {"Skin flatPlus"};
 
 class cPluginFlat : public cPlugin {


### PR DESCRIPTION
2026-08-02: Version 1.3.1
- [fix] Add missing include in imagecache.h
- [fix] Thanks to zork @ VDR-Portal for fixing:
        - imageloader: Do not report the expected 'logo_background' miss.
        - displayreplay: Never store a nullptr in 'm_Current' or 'm_Total'.
                         Show total length when replaying without a cRecording.
        - imagecache: Open only one OSD at a time while pre-loading.
        - displaychannel: Guard against null m_CurChannel in DvbapiInfoDraw()
- [update] Remove extra space in some date and time strings.
- [update] Changes in Zapcockpit:
           - Use Dynamic LineWidth and LineMargin in channel information.
           - Use medium font for wide display of channel info.
           - Use a bigger font for the channel number and name in the channel info.
           - Disable the channel number and name at the bottom of the channel info in wide display.
           - Hide EPG image and weather widget in zapcockpit channel info display.
           - Justify description in zapcockpit if it is set for event and recording info.
           - Reuse event data (Present/Following) from SetEvents() in wide channel info.
           - Use own cTextFloatingWrapper for channel info description wrapping.
           - Add a outer margin (Same as for EPG image) to wide channel info display.
           - ZapAlphaOver now exits earlier for fully opaque or fully transparent cases.
           - Refactor ZapBlendImage:
              Use the underlying pixel buffer via Data() instead of repeated GetPixel/SetPixel.
              Compute the visible clip rectangle once before the loops.
              Avoid per-pixel bounds checks in the hot loop.
           - Refactor ZapShortenText:
              Added an early guard for MaxWidth <= 0.
              If the ellipsis itself does not fit, return an empty string instead of
              attempting a meaningless truncation.
              For the final result, return a clean ellipsis-only string when the input
              becomes empty after trimming.
           - Improve ZapRunShowAnimation by using 'ViewPort' and PixmapSetAlpha().
- [update] Refactor imagescaler.c: Changing the hot loop to direct component arithmetic so
           it avoids the temporary-object style work in the inner path.
- [update] Some internal optimizations.